### PR TITLE
SYN-396: decompose spawn_container_monitor into wait_for_exit + stale-monitor detection

### DIFF
--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -986,7 +986,7 @@ pub async fn handle_resume_instance(
 // ============================================================================
 
 /// Check if a process is alive by checking /proc/<pid> existence.
-fn is_process_alive(pid: i32) -> bool {
+pub(crate) fn is_process_alive(pid: i32) -> bool {
     std::path::Path::new(&format!("/proc/{}", pid)).exists()
 }
 

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -1006,7 +1006,7 @@ pub(crate) fn is_process_alive(pid: i32) -> bool {
 /// - registry lookup errors → assume fresh, since being conservative here
 ///   would cause us to silently drop the crash-detection write on a transient
 ///   DB blip
-pub(crate) async fn detect_stale_monitor(
+pub async fn detect_stale_monitor(
     registry: &ContainerRegistry,
     instance_id: &str,
     monitor_handle_id: &str,

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -1006,9 +1006,6 @@ pub(crate) fn is_process_alive(pid: i32) -> bool {
 /// - registry lookup errors → assume fresh, since being conservative here
 ///   would cause us to silently drop the crash-detection write on a transient
 ///   DB blip
-// NOTE: `dead_code` allow is removed in the follow-up commit that wires this
-// helper into `spawn_container_monitor`.
-#[allow(dead_code)]
 pub(crate) async fn detect_stale_monitor(
     registry: &ContainerRegistry,
     instance_id: &str,
@@ -1027,15 +1024,35 @@ pub(crate) async fn detect_stale_monitor(
 /// and process output when the container finishes. The timeout is enforced here - if the
 /// container runs longer than the specified timeout, it will be killed.
 ///
-/// ## PID-based Monitoring
+/// ## Structure
 ///
-/// When a PID is provided, we use `/proc/<pid>` to detect process termination.
-/// This is more reliable than querying crun state. When the process terminates:
+/// The body is a `tokio::select!` over two futures:
+/// - `runner.wait_for_exit(...)` — runner-specific exit detection (Child::wait
+///   for WASM, /proc/<pid> for OCI, or polling for the default impl).
+/// - `tokio::time::sleep_until(...)` — the timeout deadline.
 ///
-/// - If Core already has a terminal status (completed/failed/cancelled/suspended) → normal exit
-/// - If Core still shows "running" → process crashed without sending SDK event
+/// Each runner's `wait_for_exit` impl is cancel-safe, so dropping it when the
+/// timeout branch fires is sound.
 ///
-/// Falls back to `runner.is_running()` if no PID is available.
+/// ## Exit branch
+///
+/// When the process exits, we:
+/// 1. Collect metrics and stderr (`runner.collect_result`).
+/// 2. Persist them best-effort.
+/// 3. Check whether this monitor still owns the instance (`detect_stale_monitor`)
+///    — a resumed instance gets a new monitor, and the old one must not write
+///    crash state for the previous PID.
+/// 4. If we're still the owning monitor, mirror Core's view: if the SDK already
+///    wrote a terminal status we leave it alone, otherwise we mark the instance
+///    failed/crashed (or suspended/shutdown_requested if draining).
+/// 5. Clean up the container registry entry.
+///
+/// ## Timeout branch
+///
+/// We stop the runner, mark the instance failed with `termination_reason="timeout"`,
+/// and clean up the registry. Metrics/stderr are deliberately NOT collected here
+/// — the previous implementation did not collect them on timeout either, and
+/// doing so now would race with `runner.stop`.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_container_monitor(
     pool: PgPool,
@@ -1051,80 +1068,18 @@ pub fn spawn_container_monitor(
     let instance_id = handle.instance_id.clone();
 
     tokio::spawn(async move {
-        // Brief initial delay to let the process start
+        // Brief initial delay to let the process start before we begin watching it.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Poll to check if container is still running
         let poll_interval = Duration::from_millis(50);
-        let start = std::time::Instant::now();
+        let container_registry = ContainerRegistry::new(pool.clone());
+        let sleep_until = tokio::time::Instant::now() + timeout;
 
-        // Note: pid comes from child.id() at spawn time, so it's reliable.
-        // If pid is None (shouldn't happen normally), fall back to runner.is_running().
+        let wait_fut = runner.wait_for_exit(&handle, poll_interval);
+        tokio::pin!(wait_fut);
 
-        loop {
-            // Check timeout first
-            if start.elapsed() > timeout {
-                warn!(
-                    instance_id = %instance_id,
-                    timeout_secs = %timeout.as_secs(),
-                    "Execution timed out, killing container"
-                );
-                let _ = runner.stop(&handle).await;
-
-                // Update instance status to failed with termination_reason = "timeout"
-                if let Err(e) = persistence
-                    .complete_instance_with_termination_if_running(
-                        &instance_id,
-                        "failed",
-                        Some("timeout"),             // termination_reason
-                        None,                        // exit_code
-                        None,                        // output
-                        Some("Execution timed out"), // error
-                        None,                        // stderr
-                        None,                        // checkpoint_id
-                    )
-                    .await
-                {
-                    warn!(
-                        instance_id = %instance_id,
-                        error = %e,
-                        "Failed to update instance status after timeout"
-                    );
-                }
-
-                // Clean up container registry
-                let container_registry = ContainerRegistry::new(pool.clone());
-                let _ = container_registry.cleanup(&instance_id).await;
-
-                return;
-            }
-
-            // Check if process is still running.
-            // Prefer child.wait() over PID polling — it blocks until the process
-            // fully exits (including all I/O cleanup), ensuring SDK HTTP calls
-            // have been processed before we check status.
-            let is_alive = if let Some(ref child_arc) = handle.child {
-                let mut child_guard = child_arc.lock().await;
-                if let Some(ref mut child) = *child_guard {
-                    match child.try_wait() {
-                        Ok(Some(_exit_status)) => {
-                            // Process exited — take ownership to drop it
-                            *child_guard = None;
-                            false
-                        }
-                        Ok(None) => true, // Still running
-                        Err(_) => false,  // Error checking — treat as exited
-                    }
-                } else {
-                    false // Already consumed
-                }
-            } else if let Some(p) = pid {
-                is_process_alive(p)
-            } else {
-                runner.is_running(&handle).await
-            };
-
-            if !is_alive {
+        tokio::select! {
+            _ = &mut wait_fut => {
                 info!(
                     instance_id = %instance_id,
                     pid = ?pid,
@@ -1182,21 +1137,12 @@ pub fn spawn_container_monitor(
                 // Guard: check that this monitor is still the active one for this instance.
                 // When an instance is resumed, a NEW monitor is spawned for the new process.
                 // The OLD monitor (for the previous PID) may still be running and must not
-                // interfere with the new execution.
-                let container_registry = ContainerRegistry::new(pool.clone());
-                let is_stale_monitor = match container_registry.get(&instance_id).await {
-                    Ok(Some(current)) => {
-                        // If the registered container has a different handle_id,
-                        // this monitor is stale (instance was resumed with a new process)
-                        current.container_id != handle.handle_id
-                    }
-                    Ok(None) => {
-                        // Registry entry was cleaned up (resume clears it before launching
-                        // new process) — this monitor is stale
-                        true
-                    }
-                    Err(_) => false,
-                };
+                // interfere with the new execution. The check intentionally happens AFTER
+                // metrics/stderr writes so a stale monitor doesn't drop diagnostic data
+                // for the previous process.
+                let is_stale_monitor =
+                    detect_stale_monitor(&container_registry, &instance_id, &handle.handle_id)
+                        .await;
 
                 if is_stale_monitor {
                     info!(
@@ -1285,14 +1231,40 @@ pub fn spawn_container_monitor(
                 }
 
                 // Clean up container registry
-                let container_registry = ContainerRegistry::new(pool.clone());
                 let _ = container_registry.cleanup(&instance_id).await;
-
-                break;
             }
+            _ = tokio::time::sleep_until(sleep_until) => {
+                warn!(
+                    instance_id = %instance_id,
+                    timeout_secs = %timeout.as_secs(),
+                    "Execution timed out, killing container"
+                );
+                let _ = runner.stop(&handle).await;
 
-            // Sleep before next check
-            tokio::time::sleep(poll_interval).await;
+                // Update instance status to failed with termination_reason = "timeout"
+                if let Err(e) = persistence
+                    .complete_instance_with_termination_if_running(
+                        &instance_id,
+                        "failed",
+                        Some("timeout"),             // termination_reason
+                        None,                        // exit_code
+                        None,                        // output
+                        Some("Execution timed out"), // error
+                        None,                        // stderr
+                        None,                        // checkpoint_id
+                    )
+                    .await
+                {
+                    warn!(
+                        instance_id = %instance_id,
+                        error = %e,
+                        "Failed to update instance status after timeout"
+                    );
+                }
+
+                // Clean up container registry
+                let _ = container_registry.cleanup(&instance_id).await;
+            }
         }
     });
 }

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -990,6 +990,37 @@ pub(crate) fn is_process_alive(pid: i32) -> bool {
     std::path::Path::new(&format!("/proc/{}", pid)).exists()
 }
 
+/// True if this monitor's handle no longer owns the container registry
+/// entry for the instance.
+///
+/// When an instance is resumed, a NEW monitor is spawned for the new process
+/// and the registry is rewritten with that monitor's `handle_id`. The OLD
+/// monitor (still polling the previous PID) must NOT touch instance state
+/// when it observes its own process exit, otherwise it would clobber the
+/// fresh execution.
+///
+/// Semantics (preserved from the inline check that previously lived in
+/// `spawn_container_monitor`):
+/// - registry has a different `container_id` than this monitor's handle → stale
+/// - registry has no entry (e.g. cleared by resume before relaunch) → stale
+/// - registry lookup errors → assume fresh, since being conservative here
+///   would cause us to silently drop the crash-detection write on a transient
+///   DB blip
+// NOTE: `dead_code` allow is removed in the follow-up commit that wires this
+// helper into `spawn_container_monitor`.
+#[allow(dead_code)]
+pub(crate) async fn detect_stale_monitor(
+    registry: &ContainerRegistry,
+    instance_id: &str,
+    monitor_handle_id: &str,
+) -> bool {
+    match registry.get(instance_id).await {
+        Ok(Some(current)) => current.container_id != monitor_handle_id,
+        Ok(None) => true,
+        Err(_) => false,
+    }
+}
+
 /// Spawn a background task that monitors the container and processes output when done.
 ///
 /// This function should be called after launching an instance to monitor its lifecycle

--- a/crates/runtara-environment/src/runner/oci/runner.rs
+++ b/crates/runtara-environment/src/runner/oci/runner.rs
@@ -1155,6 +1155,24 @@ impl Runner for OciRunner {
         self.is_container_running(&handle.handle_id).await
     }
 
+    async fn wait_for_exit(&self, handle: &RunnerHandle, poll_interval: Duration) {
+        // Prefer the captured wrapper PID over `crun state`: /proc/<pid> avoids
+        // spawning a subprocess every tick and mirrors the previous monitor
+        // logic exactly. Falls back to `is_container_running` only when no PID
+        // was captured (rare edge case).
+        loop {
+            let alive = if let Some(pid) = handle.spawned_pid {
+                crate::handlers::is_process_alive(pid as i32)
+            } else {
+                self.is_container_running(&handle.handle_id).await
+            };
+            if !alive {
+                return;
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
     async fn stop(&self, handle: &RunnerHandle) -> Result<()> {
         self.kill_container(&handle.handle_id).await?;
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/runtara-environment/src/runner/traits.rs
+++ b/crates/runtara-environment/src/runner/traits.rs
@@ -201,4 +201,19 @@ pub trait Runner: Send + Sync {
         let _ = handle;
         None
     }
+
+    /// Wait for the instance to exit, polling with the given interval.
+    ///
+    /// The default implementation polls [`Runner::is_running`] at `poll_interval`.
+    /// Runners that own a `Child` on the handle (e.g. WasmRunner) should override
+    /// this to use `child.wait()` so process exit is observed without a poll
+    /// budget and so all stdio is flushed before the monitor proceeds.
+    ///
+    /// Implementations must be cancel-safe: when the surrounding `select!` drops
+    /// this future on a timeout, no resources should leak.
+    async fn wait_for_exit(&self, handle: &RunnerHandle, poll_interval: Duration) {
+        while self.is_running(handle).await {
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
 }

--- a/crates/runtara-environment/src/runner/wasm.rs
+++ b/crates/runtara-environment/src/runner/wasm.rs
@@ -640,6 +640,27 @@ impl Runner for WasmRunner {
         }
     }
 
+    async fn wait_for_exit(&self, handle: &RunnerHandle, poll_interval: Duration) {
+        // Prefer waiting on the owned Child handle: this blocks until the
+        // wasmtime process has fully exited (and stdio has been flushed),
+        // which is what the monitor needs before reading SDK-written status.
+        //
+        // tokio::process::Child::wait is cancel-safe, so dropping this future
+        // when the surrounding select! fires the timeout branch is safe.
+        // No other code locks `handle.child` after the monitor starts.
+        if let Some(child_arc) = handle.child.clone() {
+            let mut guard = child_arc.lock().await;
+            if let Some(child) = guard.as_mut() {
+                let _ = child.wait().await;
+            }
+            *guard = None;
+            return;
+        }
+        while self.is_running(handle).await {
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
     async fn stop(&self, handle: &RunnerHandle) -> Result<()> {
         if let Some(pid) = handle.spawned_pid {
             debug!(pid = pid, instance_id = %handle.instance_id, "Killing wasmtime process");

--- a/crates/runtara-environment/tests/handlers_test.rs
+++ b/crates/runtara-environment/tests/handlers_test.rs
@@ -8,13 +8,14 @@ mod common;
 
 use chrono::Utc;
 use runtara_core::persistence::{Persistence, PostgresPersistence};
+use runtara_environment::container_registry::{ContainerInfo, ContainerRegistry};
 use runtara_environment::db;
 use runtara_environment::handlers::{
     DrainController, EnvironmentHandlerState, GetCapabilityRequest, RegisterImageRequest,
     ResumeInstanceRequest, StartInstanceRequest, StopInstanceRequest, TestCapabilityRequest,
-    handle_get_capability, handle_health_check, handle_list_agents, handle_register_image,
-    handle_resume_instance, handle_start_instance, handle_stop_instance, handle_test_capability,
-    spawn_container_monitor,
+    detect_stale_monitor, handle_get_capability, handle_health_check, handle_list_agents,
+    handle_register_image, handle_resume_instance, handle_start_instance, handle_stop_instance,
+    handle_test_capability, spawn_container_monitor,
 };
 use runtara_environment::image_registry::{ImageRegistry, RunnerType};
 use runtara_environment::runner::MockRunner;
@@ -1266,6 +1267,7 @@ async fn test_spawn_container_monitor_timeout_enforcement() {
         tenant_id: tenant_id.to_string(),
         started_at: Utc::now(),
         spawned_pid: None,
+        child: None,
     };
 
     // Register the mock instance in the runner
@@ -1518,4 +1520,124 @@ async fn test_spawn_container_monitor_timeout_race_condition() {
 
     // Cleanup
     cleanup(&pool, Some(&instance_id), None).await;
+}
+
+/// Helper: build a `ContainerInfo` populated with the fields the registry stores.
+fn make_container_info(instance_id: &str, tenant_id: &str, container_id: &str) -> ContainerInfo {
+    ContainerInfo {
+        container_id: container_id.to_string(),
+        instance_id: instance_id.to_string(),
+        tenant_id: tenant_id.to_string(),
+        binary_path: "/usr/bin/test".to_string(),
+        bundle_path: Some("/tmp/bundle".to_string()),
+        started_at: Utc::now(),
+        pid: None,
+        timeout_seconds: Some(60),
+        process_killed: false,
+    }
+}
+
+/// Verify `detect_stale_monitor`'s three branches: mismatched container_id is
+/// stale, missing entry is stale, matching entry is fresh.
+#[tokio::test]
+async fn test_detect_stale_monitor_registry_cleared() {
+    skip_if_no_db!();
+    let Some(pool) = get_test_pool().await else {
+        eprintln!("Skipping test: could not connect to database");
+        return;
+    };
+
+    let registry = ContainerRegistry::new(pool.clone());
+    let instance_id = Uuid::new_v4().to_string();
+    let tenant_id = "test-tenant-stale-monitor";
+
+    // 1. No registry entry → stale.
+    assert!(
+        detect_stale_monitor(&registry, &instance_id, "monitor-handle").await,
+        "Missing registry entry should be considered stale"
+    );
+
+    // 2. Registry entry whose container_id != monitor_handle_id → stale.
+    let other_handle = "other-handle-id";
+    registry
+        .register(&make_container_info(&instance_id, tenant_id, other_handle))
+        .await
+        .expect("Failed to register container");
+    assert!(
+        detect_stale_monitor(&registry, &instance_id, "monitor-handle").await,
+        "Mismatched container_id should be considered stale"
+    );
+
+    // 3. Registry entry whose container_id matches → fresh.
+    let monitor_handle = "monitor-handle";
+    registry
+        .register(&make_container_info(
+            &instance_id,
+            tenant_id,
+            monitor_handle,
+        ))
+        .await
+        .expect("Failed to update registered container");
+    assert!(
+        !detect_stale_monitor(&registry, &instance_id, monitor_handle).await,
+        "Matching container_id should be considered fresh"
+    );
+
+    // Cleanup
+    cleanup(&pool, Some(&instance_id), None).await;
+}
+
+/// Verify the default `Runner::wait_for_exit` impl returns once `is_running`
+/// flips to false. Uses the never-completing MockRunner so the exit only
+/// happens via an explicit `stop` call from the test.
+#[tokio::test]
+async fn test_wait_for_exit_default_impl_returns_on_not_running() {
+    let runner = Arc::new(MockRunner::never_completing());
+    let instance_id = Uuid::new_v4().to_string();
+    let tenant_id = "test-tenant-wait-for-exit";
+
+    let handle = runner
+        .launch_detached(&LaunchOptions {
+            instance_id: instance_id.clone(),
+            tenant_id: tenant_id.to_string(),
+            bundle_path: PathBuf::from("/test/bundle"),
+            input: serde_json::json!({}),
+            timeout: Duration::from_secs(10),
+            runtara_core_addr: "127.0.0.1:8001".to_string(),
+            checkpoint_id: None,
+            env: std::collections::HashMap::new(),
+        })
+        .await
+        .expect("Failed to launch detached");
+
+    assert!(
+        runner.is_running(&handle).await,
+        "Runner should be running before stop"
+    );
+
+    // Drive wait_for_exit concurrently with the stop that flips `running`.
+    let runner_for_stop = runner.clone();
+    let handle_for_stop = handle.clone();
+    let stopper = tokio::spawn(async move {
+        // Brief delay so wait_for_exit observes a "running" state first.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        runner_for_stop.stop(&handle_for_stop).await.unwrap();
+    });
+
+    let waited = tokio::time::timeout(
+        Duration::from_millis(200),
+        runner.wait_for_exit(&handle, Duration::from_millis(5)),
+    )
+    .await;
+
+    stopper.await.unwrap();
+
+    assert!(
+        waited.is_ok(),
+        "wait_for_exit should return promptly once is_running flips to false"
+    );
+    assert!(
+        !runner.is_running(&handle).await,
+        "Runner should report not running after wait_for_exit returns"
+    );
 }


### PR DESCRIPTION
## Summary

Closes [SYN-396](https://linear.app/syncmyordershq/issue/SYN-396).

Breaks the 260-line `spawn_container_monitor` polling loop in `runtara-environment` into composable seams:

- New `Runner::wait_for_exit(handle, poll_interval)` trait method with a default impl polling `is_running`; overridden in `WasmRunner` to drive `child.wait()` and in `OciRunner` to prefer PID-based detection.
- New free fn `detect_stale_monitor(registry, instance_id, handle_id)` encapsulating the registry-ownership check.
- Main loop rewritten as `tokio::select!` over `wait_for_exit` and `sleep(timeout)`.

Function signature and call sites unchanged. Two new unit tests for the extracted seams.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check -p runtara-environment --all-targets`
- [x] `cargo clippy -p runtara-environment --all-targets -- -D warnings`
- [x] `cargo test -p runtara-environment` (222/223 pass; one pre-existing macOS `/proc` failure unrelated to this change)
- [x] `cargo check --workspace`