### PR TITLE
refactor(config): centralize RUNTARA_* parsing (SYN-399)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-agent-macro"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-agents"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "calamine",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-ai"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "runtara-http",
  "serde",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-connections"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "axum 0.8.8",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-core"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-dsl"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "inventory",
  "schemars 0.8.22",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-environment"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-http"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-management-sdk"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-object-store"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "regex",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-sdk"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-sdk-macros"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-server"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-test-harness"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "runtara-dsl",
  "runtara-workflow-stdlib",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-text-parser"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "regex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-workflow-stdlib"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "inventory",
  "minijinja",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "runtara-workflows"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "minijinja",
  "proc-macro2",

--- a/crates/runtara-agents/src/agents/integrations/ai_tools.rs
+++ b/crates/runtara-agents/src/agents/integrations/ai_tools.rs
@@ -28,10 +28,13 @@ fn resolve_integration_id(connection: &RawConnection) -> Result<String, AgentErr
         return Ok(integration_id.clone());
     }
 
-    let base_url = std::env::var("CONNECTION_SERVICE_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:7002/api/connections".to_string());
-    let tenant_id = std::env::var("RUNTARA_TENANT_ID").unwrap_or_default();
-    let url = format!("{}/{}/{}", base_url, tenant_id, connection.connection_id);
+    use crate::integrations::integration_utils::env;
+    let url = format!(
+        "{}/{}/{}",
+        env::connection_service_url(),
+        env::tenant_id(),
+        connection.connection_id
+    );
 
     let client = runtara_http::HttpClient::new();
     let resp = client.request("GET", &url).call().map_err(|e| {

--- a/crates/runtara-agents/src/agents/integrations/commerce.rs
+++ b/crates/runtara-agents/src/agents/integrations/commerce.rs
@@ -23,10 +23,13 @@ fn resolve_integration_id(connection: &RawConnection) -> Result<String, AgentErr
     }
 
     // Fetch from connection service
-    let base_url = std::env::var("CONNECTION_SERVICE_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:7002/api/connections".to_string());
-    let tenant_id = std::env::var("RUNTARA_TENANT_ID").unwrap_or_default();
-    let url = format!("{}/{}/{}", base_url, tenant_id, connection.connection_id);
+    use crate::integrations::integration_utils::env;
+    let url = format!(
+        "{}/{}/{}",
+        env::connection_service_url(),
+        env::tenant_id(),
+        connection.connection_id
+    );
 
     let client = runtara_http::HttpClient::new();
     let resp = client.request("GET", &url).call().map_err(|e| {

--- a/crates/runtara-agents/src/agents/integrations/integration_utils/env.rs
+++ b/crates/runtara-agents/src/agents/integrations/integration_utils/env.rs
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Scenario-runtime environment lookups for integration capabilities.
+//!
+//! These env vars are stable for the lifetime of a scenario process — set
+//! once by the runner at launch time and never mutated. Caching the values in
+//! `OnceLock`s replaces the per-call `env::var` reads that capabilities used
+//! to perform.
+
+use std::sync::OnceLock;
+
+/// Tenant ID forwarded from the host (empty string if unset).
+pub fn tenant_id() -> &'static str {
+    static TENANT_ID: OnceLock<String> = OnceLock::new();
+    TENANT_ID
+        .get_or_init(|| std::env::var("RUNTARA_TENANT_ID").unwrap_or_default())
+        .as_str()
+}
+
+/// Base URL of the connection service (used by integrations to resolve
+/// `integration_id` from an abstract `connection_id`).
+pub fn connection_service_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| {
+        std::env::var("CONNECTION_SERVICE_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:7002/api/connections".to_string())
+    })
+    .as_str()
+}
+
+/// Base URL of the internal object-model API.
+pub fn object_model_base_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| {
+        std::env::var("RUNTARA_OBJECT_MODEL_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:7002/api/internal/object-model".to_string())
+    })
+    .as_str()
+}

--- a/crates/runtara-agents/src/agents/integrations/integration_utils/mod.rs
+++ b/crates/runtara-agents/src/agents/integrations/integration_utils/mod.rs
@@ -9,10 +9,12 @@
 
 pub mod client;
 pub mod connection;
+pub mod env;
 pub mod pagination;
 pub mod url;
 
 pub use client::{DEFAULT_TIMEOUT_MS, ProxyHttpClient, ProxyRequest};
 pub use connection::require_connection;
+pub use env::{connection_service_url, object_model_base_url, tenant_id};
 pub use pagination::{Page, PageCursor, extract_page};
 pub use url::urlencoded;

--- a/crates/runtara-agents/src/agents/integrations/object_model.rs
+++ b/crates/runtara-agents/src/agents/integrations/object_model.rs
@@ -22,26 +22,16 @@ use std::collections::HashMap;
 // HTTP Client Helpers
 // ============================================================================
 
-/// Get the base URL for the internal object model API.
-fn base_url() -> String {
-    std::env::var("RUNTARA_OBJECT_MODEL_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:7002/api/internal/object-model".to_string())
-}
-
-/// Get the tenant ID from environment.
-fn tenant_id() -> String {
-    std::env::var("RUNTARA_TENANT_ID").unwrap_or_default()
-}
-
 /// Make a POST request to the internal API and parse the JSON response.
 fn http_post(path: &str, body: Value) -> Result<Value, AgentError> {
-    let url = format!("{}{}", base_url(), path);
-    let tid = tenant_id();
+    use crate::integrations::integration_utils::env;
+    let url = format!("{}{}", env::object_model_base_url(), path);
+    let tid = env::tenant_id();
     let client = runtara_http::HttpClient::new();
 
     let resp = client
         .request("POST", &url)
-        .header("X-Org-Id", &tid)
+        .header("X-Org-Id", tid)
         .header("Content-Type", "application/json")
         .body_json(&body)
         .call()
@@ -64,13 +54,14 @@ fn http_post(path: &str, body: Value) -> Result<Value, AgentError> {
 
 /// Make a PUT request to the internal API and parse the JSON response.
 fn http_put(path: &str, body: Value) -> Result<Value, AgentError> {
-    let url = format!("{}{}", base_url(), path);
-    let tid = tenant_id();
+    use crate::integrations::integration_utils::env;
+    let url = format!("{}{}", env::object_model_base_url(), path);
+    let tid = env::tenant_id();
     let client = runtara_http::HttpClient::new();
 
     let resp = client
         .request("PUT", &url)
-        .header("X-Org-Id", &tid)
+        .header("X-Org-Id", tid)
         .header("Content-Type", "application/json")
         .body_json(&body)
         .call()
@@ -93,13 +84,14 @@ fn http_put(path: &str, body: Value) -> Result<Value, AgentError> {
 
 /// Make a GET request to the internal API and parse the JSON response.
 fn http_get(path: &str) -> Result<Value, AgentError> {
-    let url = format!("{}{}", base_url(), path);
-    let tid = tenant_id();
+    use crate::integrations::integration_utils::env;
+    let url = format!("{}{}", env::object_model_base_url(), path);
+    let tid = env::tenant_id();
     let client = runtara_http::HttpClient::new();
 
     let resp = client
         .request("GET", &url)
-        .header("X-Org-Id", &tid)
+        .header("X-Org-Id", tid)
         .call()
         .map_err(|e| {
             AgentError::permanent(

--- a/crates/runtara-environment/src/config.rs
+++ b/crates/runtara-environment/src/config.rs
@@ -45,7 +45,8 @@ impl Config {
             PathBuf::from(std::env::var("DATA_DIR").unwrap_or_else(|_| ".data".to_string()));
 
         let skip_cert_verification = std::env::var("RUNTARA_SKIP_CERT_VERIFICATION")
-            .map(|v| v == "true" || v == "1")
+            .ok()
+            .map(|v| parse_bool_lenient(&v))
             .unwrap_or(false);
 
         let db_pool_size = std::env::var("RUNTARA_DB_POOL_SIZE")
@@ -79,6 +80,15 @@ pub enum ConfigError {
     /// The port number is invalid.
     #[error("Invalid port number")]
     InvalidPort,
+}
+
+/// Parse a boolean env var accepting the common forms: `true/false`, `1/0`,
+/// `yes/no`, `on/off` (case-insensitive). Unknown values are treated as `false`.
+pub(crate) fn parse_bool_lenient(s: &str) -> bool {
+    matches!(
+        s.trim().to_ascii_lowercase().as_str(),
+        "true" | "1" | "yes" | "on"
+    )
 }
 
 #[cfg(test)]

--- a/crates/runtara-environment/src/runner/native.rs
+++ b/crates/runtara-environment/src/runner/native.rs
@@ -61,7 +61,8 @@ impl NativeRunnerConfig {
                     .unwrap_or(300),
             ),
             skip_cert_verification: std::env::var("RUNTARA_SKIP_CERT_VERIFICATION")
-                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+                .ok()
+                .map(|v| crate::config::parse_bool_lenient(&v))
                 .unwrap_or(false),
             connection_service_url: std::env::var("RUNTARA_CONNECTION_SERVICE_URL").ok(),
         }
@@ -140,15 +141,11 @@ impl NativeRunner {
             env.insert("RUNTARA_CORE_HTTP_PORT".to_string(), port);
         }
 
-        // Forward object model internal API URL for smo-stdlib agents
-        if let Ok(url) = std::env::var("RUNTARA_OBJECT_MODEL_URL") {
-            env.insert("RUNTARA_OBJECT_MODEL_URL".to_string(), url);
-        }
-
-        // Forward tenant ID for internal API authentication
-        if let Ok(tid) = std::env::var("RUNTARA_TENANT_ID") {
-            env.insert("RUNTARA_TENANT_ID".to_string(), tid);
-        }
+        // RUNTARA_OBJECT_MODEL_URL, RUNTARA_AGENT_SERVICE_URL, RUNTARA_HTTP_PROXY_URL
+        // and RUNTARA_TENANT_ID now arrive via LaunchOptions.env (populated by
+        // the caller from its typed config) and are merged into `env` by the
+        // caller of build_env. The runner no longer reads them from its own
+        // process environment.
 
         env
     }

--- a/crates/runtara-environment/src/runner/oci/runner.rs
+++ b/crates/runtara-environment/src/runner/oci/runner.rs
@@ -264,15 +264,11 @@ impl OciRunner {
             env.insert("RUNTARA_CORE_HTTP_PORT".to_string(), port);
         }
 
-        // Forward object model internal API URL for smo-stdlib agents
-        if let Ok(url) = std::env::var("RUNTARA_OBJECT_MODEL_URL") {
-            env.insert("RUNTARA_OBJECT_MODEL_URL".to_string(), url);
-        }
-
-        // Forward tenant ID for internal API authentication
-        if let Ok(tid) = std::env::var("RUNTARA_TENANT_ID") {
-            env.insert("RUNTARA_TENANT_ID".to_string(), tid);
-        }
+        // RUNTARA_OBJECT_MODEL_URL, RUNTARA_AGENT_SERVICE_URL, RUNTARA_HTTP_PROXY_URL
+        // and RUNTARA_TENANT_ID now arrive via LaunchOptions.env (populated by
+        // the caller from its typed config) and are merged into `env` by the
+        // caller of build_env. The runner no longer reads them from its own
+        // process environment.
 
         env
     }

--- a/crates/runtara-environment/src/runner/wasm.rs
+++ b/crates/runtara-environment/src/runner/wasm.rs
@@ -85,7 +85,8 @@ impl WasmRunnerConfig {
                     .unwrap_or(300),
             ),
             skip_cert_verification: std::env::var("RUNTARA_SKIP_CERT_VERIFICATION")
-                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+                .ok()
+                .map(|v| crate::config::parse_bool_lenient(&v))
                 .unwrap_or(false),
             connection_service_url: std::env::var("RUNTARA_CONNECTION_SERVICE_URL").ok(),
         }
@@ -170,32 +171,11 @@ impl WasmRunner {
             env.insert("RUNTARA_CORE_HTTP_PORT".to_string(), port);
         }
 
-        // HTTP proxy URL for routing all outbound HTTP through smo-runtime
-        if let Ok(url) = std::env::var("RUNTARA_HTTP_PROXY_URL") {
-            env.insert("RUNTARA_HTTP_PROXY_URL".to_string(), url);
-        } else {
-            // Default: smo-runtime's internal proxy endpoint
-            let port = std::env::var("SERVER_PORT").unwrap_or_else(|_| "7001".to_string());
-            env.insert(
-                "RUNTARA_HTTP_PROXY_URL".to_string(),
-                format!("http://127.0.0.1:{}/api/internal/proxy", port),
-            );
-        }
-
-        // Forward object model internal API URL for smo-stdlib agents
-        if let Ok(url) = std::env::var("RUNTARA_OBJECT_MODEL_URL") {
-            env.insert("RUNTARA_OBJECT_MODEL_URL".to_string(), url);
-        }
-
-        // Forward agent service URL for native-only capability execution (xlsx, sftp, compression)
-        if let Ok(url) = std::env::var("RUNTARA_AGENT_SERVICE_URL") {
-            env.insert("RUNTARA_AGENT_SERVICE_URL".to_string(), url);
-        }
-
-        // Forward tenant ID for internal API authentication
-        if let Ok(tid) = std::env::var("RUNTARA_TENANT_ID") {
-            env.insert("RUNTARA_TENANT_ID".to_string(), tid);
-        }
+        // RUNTARA_HTTP_PROXY_URL, RUNTARA_OBJECT_MODEL_URL, RUNTARA_AGENT_SERVICE_URL
+        // and RUNTARA_TENANT_ID now arrive via LaunchOptions.env (populated by
+        // the caller from its typed config) and are merged into `env` by the
+        // caller of build_env. The runner no longer reads them from its own
+        // process environment.
 
         // Store the host run_dir path for reference (not visible to guest)
         let _ = run_dir;

--- a/crates/runtara-http/src/lib.rs
+++ b/crates/runtara-http/src/lib.rs
@@ -214,16 +214,20 @@ impl RequestBuilder {
 
         // Forward tenant ID header (X-Org-Id)
         // Try from original request headers first, then from RUNTARA_TENANT_ID env var
+        // (cached on first read — env is stable for scenario lifetime).
+        static TENANT_ID: OnceLock<Option<String>> = OnceLock::new();
         if let Some(tenant) = self
             .headers
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case("x-org-id"))
         {
             proxy_request.headers.push(tenant.clone());
-        } else if let Ok(tenant_id) = std::env::var("RUNTARA_TENANT_ID") {
+        } else if let Some(tenant_id) =
+            TENANT_ID.get_or_init(|| std::env::var("RUNTARA_TENANT_ID").ok())
+        {
             proxy_request
                 .headers
-                .push(("X-Org-Id".to_string(), tenant_id));
+                .push(("X-Org-Id".to_string(), tenant_id.clone()));
         }
 
         // Execute directly (bypass proxy check to avoid recursion)

--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -43,29 +43,16 @@ pub struct HttpSdkConfig {
 impl HttpSdkConfig {
     /// Create config from environment variables.
     ///
-    /// Required: `RUNTARA_INSTANCE_ID`, `RUNTARA_TENANT_ID`, `RUNTARA_HTTP_URL`
+    /// Required: `RUNTARA_INSTANCE_ID`, `RUNTARA_TENANT_ID`.
+    /// Optional: `RUNTARA_HTTP_URL` (default `http://127.0.0.1:8003`).
     pub fn from_env() -> Result<Self> {
         let instance_id = std::env::var("RUNTARA_INSTANCE_ID")
             .map_err(|_| SdkError::Config("RUNTARA_INSTANCE_ID not set".into()))?;
         let tenant_id = std::env::var("RUNTARA_TENANT_ID")
             .map_err(|_| SdkError::Config("RUNTARA_TENANT_ID not set".into()))?;
 
-        // Try RUNTARA_HTTP_URL first, then derive from RUNTARA_SERVER_ADDR
-        let base_url = if let Ok(url) = std::env::var("RUNTARA_HTTP_URL") {
-            url
-        } else if let Ok(addr) = std::env::var("RUNTARA_SERVER_ADDR") {
-            // RUNTARA_SERVER_ADDR is host:port. HTTP is typically on port+2.
-            let parts: Vec<&str> = addr.split(':').collect();
-            let host = parts.first().unwrap_or(&"127.0.0.1");
-            let base_port: u16 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(8001);
-            let http_port = std::env::var("RUNTARA_CORE_HTTP_PORT")
-                .ok()
-                .and_then(|p| p.parse().ok())
-                .unwrap_or(base_port + 2); // Default: base port + 2 (8001 → 8003)
-            format!("http://{}:{}", host, http_port)
-        } else {
-            "http://127.0.0.1:8003".to_string()
-        };
+        let base_url = std::env::var("RUNTARA_HTTP_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:8003".to_string());
 
         let request_timeout_ms = std::env::var("RUNTARA_REQUEST_TIMEOUT_MS")
             .ok()
@@ -693,5 +680,80 @@ impl std::fmt::Debug for HttpBackend {
             .field("base_url", &self.base_url)
             .field("connected", &self.connected.load(Ordering::SeqCst))
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::HttpSdkConfig;
+    use std::sync::Mutex;
+
+    // Env access in tests is mutex-serialized.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        vars: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self { vars: Vec::new() }
+        }
+
+        fn set(&mut self, key: &str, value: &str) {
+            let old = std::env::var(key).ok();
+            self.vars.push((key.to_string(), old));
+            // SAFETY: serialized by ENV_MUTEX.
+            unsafe { std::env::set_var(key, value) };
+        }
+
+        fn remove(&mut self, key: &str) {
+            let old = std::env::var(key).ok();
+            self.vars.push((key.to_string(), old));
+            // SAFETY: serialized by ENV_MUTEX.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.vars.drain(..).rev() {
+                // SAFETY: serialized by ENV_MUTEX.
+                unsafe {
+                    match value {
+                        Some(v) => std::env::set_var(&key, v),
+                        None => std::env::remove_var(&key),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_http_sdk_config_ignores_server_addr() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_INSTANCE_ID", "test-instance");
+        guard.set("RUNTARA_TENANT_ID", "test-tenant");
+        guard.remove("RUNTARA_HTTP_URL");
+        guard.set("RUNTARA_SERVER_ADDR", "10.0.0.1:9999");
+        guard.set("RUNTARA_CORE_HTTP_PORT", "9001");
+
+        let cfg = HttpSdkConfig::from_env().unwrap();
+
+        assert_eq!(cfg.base_url, "http://127.0.0.1:8003");
+    }
+
+    #[test]
+    fn test_http_sdk_config_uses_http_url() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_INSTANCE_ID", "test-instance");
+        guard.set("RUNTARA_TENANT_ID", "test-tenant");
+        guard.set("RUNTARA_HTTP_URL", "http://example.test:1234");
+
+        let cfg = HttpSdkConfig::from_env().unwrap();
+
+        assert_eq!(cfg.base_url, "http://example.test:1234");
     }
 }

--- a/crates/runtara-server/src/config.rs
+++ b/crates/runtara-server/src/config.rs
@@ -1,51 +1,189 @@
 use std::sync::OnceLock;
 
-/// Global application configuration
-#[derive(Debug)]
+/// Global application configuration.
+///
+/// Loaded once at startup via [`Config::from_env`], then stored in a `OnceLock`.
+/// All env-var parsing happens eagerly, so typos and invalid values fail fast.
+#[derive(Debug, Clone)]
 pub struct Config {
-    /// Tenant ID for all API operations
+    /// Tenant ID for all API operations (required).
     pub tenant_id: String,
-    /// Maximum number of concurrent scenario executions
+    /// Maximum number of concurrent scenario executions.
     pub max_concurrent_executions: usize,
+    /// Checkpoint TTL in hours.
+    pub checkpoint_ttl_hours: u64,
+    /// Whether adaptive rate limiting is enabled.
+    pub adaptive_rate_limiting_enabled: bool,
+    /// Whether automatic retry on HTTP 429 responses is enabled.
+    pub auto_retry_on_429_enabled: bool,
+    /// Maximum retry attempts for 429 responses.
+    pub max_429_retries: u32,
+    /// Maximum retry delay in milliseconds.
+    pub max_retry_delay_ms: u64,
+    /// Object model database URL (required).
+    pub object_model_database_url: String,
+    /// Maximum pool connections for the object model database.
+    pub object_model_max_connections: u32,
+    /// Whether the object model uses soft delete.
+    pub object_model_soft_delete: bool,
+    /// Internal HTTP port (used to derive default service URLs).
+    pub internal_port: u16,
+    /// Name of the stdlib crate compiled into scenarios.
+    pub stdlib_name: String,
+    /// HTTP proxy URL forwarded to scenario processes for outbound HTTP.
+    pub http_proxy_url: String,
+    /// Object-model internal API URL forwarded to scenario processes.
+    pub object_model_url: String,
+    /// Agent service URL forwarded to scenario processes for native-only capabilities.
+    pub agent_service_url: String,
 }
 
-/// Global configuration instance
+/// Global configuration instance.
 static CONFIG: OnceLock<Config> = OnceLock::new();
 
-/// Initialize the global configuration
-pub fn init(tenant_id: String, max_concurrent_executions: usize) {
-    CONFIG
-        .set(Config {
+impl Config {
+    /// Load configuration from environment variables.
+    ///
+    /// Required:
+    /// - `TENANT_ID`: organization identifier
+    /// - `OBJECT_MODEL_DATABASE_URL`: Postgres URL for the object model DB
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let tenant_id =
+            std::env::var("TENANT_ID").map_err(|_| ConfigError::Missing("TENANT_ID"))?;
+
+        let max_concurrent_executions: usize = std::env::var("MAX_CONCURRENT_EXECUTIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| num_cpus::get() * 32);
+
+        let checkpoint_ttl_hours: u64 = parse_u64_or("CHECKPOINT_TTL_HOURS", 48)?;
+        let adaptive_rate_limiting_enabled: bool = parse_bool_or("ADAPTIVE_RATE_LIMITING", true)?;
+        let auto_retry_on_429_enabled: bool = parse_bool_or("AUTO_RETRY_ON_429", true)?;
+        let max_429_retries: u32 = parse_u32_or("MAX_429_RETRIES", 3)?;
+        let max_retry_delay_ms: u64 = parse_u64_or("MAX_RETRY_DELAY_MS", 60_000)?;
+
+        let object_model_database_url = std::env::var("OBJECT_MODEL_DATABASE_URL")
+            .map_err(|_| ConfigError::Missing("OBJECT_MODEL_DATABASE_URL"))?;
+        let object_model_max_connections: u32 = parse_u32_or("OBJECT_MODEL_MAX_CONNECTIONS", 5)?;
+        let object_model_soft_delete: bool = parse_bool_or("OBJECT_MODEL_SOFT_DELETE", true)?;
+
+        let internal_port: u16 = std::env::var("INTERNAL_PORT")
+            .unwrap_or_else(|_| "7002".to_string())
+            .parse()
+            .map_err(|_| ConfigError::Invalid("INTERNAL_PORT", "must be a valid port number"))?;
+
+        let stdlib_name = std::env::var("RUNTARA_STDLIB_NAME")
+            .unwrap_or_else(|_| "runtara_workflow_stdlib".to_string());
+
+        let http_proxy_url = std::env::var("RUNTARA_HTTP_PROXY_URL")
+            .unwrap_or_else(|_| format!("http://127.0.0.1:{}/api/internal/proxy", internal_port));
+
+        let object_model_url = std::env::var("RUNTARA_OBJECT_MODEL_URL").unwrap_or_else(|_| {
+            format!(
+                "http://127.0.0.1:{}/api/internal/object-model",
+                internal_port
+            )
+        });
+
+        let agent_service_url = std::env::var("RUNTARA_AGENT_SERVICE_URL")
+            .unwrap_or_else(|_| format!("http://127.0.0.1:{}/api/internal/agents", internal_port));
+
+        Ok(Self {
             tenant_id,
             max_concurrent_executions,
+            checkpoint_ttl_hours,
+            adaptive_rate_limiting_enabled,
+            auto_retry_on_429_enabled,
+            max_429_retries,
+            max_retry_delay_ms,
+            object_model_database_url,
+            object_model_max_connections,
+            object_model_soft_delete,
+            internal_port,
+            stdlib_name,
+            http_proxy_url,
+            object_model_url,
+            agent_service_url,
         })
+    }
+}
+
+/// Configuration errors.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// A required environment variable is missing.
+    #[error("missing required environment variable: {0}")]
+    Missing(&'static str),
+
+    /// An environment variable has an invalid value.
+    #[error("invalid value for {0}: {1}")]
+    Invalid(&'static str, &'static str),
+}
+
+fn parse_bool_or(name: &'static str, default: bool) -> Result<bool, ConfigError> {
+    match std::env::var(name) {
+        Ok(v) => parse_bool(&v).ok_or(ConfigError::Invalid(
+            name,
+            "must be one of true/false/1/0/yes/no/on/off",
+        )),
+        Err(_) => Ok(default),
+    }
+}
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_u32_or(name: &'static str, default: u32) -> Result<u32, ConfigError> {
+    match std::env::var(name) {
+        Ok(v) => v
+            .parse()
+            .map_err(|_| ConfigError::Invalid(name, "must be a non-negative integer")),
+        Err(_) => Ok(default),
+    }
+}
+
+fn parse_u64_or(name: &'static str, default: u64) -> Result<u64, ConfigError> {
+    match std::env::var(name) {
+        Ok(v) => v
+            .parse()
+            .map_err(|_| ConfigError::Invalid(name, "must be a non-negative integer")),
+        Err(_) => Ok(default),
+    }
+}
+
+/// Initialize the global configuration. Must be called once at startup.
+pub fn init(config: Config) {
+    CONFIG
+        .set(config)
         .expect("Config can only be initialized once");
 }
 
-/// Get the global configuration
+/// Get the global configuration.
 pub fn get() -> &'static Config {
     CONFIG.get().expect("Config must be initialized before use")
 }
 
-/// Get the tenant ID
+/// Get the tenant ID.
 pub fn tenant_id() -> &'static str {
     &get().tenant_id
 }
 
-/// Get the maximum concurrent executions
+/// Get the maximum concurrent executions.
 pub fn max_concurrent_executions() -> usize {
     get().max_concurrent_executions
 }
 
-/// Get checkpoint TTL in hours (default: 48 hours)
+/// Get checkpoint TTL in hours.
 pub fn checkpoint_ttl_hours() -> u64 {
-    std::env::var("CHECKPOINT_TTL_HOURS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(48)
+    get().checkpoint_ttl_hours
 }
 
-/// Validate that Redis is configured for checkpoint storage
+/// Validate that Redis is configured for checkpoint storage.
 pub fn validate_checkpoint_config() -> Result<(), String> {
     let valkey_host = std::env::var("VALKEY_HOST").ok();
 
@@ -60,61 +198,54 @@ pub fn validate_checkpoint_config() -> Result<(), String> {
     Ok(())
 }
 
-/// Check if adaptive rate limiting is enabled (default: true)
+/// Check if adaptive rate limiting is enabled.
 pub fn adaptive_rate_limiting_enabled() -> bool {
-    std::env::var("ADAPTIVE_RATE_LIMITING")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(true)
+    get().adaptive_rate_limiting_enabled
 }
 
-/// Check if automatic retry on 429 is enabled (default: true)
+/// Check if automatic retry on 429 is enabled.
 pub fn auto_retry_on_429_enabled() -> bool {
-    std::env::var("AUTO_RETRY_ON_429")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(true)
+    get().auto_retry_on_429_enabled
 }
 
-/// Get maximum retry attempts for 429 responses (default: 3)
+/// Get maximum retry attempts for 429 responses.
 pub fn max_429_retries() -> u32 {
-    std::env::var("MAX_429_RETRIES")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(3)
+    get().max_429_retries
 }
 
-/// Get maximum retry delay in milliseconds (default: 60000 = 1 minute)
+/// Get maximum retry delay in milliseconds.
 pub fn max_retry_delay_ms() -> u64 {
-    std::env::var("MAX_RETRY_DELAY_MS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(60000)
+    get().max_retry_delay_ms
 }
 
-/// Get the object model database URL (required)
+/// Get the object model database URL.
 pub fn object_model_database_url() -> String {
-    std::env::var("OBJECT_MODEL_DATABASE_URL")
-        .expect("OBJECT_MODEL_DATABASE_URL environment variable is required")
+    get().object_model_database_url.clone()
 }
 
-/// Get the maximum number of connections for the object model database pool (default: 5)
+/// Get the maximum number of connections for the object model database pool.
 pub fn object_model_max_connections() -> u32 {
-    std::env::var("OBJECT_MODEL_MAX_CONNECTIONS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(5)
+    get().object_model_max_connections
 }
 
-/// Whether the object model uses soft delete (default: true).
-///
-/// Applied when tables are created: `true` adds a `deleted` column and a
-/// partial index; `false` issues hard `DELETE` statements. Changing this
-/// after tables exist only affects delete behavior — the column/index are
-/// fixed at DDL time.
+/// Whether the object model uses soft delete.
 pub fn object_model_soft_delete() -> bool {
-    std::env::var("OBJECT_MODEL_SOFT_DELETE")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(true)
+    get().object_model_soft_delete
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bool_values() {
+        for v in ["true", "TRUE", "1", "yes", "YES", "on", "On"] {
+            assert_eq!(parse_bool(v), Some(true), "{v:?} should be true");
+        }
+        for v in ["false", "0", "no", "off", "Off"] {
+            assert_eq!(parse_bool(v), Some(false), "{v:?} should be false");
+        }
+        assert_eq!(parse_bool("nope"), None);
+        assert_eq!(parse_bool(""), None);
+    }
 }

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -272,6 +272,20 @@ impl RuntimeClient {
         options = options.with_env_var("TENANT_ID", tenant_id);
         options = options.with_env_var("INSTANCE_ID", &actual_instance_id);
 
+        // Server-side service URLs and tenant ID forwarded to the guest. These
+        // were previously read by runners via env::var against the host process
+        // environment (set by an unsafe env::set_var in server startup) —
+        // passing them explicitly through StartInstanceOptions removes that
+        // race-prone pattern and makes the scenario ABI typed.
+        let server_config = crate::config::get();
+        options = options.with_env_var("RUNTARA_TENANT_ID", &server_config.tenant_id);
+        options = options.with_env_var("RUNTARA_HTTP_PROXY_URL", &server_config.http_proxy_url);
+        options = options.with_env_var("RUNTARA_OBJECT_MODEL_URL", &server_config.object_model_url);
+        options = options.with_env_var(
+            "RUNTARA_AGENT_SERVICE_URL",
+            &server_config.agent_service_url,
+        );
+
         // Debug mode (pause at breakpoints)
         if debug {
             options = options.with_env_var("DEBUG_MODE", "true");

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -430,33 +430,20 @@ async fn health_handler() -> Json<HealthResponse> {
 }
 
 pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    // Configure Runtara stdlib for workflow compilation
-    // This enables agents in compiled workflows
-    // SAFETY: This is called early in main() before any threads are spawned,
-    // so there are no data races. The environment variable is only read later
-    // during workflow compilation.
+    // Load all env-derived configuration up front; fails fast on missing/invalid.
+    let server_config = config::Config::from_env()?;
+
+    // Expose stdlib name to workflow compilation, which reads it from the process
+    // environment at codegen time (runtara_workflows::agents_library and
+    // runtara_workflows::codegen). This is the only env::set_var the server
+    // performs; all other scenario-side values are passed through
+    // LaunchOptions.env at runner launch time.
+    // SAFETY: called early in start() before any threads are spawned.
     unsafe {
-        if std::env::var("RUNTARA_STDLIB_NAME").is_err() {
-            std::env::set_var("RUNTARA_STDLIB_NAME", "runtara_workflow_stdlib");
-        }
-
-        // Ensure in-process S3Client (used by Files endpoints) routes through the internal proxy
-        if std::env::var("RUNTARA_HTTP_PROXY_URL").is_err() {
-            let port = std::env::var("INTERNAL_PORT").unwrap_or_else(|_| "7002".to_string());
-            std::env::set_var(
-                "RUNTARA_HTTP_PROXY_URL",
-                format!("http://127.0.0.1:{}/api/internal/proxy", port),
-            );
-        }
-
-        // Note: RUNTARA_NATIVE_LIBRARY_DIR is optional - runtara-workflows automatically
-        // checks target/native_cache which is where build.rs outputs the compiled stdlib.
-        // Only set this env var if you need to override the default location.
+        std::env::set_var("RUNTARA_STDLIB_NAME", &server_config.stdlib_name);
     }
-    println!(
-        "✓ Runtara stdlib: {}",
-        std::env::var("RUNTARA_STDLIB_NAME").unwrap_or_default()
-    );
+    println!("✓ Runtara stdlib: {}", server_config.stdlib_name);
+
     if let Ok(lib_dir) = std::env::var("RUNTARA_NATIVE_LIBRARY_DIR") {
         println!("✓ Native library dir: {}", lib_dir);
     } else {
@@ -485,62 +472,20 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     runtara_dsl::agent_meta::validate_agent_metadata_or_panic();
     println!("✓ Agent metadata validated");
 
-    // Load and initialize tenant ID from environment (REQUIRED - no default)
-    let tenant_id = std::env::var("TENANT_ID").expect(
-        "TENANT_ID environment variable is required. \
-         Set it to your organization ID (e.g., export TENANT_ID=org_abc123)",
-    );
-    println!("✓ Configured for tenant: {}", tenant_id);
-
-    // Set env vars for scenario binaries (forwarded by OCI/native runners)
-    // SAFETY: Called early in main() before threads are spawned.
-    unsafe {
-        // Object model internal API URL — scenarios use this for CRUD operations
-        if std::env::var("RUNTARA_OBJECT_MODEL_URL").is_err() {
-            let port = std::env::var("INTERNAL_PORT").unwrap_or_else(|_| "7002".to_string());
-            std::env::set_var(
-                "RUNTARA_OBJECT_MODEL_URL",
-                format!("http://127.0.0.1:{}/api/internal/object-model", port),
-            );
-        }
-        // Tenant ID for internal API authentication (X-Org-Id header)
-        if std::env::var("RUNTARA_TENANT_ID").is_err() {
-            std::env::set_var("RUNTARA_TENANT_ID", &tenant_id);
-        }
-        // Agent service URL — scenario binaries use this to call native-only capabilities
-        if std::env::var("RUNTARA_AGENT_SERVICE_URL").is_err() {
-            let port = std::env::var("INTERNAL_PORT").unwrap_or_else(|_| "7002".to_string());
-            std::env::set_var(
-                "RUNTARA_AGENT_SERVICE_URL",
-                format!("http://127.0.0.1:{}/api/internal/agents", port),
-            );
-        }
-    }
+    println!("✓ Configured for tenant: {}", server_config.tenant_id);
+    println!("✓ Object model URL: {}", server_config.object_model_url);
+    println!("✓ Agent service URL: {}", server_config.agent_service_url);
     println!(
-        "✓ Object model URL: {}",
-        std::env::var("RUNTARA_OBJECT_MODEL_URL").unwrap_or_default()
-    );
-    println!(
-        "✓ Agent service URL: {}",
-        std::env::var("RUNTARA_AGENT_SERVICE_URL").unwrap_or_default()
+        "Max concurrent executions: {} (CPU cores: {})",
+        server_config.max_concurrent_executions,
+        num_cpus::get()
     );
 
     // Get version for logging context
     let version = env!("BUILD_VERSION");
 
-    // Load max concurrent executions from environment (default: num_cpus * 32)
-    let max_concurrent_executions = std::env::var("MAX_CONCURRENT_EXECUTIONS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or_else(|| num_cpus::get() * 32);
-
-    println!(
-        "Max concurrent executions: {} (CPU cores: {})",
-        max_concurrent_executions,
-        num_cpus::get()
-    );
-
-    config::init(tenant_id.clone(), max_concurrent_executions);
+    let tenant_id = server_config.tenant_id.clone();
+    config::init(server_config);
 
     // Create a root span with global context that will be included in all logs
     let root_span = tracing::info_span!(

--- a/crates/runtara-workflow-stdlib/src/dispatch.rs
+++ b/crates/runtara-workflow-stdlib/src/dispatch.rs
@@ -25,15 +25,22 @@ pub fn native_agent_stub(
     capability_id: &str,
     input: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let base_url = std::env::var("RUNTARA_AGENT_SERVICE_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:7002/api/internal/agents".to_string());
+    // Env vars are stable for the lifetime of a scenario process — cache on first read.
+    use std::sync::OnceLock;
+    static AGENT_SERVICE_URL: OnceLock<String> = OnceLock::new();
+    static TENANT_ID: OnceLock<String> = OnceLock::new();
+
+    let base_url = AGENT_SERVICE_URL.get_or_init(|| {
+        std::env::var("RUNTARA_AGENT_SERVICE_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:7002/api/internal/agents".to_string())
+    });
     let url = format!("{}/{}/{}", base_url, module, capability_id);
-    let tid = std::env::var("RUNTARA_TENANT_ID").unwrap_or_default();
+    let tid = TENANT_ID.get_or_init(|| std::env::var("RUNTARA_TENANT_ID").unwrap_or_default());
 
     let client = runtara_http::HttpClient::new();
     let resp = client
         .request("POST", &url)
-        .header("X-Org-Id", &tid)
+        .header("X-Org-Id", tid)
         .header("Content-Type", "application/json")
         .body_json(&input)
         .call()

--- a/crates/runtara-workflows/tests/e2e_compile_and_run.rs
+++ b/crates/runtara-workflows/tests/e2e_compile_and_run.rs
@@ -2110,7 +2110,7 @@ fn test_run_in_oci_container() {
         &[
             ("RUNTARA_INSTANCE_ID", "test-instance"),
             ("RUNTARA_TENANT_ID", "test-tenant"),
-            ("RUNTARA_SERVER_ADDR", "127.0.0.1:8001"),
+            ("RUNTARA_HTTP_URL", "http://127.0.0.1:8003"),
             ("RUNTARA_SKIP_CERT_VERIFICATION", "true"),
         ],
         Some(&input_json),
@@ -2193,7 +2193,7 @@ fn test_run_split_workflow_in_oci_container() {
         &[
             ("RUNTARA_INSTANCE_ID", "test-split-instance"),
             ("RUNTARA_TENANT_ID", "test-tenant"),
-            ("RUNTARA_SERVER_ADDR", "127.0.0.1:8001"),
+            ("RUNTARA_HTTP_URL", "http://127.0.0.1:8003"),
             ("RUNTARA_SKIP_CERT_VERIFICATION", "true"),
         ],
         Some(&input_json),
@@ -2281,7 +2281,7 @@ fn test_run_start_scenario_workflow_in_oci_container() {
         &[
             ("RUNTARA_INSTANCE_ID", "test-start-scenario-instance"),
             ("RUNTARA_TENANT_ID", "test-tenant"),
-            ("RUNTARA_SERVER_ADDR", "127.0.0.1:8001"),
+            ("RUNTARA_HTTP_URL", "http://127.0.0.1:8003"),
             ("RUNTARA_SKIP_CERT_VERIFICATION", "true"),
         ],
         Some(&input_json),


### PR DESCRIPTION
## Summary

Closes [SYN-399](https://linear.app/syncmyordershq/issue/SYN-399/centralize-runtara-config-parsing).

- Deletes the legacy `RUNTARA_SERVER_ADDR` → `port+2` fallback in `HttpSdkConfig::from_env` (the ticket's explicit ask).
- Expands `runtara-server::config::Config` to hold every env-derived setting and parse eagerly in `Config::from_env` with typed `ConfigError`; removes the two `unsafe { env::set_var }` blocks from server startup. One blessed `env::set_var` remains for `RUNTARA_STDLIB_NAME`, which workflow codegen reads at compile time (threading it through the codegen API was out of scope).
- Threads the 4 scenario-ABI env vars (`RUNTARA_TENANT_ID`, `RUNTARA_HTTP_PROXY_URL`, `RUNTARA_OBJECT_MODEL_URL`, `RUNTARA_AGENT_SERVICE_URL`) explicitly through `StartInstanceOptions.env` in `runtime_client::start_instance`, and deletes the `env::var()`-based forwarding that the three runners (native/wasm/OCI) used to do against the host process environment.
- Caches per-call env reads in `OnceLock` for WASM-side callers: `runtara-http::call_via_proxy` tenant id, `workflow-stdlib::dispatch::native_agent_stub`, and a new shared `integrations::integration_utils::env` module used by the `ai_tools`, `commerce`, and `object_model` integrations.
- Standardizes lenient bool parsing (`true|1|yes|on`) via `runtara-environment::config::parse_bool_lenient`, replacing two inconsistent inline parsers across the three runners.

## Test plan

- [x] `cargo build --workspace` (host, including runtara-server with spec generation)
- [x] `cargo test --workspace --lib` (1509+ tests across 16 suites pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --target wasm32-wasip2 -p runtara-workflow-stdlib --no-default-features --features wasi`
- [x] `cargo build --target wasm32-wasip2 -p runtara-agents --no-default-features --features wasi,integrations`
- [x] Added SDK tests `test_http_sdk_config_ignores_server_addr` / `test_http_sdk_config_uses_http_url` to lock the SERVER_ADDR → port+2 removal.
- [x] **End-to-end WASM smoke test**: ran runtara-server (embedded environment + WasmRunner) against Postgres and Valkey in Docker, compiled and registered `simple_passthrough` + `delay_workflow` as WASM images, and verified:
  - Server boot prints URLs derived from the new `Config::from_env` using `INTERNAL_PORT=17002`: `✓ Object model URL: http://127.0.0.1:17002/api/internal/object-model`, `✓ Agent service URL: http://127.0.0.1:17002/api/internal/agents`, `✓ Configured for tenant: e2e-test`.
  - Passthrough scenario completed successfully (`{"data":{"input":{"message":"hello"}}}` → `{"result":{"message":"hello"}}`).
  - Posting a `StartInstanceRequest` to `/api/v1/instances` with `env` containing the 4 scenario-ABI vars (exactly what `runtime_client::start_instance` now populates from `server_config`) causes them to appear on the `wasmtime --env` command line for the guest process:

    ```
    --env RUNTARA_OBJECT_MODEL_URL=http://127.0.0.1:17002/api/internal/object-model
    --env RUNTARA_AGENT_SERVICE_URL=http://127.0.0.1:17002/api/internal/agents
    --env RUNTARA_HTTP_PROXY_URL=http://127.0.0.1:17002/api/internal/proxy
    --env RUNTARA_TENANT_ID=e2e-test
    ```

    Without my changes these values used to come from the host process env via the runner's `env::var` calls; after the change they only appear when the server passes them explicitly, which is what we want.