### PR TITLE
fix(cleanup): default retention to 3 days and run cleanup eagerly on startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: runtara_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -194,7 +209,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ github.sha }}
 
       - name: Run runtara-server tests
-        run: cargo test -p runtara-server
+        # TEST_RUNTARA_SERVER_DATABASE_URL opts the integration tests in
+        # crates/runtara-server/tests/*.rs (e.g. invocation_cleanup_test.rs)
+        # into running against a real Postgres. Without it, skip_if_no_db!()
+        # makes them silently no-op — which previously hid the eager-pass
+        # cleanup regression that motivated this setup.
+        env:
+          TEST_RUNTARA_SERVER_DATABASE_URL: postgres://postgres:postgres@localhost:5432/runtara_test
+        run: cargo test -p runtara-server -- --test-threads=1
 
   test-environment:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously, each worker waited a full `poll_interval` (default 1 hour)
   before its first run, so frequent server restarts could prevent cleanup
   from ever happening.
+- `runtara-server` integration tests in CI now run against a real Postgres
+  service (previously skipped via `skip_if_no_db!()` because the CI
+  workflow had no DB). New regression test
+  `test_run_performs_eager_cleanup_on_startup` (in
+  `crates/runtara-server/tests/invocation_cleanup_test.rs`) seeds an old
+  terminal execution and asserts it is swept within seconds — guarding
+  the eager-pass behavior described above.
 
 ### Changed
 
@@ -48,6 +55,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RUNTARA_INVOCATION_CLEANUP_ENABLED=false` / `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS=<n>`
   On first run after upgrade, existing data older than 3 days in terminal
   states will be deleted.
+
+### Fixed
+
+- `*_CLEANUP_ENABLED` env-var parsing across all four cleanup workers
+  previously treated **any** value other than `"true"` or `"1"` as
+  disabled — including misconfigurations like `"yes"`, `"on"`, `"True"`,
+  or a typo, all of which silently turned cleanup off. The parse is now
+  inverted: cleanup is enabled by default and only an explicit false-like
+  value (`"false"`, `"0"`, `"no"`, `"off"`, `"disabled"`,
+  case-insensitive) disables it. Anything else — unset, malformed, or
+  truthy in any common spelling — leaves cleanup running.
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,26 +21,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   working unchanged.
 - `InvocationCleanupWorker` (runtara-server) deletes terminal
   `workflow_executions` older than `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS`
-  (default 7) and `workflow_metrics_hourly` rows older than
+  (default 3) and `workflow_metrics_hourly` rows older than
   `RUNTARA_INVOCATION_CLEANUP_METRICS_MAX_AGE_DAYS` (default 365). Events
   and side-effect usage rows cascade with their parent execution. Tune via
   `RUNTARA_INVOCATION_CLEANUP_ENABLED`, `_POLL_INTERVAL_SECS`,
   `_MAX_AGE_DAYS`, `_METRICS_MAX_AGE_DAYS`, `_BATCH_SIZE`.
 - `CleanupWorker` (runtara-environment) now reads configuration from env:
   `RUNTARA_RUN_DIR_CLEANUP_ENABLED`, `_POLL_INTERVAL_SECS`, `_MAX_AGE_DAYS`.
+- All four cleanup workers (`InvocationCleanupWorker`, `DbCleanupWorker`,
+  `ImageCleanupWorker`, run-dir `CleanupWorker`) now perform an **eager
+  first cleanup pass on startup**, before entering the poll loop.
+  Previously, each worker waited a full `poll_interval` (default 1 hour)
+  before its first run, so frequent server restarts could prevent cleanup
+  from ever happening.
 
 ### Changed
 
-- **Retention defaults are now on and aligned at 7 days.** Previously
+- **Retention defaults are now on and aligned at 3 days.** Previously
   `DbCleanupWorker` and `ImageCleanupWorker` were off-by-default and the
-  `CleanupWorker` ran at a 24-hour retention. All three workers now default
-  to enabled, 7-day retention. Operators who relied on long retention (or
+  `CleanupWorker` ran at a 24-hour retention. All four workers now default
+  to enabled, 3-day retention. Operators who relied on long retention (or
   silent cleanup) must opt out before upgrading:
   - `RUNTARA_DB_CLEANUP_ENABLED=false` / `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS=<n>`
   - `RUNTARA_IMAGE_CLEANUP_ENABLED=false` / `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS=<n>`
   - `RUNTARA_RUN_DIR_CLEANUP_ENABLED=false` / `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS=<n>`
   - `RUNTARA_INVOCATION_CLEANUP_ENABLED=false` / `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS=<n>`
-  On first run after upgrade, existing data older than 7 days in terminal
+  On first run after upgrade, existing data older than 3 days in terminal
   states will be deleted.
 
 ## [3.0.0]

--- a/crates/runtara-core/src/config.rs
+++ b/crates/runtara-core/src/config.rs
@@ -65,6 +65,27 @@ pub enum ConfigError {
     Invalid(&'static str, &'static str),
 }
 
+/// Resolve a boolean "enabled" env var with a "default-on, opt-out only" rule.
+///
+/// Returns `true` unless the env var is set to a recognised false-like value
+/// (case-insensitive, trimmed): `"false"`, `"0"`, `"no"`, `"off"`, or
+/// `"disabled"`. **Any other value — including unset, malformed input, typos,
+/// or truthy spellings like `"yes"`/`"on"`/`"True"` — leaves the feature
+/// enabled.** This is the inverse of the naive `v == "true" || v == "1"`
+/// parse: it cannot silently disable a feature because of a misconfiguration.
+///
+/// Used by all four cleanup workers (`*_CLEANUP_ENABLED`); pull it in via
+/// `use runtara_core::config::parse_enabled_env;`.
+pub fn parse_enabled_env(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off" | "disabled"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,5 +321,50 @@ mod tests {
             config.max_concurrent_instances,
             cloned.max_concurrent_instances
         );
+    }
+
+    #[test]
+    fn test_parse_enabled_env_default_on() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+        const VAR: &str = "RUNTARA_TEST_PARSE_ENABLED_HELPER";
+
+        // Unset → enabled
+        guard.remove(VAR);
+        assert!(parse_enabled_env(VAR), "unset must be enabled");
+
+        // Truthy spellings (and typos) leave the feature on
+        for v in [
+            "true",
+            "1",
+            "yes",
+            "on",
+            "True",
+            "TRUE",
+            "anything-else",
+            "",
+            "  true  ",
+        ] {
+            guard.set(VAR, v);
+            assert!(
+                parse_enabled_env(VAR),
+                "{v:?} must NOT silently disable the feature"
+            );
+        }
+
+        // Only explicit false-like values disable
+        for v in [
+            "false",
+            "0",
+            "no",
+            "off",
+            "disabled",
+            "FALSE",
+            "Off",
+            "  false  ",
+        ] {
+            guard.set(VAR, v);
+            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
+        }
     }
 }

--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use runtara_core::config::parse_enabled_env;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
 
@@ -299,21 +300,6 @@ impl CleanupWorker {
     }
 }
 
-/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
-/// rule. Cleanup is enabled unless the env var is explicitly set to a
-/// recognised false-like value (case-insensitive). Misconfigurations like
-/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup — the
-/// inverse of the naive `v == "true" || v == "1"` parse.
-fn parse_enabled_env(name: &str) -> bool {
-    match std::env::var(name) {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "false" | "0" | "no" | "off" | "disabled"
-        ),
-        Err(_) => true,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,41 +311,6 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
         assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
-    }
-
-    #[test]
-    fn test_parse_enabled_env_default_on() {
-        // Use unique var names so parallel tests don't trample each other.
-        const VAR: &str = "RUNTARA_TEST_RUN_DIR_CLEANUP_ENABLED_PARSE";
-        // SAFETY: tests in this binary run on a single thread for env-mutation
-        unsafe { std::env::remove_var(VAR) };
-        assert!(parse_enabled_env(VAR), "unset must be enabled");
-
-        for v in [
-            "true",
-            "1",
-            "yes",
-            "on",
-            "True",
-            "TRUE",
-            "anything-else",
-            "",
-        ] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(
-                parse_enabled_env(VAR),
-                "{v:?} must NOT silently disable cleanup"
-            );
-        }
-
-        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(
-                !parse_enabled_env(VAR),
-                "{v:?} must explicitly disable cleanup"
-            );
-        }
-        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -36,7 +36,7 @@ impl Default for CleanupWorkerConfig {
             enabled: true,
             data_dir: PathBuf::from(".data"),
             poll_interval: Duration::from_secs(3600), // 1 hour
-            max_age: Duration::from_secs(7 * 24 * 3600), // 7 days
+            max_age: Duration::from_secs(3 * 24 * 3600), // 3 days
         }
     }
 }
@@ -47,7 +47,7 @@ impl CleanupWorkerConfig {
     /// Environment variables:
     /// - `RUNTARA_RUN_DIR_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
     /// - `RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS`: seconds between scans (default: 3600)
-    /// - `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS`: days before run dirs are removed (default: 7)
+    /// - `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS`: days before run dirs are removed (default: 3)
     pub fn from_env() -> Self {
         let enabled = std::env::var("RUNTARA_RUN_DIR_CLEANUP_ENABLED")
             .map(|v| v == "true" || v == "1")
@@ -61,7 +61,7 @@ impl CleanupWorkerConfig {
         let max_age_days = std::env::var("RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(7);
+            .unwrap_or(3);
 
         Self {
             enabled,
@@ -108,6 +108,25 @@ impl CleanupWorker {
             max_age_hours = self.config.max_age.as_secs() / 3600,
             "Cleanup worker started"
         );
+
+        // Eager first pass: enforce retention immediately on startup so that
+        // cleanup runs even when the server restarts more frequently than
+        // `poll_interval`. Race against the shutdown signal so a slow or
+        // hanging cleanup cannot block shutdown.
+        tokio::select! {
+            biased;
+
+            _ = self.shutdown.notified() => {
+                info!("Cleanup worker received shutdown signal during eager pass");
+                return;
+            }
+
+            res = self.cleanup_old_directories() => {
+                if let Err(e) = res {
+                    error!(error = %e, "Failed to cleanup old directories");
+                }
+            }
+        }
 
         loop {
             tokio::select! {
@@ -289,7 +308,7 @@ mod tests {
         let config = CleanupWorkerConfig::default();
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
-        assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
     }
 
     #[test]

--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -45,13 +45,14 @@ impl CleanupWorkerConfig {
     /// Load configuration from environment variables.
     ///
     /// Environment variables:
-    /// - `RUNTARA_RUN_DIR_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
+    /// - `RUNTARA_RUN_DIR_CLEANUP_ENABLED`: set to `false`/`0`/`no`/`off`
+    ///   (case-insensitive) to disable. **Any other value — including unset,
+    ///   typos, or `"yes"`/`"on"` — leaves cleanup enabled.** Cleanup is on
+    ///   by default; only an explicit opt-out turns it off.
     /// - `RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS`: seconds between scans (default: 3600)
     /// - `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS`: days before run dirs are removed (default: 3)
     pub fn from_env() -> Self {
-        let enabled = std::env::var("RUNTARA_RUN_DIR_CLEANUP_ENABLED")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(true);
+        let enabled = parse_enabled_env("RUNTARA_RUN_DIR_CLEANUP_ENABLED");
 
         let poll_interval_secs = std::env::var("RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS")
             .ok()
@@ -298,6 +299,21 @@ impl CleanupWorker {
     }
 }
 
+/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
+/// rule. Cleanup is enabled unless the env var is explicitly set to a
+/// recognised false-like value (case-insensitive). Misconfigurations like
+/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup — the
+/// inverse of the naive `v == "true" || v == "1"` parse.
+fn parse_enabled_env(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off" | "disabled"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,6 +325,41 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
         assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
+    }
+
+    #[test]
+    fn test_parse_enabled_env_default_on() {
+        // Use unique var names so parallel tests don't trample each other.
+        const VAR: &str = "RUNTARA_TEST_RUN_DIR_CLEANUP_ENABLED_PARSE";
+        // SAFETY: tests in this binary run on a single thread for env-mutation
+        unsafe { std::env::remove_var(VAR) };
+        assert!(parse_enabled_env(VAR), "unset must be enabled");
+
+        for v in [
+            "true",
+            "1",
+            "yes",
+            "on",
+            "True",
+            "TRUE",
+            "anything-else",
+            "",
+        ] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(
+                parse_enabled_env(VAR),
+                "{v:?} must NOT silently disable cleanup"
+            );
+        }
+
+        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(
+                !parse_enabled_env(VAR),
+                "{v:?} must explicitly disable cleanup"
+            );
+        }
+        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/db_cleanup_worker.rs
+++ b/crates/runtara-environment/src/db_cleanup_worker.rs
@@ -57,14 +57,15 @@ impl DbCleanupWorkerConfig {
     /// Load configuration from environment variables.
     ///
     /// Environment variables:
-    /// - `RUNTARA_DB_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
+    /// - `RUNTARA_DB_CLEANUP_ENABLED`: set to `false`/`0`/`no`/`off`
+    ///   (case-insensitive) to disable. **Any other value — including unset,
+    ///   typos, or `"yes"`/`"on"` — leaves cleanup enabled.** Cleanup is on
+    ///   by default; only an explicit opt-out turns it off.
     /// - `RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS`: seconds between cleanup runs (default: 3600)
     /// - `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS`: days before terminal instances are deleted (default: 3)
     /// - `RUNTARA_DB_CLEANUP_BATCH_SIZE`: max instances per batch (default: 100)
     pub fn from_env() -> Self {
-        let enabled = std::env::var("RUNTARA_DB_CLEANUP_ENABLED")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(true);
+        let enabled = parse_enabled_env("RUNTARA_DB_CLEANUP_ENABLED");
 
         let poll_interval_secs = std::env::var("RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS")
             .ok()
@@ -289,6 +290,20 @@ impl DbCleanupWorker {
     }
 }
 
+/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
+/// rule. Cleanup is enabled unless the env var is explicitly set to a
+/// recognised false-like value (case-insensitive). Misconfigurations like
+/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
+fn parse_enabled_env(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off" | "disabled"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,6 +315,32 @@ mod tests {
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
         assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
         assert_eq!(config.batch_size, 100);
+    }
+
+    #[test]
+    fn test_parse_enabled_env_default_on() {
+        const VAR: &str = "RUNTARA_TEST_DB_CLEANUP_ENABLED_PARSE";
+        unsafe { std::env::remove_var(VAR) };
+        assert!(parse_enabled_env(VAR), "unset must be enabled");
+
+        for v in [
+            "true",
+            "1",
+            "yes",
+            "on",
+            "True",
+            "TRUE",
+            "anything-else",
+            "",
+        ] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
+        }
+        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
+        }
+        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/db_cleanup_worker.rs
+++ b/crates/runtara-environment/src/db_cleanup_worker.rs
@@ -47,7 +47,7 @@ impl Default for DbCleanupWorkerConfig {
             enabled: true, // Enabled by default — retention is
             // bounded; override via env to disable
             poll_interval: Duration::from_secs(3600), // 1 hour
-            max_age: Duration::from_secs(7 * 24 * 3600), // 7 days
+            max_age: Duration::from_secs(3 * 24 * 3600), // 3 days
             batch_size: 100,
         }
     }
@@ -59,7 +59,7 @@ impl DbCleanupWorkerConfig {
     /// Environment variables:
     /// - `RUNTARA_DB_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
     /// - `RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS`: seconds between cleanup runs (default: 3600)
-    /// - `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS`: days before terminal instances are deleted (default: 7)
+    /// - `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS`: days before terminal instances are deleted (default: 3)
     /// - `RUNTARA_DB_CLEANUP_BATCH_SIZE`: max instances per batch (default: 100)
     pub fn from_env() -> Self {
         let enabled = std::env::var("RUNTARA_DB_CLEANUP_ENABLED")
@@ -74,7 +74,7 @@ impl DbCleanupWorkerConfig {
         let max_age_days = std::env::var("RUNTARA_DB_CLEANUP_MAX_AGE_DAYS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(7);
+            .unwrap_or(3);
 
         let batch_size = std::env::var("RUNTARA_DB_CLEANUP_BATCH_SIZE")
             .ok()
@@ -134,6 +134,25 @@ impl DbCleanupWorker {
             batch_size = self.config.batch_size,
             "Database cleanup worker started"
         );
+
+        // Eager first pass: enforce retention immediately on startup so that
+        // cleanup runs even when the server restarts more frequently than
+        // `poll_interval`. Race against the shutdown signal so a slow or
+        // hanging cleanup (e.g. unreachable DB) cannot block shutdown.
+        tokio::select! {
+            biased;
+
+            _ = self.shutdown.notified() => {
+                info!("Database cleanup worker received shutdown signal during eager pass");
+                return;
+            }
+
+            res = self.cleanup_old_instances() => {
+                if let Err(e) = res {
+                    error!(error = %e, "Failed to cleanup old instances");
+                }
+            }
+        }
 
         loop {
             tokio::select! {
@@ -279,17 +298,17 @@ mod tests {
         let config = DbCleanupWorkerConfig::default();
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
-        assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
         assert_eq!(config.batch_size, 100);
     }
 
     #[test]
     fn test_config_max_age_days() {
         let config = DbCleanupWorkerConfig {
-            max_age: Duration::from_secs(7 * 24 * 3600), // 7 days
+            max_age: Duration::from_secs(3 * 24 * 3600), // 3 days
             ..Default::default()
         };
-        assert_eq!(config.max_age.as_secs() / 86400, 7);
+        assert_eq!(config.max_age.as_secs() / 86400, 3);
     }
 
     #[test]

--- a/crates/runtara-environment/src/db_cleanup_worker.rs
+++ b/crates/runtara-environment/src/db_cleanup_worker.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use runtara_core::config::parse_enabled_env;
 use runtara_core::persistence::Persistence;
 use sqlx::PgPool;
 use tokio::sync::Notify;
@@ -290,20 +291,6 @@ impl DbCleanupWorker {
     }
 }
 
-/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
-/// rule. Cleanup is enabled unless the env var is explicitly set to a
-/// recognised false-like value (case-insensitive). Misconfigurations like
-/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
-fn parse_enabled_env(name: &str) -> bool {
-    match std::env::var(name) {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "false" | "0" | "no" | "off" | "disabled"
-        ),
-        Err(_) => true,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,32 +302,6 @@ mod tests {
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
         assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
         assert_eq!(config.batch_size, 100);
-    }
-
-    #[test]
-    fn test_parse_enabled_env_default_on() {
-        const VAR: &str = "RUNTARA_TEST_DB_CLEANUP_ENABLED_PARSE";
-        unsafe { std::env::remove_var(VAR) };
-        assert!(parse_enabled_env(VAR), "unset must be enabled");
-
-        for v in [
-            "true",
-            "1",
-            "yes",
-            "on",
-            "True",
-            "TRUE",
-            "anything-else",
-            "",
-        ] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
-        }
-        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
-        }
-        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -60,14 +60,15 @@ impl ImageCleanupWorkerConfig {
     /// Load configuration from environment variables.
     ///
     /// Environment variables:
-    /// - `RUNTARA_IMAGE_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
+    /// - `RUNTARA_IMAGE_CLEANUP_ENABLED`: set to `false`/`0`/`no`/`off`
+    ///   (case-insensitive) to disable. **Any other value — including unset,
+    ///   typos, or `"yes"`/`"on"` — leaves cleanup enabled.** Cleanup is on
+    ///   by default; only an explicit opt-out turns it off.
     /// - `RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS`: seconds between cleanup runs (default: 21600)
     /// - `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS`: days before stale images are deleted (default: 3)
     /// - `RUNTARA_IMAGE_CLEANUP_BATCH_SIZE`: max images per cycle (default: 50)
     pub fn from_env() -> Self {
-        let enabled = std::env::var("RUNTARA_IMAGE_CLEANUP_ENABLED")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(true);
+        let enabled = parse_enabled_env("RUNTARA_IMAGE_CLEANUP_ENABLED");
 
         let poll_interval_secs = std::env::var("RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS")
             .ok()
@@ -338,6 +339,20 @@ impl ImageCleanupWorker {
     }
 }
 
+/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
+/// rule. Cleanup is enabled unless the env var is explicitly set to a
+/// recognised false-like value (case-insensitive). Misconfigurations like
+/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
+fn parse_enabled_env(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off" | "disabled"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,6 +374,32 @@ mod tests {
             config.enabled,
             "Image cleanup should be enabled by default; disable via RUNTARA_IMAGE_CLEANUP_ENABLED=false"
         );
+    }
+
+    #[test]
+    fn test_parse_enabled_env_default_on() {
+        const VAR: &str = "RUNTARA_TEST_IMAGE_CLEANUP_ENABLED_PARSE";
+        unsafe { std::env::remove_var(VAR) };
+        assert!(parse_enabled_env(VAR), "unset must be enabled");
+
+        for v in [
+            "true",
+            "1",
+            "yes",
+            "on",
+            "True",
+            "TRUE",
+            "anything-else",
+            "",
+        ] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
+        }
+        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
+        }
+        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -49,7 +49,7 @@ impl Default for ImageCleanupWorkerConfig {
         Self {
             enabled: true, // Enabled by default — override via env to disable
             poll_interval: Duration::from_secs(6 * 3600), // 6 hours
-            max_age: Duration::from_secs(7 * 24 * 3600), // 7 days
+            max_age: Duration::from_secs(3 * 24 * 3600), // 3 days
             batch_size: 50,
             data_dir: PathBuf::new(), // Set by runtime
         }
@@ -62,7 +62,7 @@ impl ImageCleanupWorkerConfig {
     /// Environment variables:
     /// - `RUNTARA_IMAGE_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
     /// - `RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS`: seconds between cleanup runs (default: 21600)
-    /// - `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS`: days before stale images are deleted (default: 7)
+    /// - `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS`: days before stale images are deleted (default: 3)
     /// - `RUNTARA_IMAGE_CLEANUP_BATCH_SIZE`: max images per cycle (default: 50)
     pub fn from_env() -> Self {
         let enabled = std::env::var("RUNTARA_IMAGE_CLEANUP_ENABLED")
@@ -77,7 +77,7 @@ impl ImageCleanupWorkerConfig {
         let max_age_days = std::env::var("RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(7);
+            .unwrap_or(3);
 
         let batch_size = std::env::var("RUNTARA_IMAGE_CLEANUP_BATCH_SIZE")
             .ok()
@@ -132,6 +132,25 @@ impl ImageCleanupWorker {
             batch_size = self.config.batch_size,
             "Image cleanup worker started"
         );
+
+        // Eager first pass: enforce retention immediately on startup so that
+        // cleanup runs even when the server restarts more frequently than
+        // `poll_interval`. Race against the shutdown signal so a slow or
+        // hanging cleanup (e.g. unreachable DB) cannot block shutdown.
+        tokio::select! {
+            biased;
+
+            _ = self.shutdown.notified() => {
+                info!("Image cleanup worker received shutdown signal during eager pass");
+                return;
+            }
+
+            res = self.cleanup_images() => {
+                if let Err(e) = res {
+                    error!(error = %e, "Failed to cleanup images");
+                }
+            }
+        }
 
         loop {
             tokio::select! {
@@ -329,7 +348,7 @@ mod tests {
         let config = ImageCleanupWorkerConfig::default();
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(6 * 3600));
-        assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
         assert_eq!(config.batch_size, 50);
     }
 

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use runtara_core::config::parse_enabled_env;
 use sqlx::PgPool;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
@@ -339,20 +340,6 @@ impl ImageCleanupWorker {
     }
 }
 
-/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
-/// rule. Cleanup is enabled unless the env var is explicitly set to a
-/// recognised false-like value (case-insensitive). Misconfigurations like
-/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
-fn parse_enabled_env(name: &str) -> bool {
-    match std::env::var(name) {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "false" | "0" | "no" | "off" | "disabled"
-        ),
-        Err(_) => true,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -374,32 +361,6 @@ mod tests {
             config.enabled,
             "Image cleanup should be enabled by default; disable via RUNTARA_IMAGE_CLEANUP_ENABLED=false"
         );
-    }
-
-    #[test]
-    fn test_parse_enabled_env_default_on() {
-        const VAR: &str = "RUNTARA_TEST_IMAGE_CLEANUP_ENABLED_PARSE";
-        unsafe { std::env::remove_var(VAR) };
-        assert!(parse_enabled_env(VAR), "unset must be enabled");
-
-        for v in [
-            "true",
-            "1",
-            "yes",
-            "on",
-            "True",
-            "TRUE",
-            "anything-else",
-            "",
-        ] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
-        }
-        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
-        }
-        unsafe { std::env::remove_var(VAR) };
     }
 
     #[test]

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -127,7 +127,7 @@ impl Default for EnvironmentRuntimeBuilder {
             wake_batch_size: 10,
             request_timeout: Duration::from_secs(30),
             cleanup_poll_interval: Duration::from_secs(3600), // 1 hour
-            cleanup_max_age: Duration::from_secs(7 * 24 * 3600), // 7 days
+            cleanup_max_age: Duration::from_secs(3 * 24 * 3600), // 3 days
             heartbeat_poll_interval: Duration::from_secs(30), // 30 seconds
             heartbeat_timeout: Duration::from_secs(120),      // 2 minutes
             db_cleanup_config: DbCleanupWorkerConfig::from_env(),

--- a/crates/runtara-environment/tests/db_cleanup_worker_test.rs
+++ b/crates/runtara-environment/tests/db_cleanup_worker_test.rs
@@ -344,7 +344,7 @@ fn test_config_default() {
 
     assert!(config.enabled, "Should be enabled by default");
     assert_eq!(config.poll_interval, Duration::from_secs(3600));
-    assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+    assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
     assert_eq!(config.batch_size, 100);
 }
 

--- a/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
+++ b/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use chrono::Utc;
+use runtara_core::config::parse_enabled_env;
 use sqlx::PgPool;
 use tracing::{debug, error, info, warn};
 
@@ -246,20 +247,6 @@ impl InvocationCleanupWorker {
     }
 }
 
-/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
-/// rule. Cleanup is enabled unless the env var is explicitly set to a
-/// recognised false-like value (case-insensitive). Misconfigurations like
-/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
-fn parse_enabled_env(name: &str) -> bool {
-    match std::env::var(name) {
-        Ok(v) => !matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "false" | "0" | "no" | "off" | "disabled"
-        ),
-        Err(_) => true,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,32 +277,6 @@ mod tests {
         assert!(config.enabled, "Enabled-by-default expected");
         assert_eq!(config.max_age.as_secs() / 86400, 3);
         assert_eq!(config.metrics_max_age.as_secs() / 86400, 365);
-    }
-
-    #[test]
-    fn test_parse_enabled_env_default_on() {
-        const VAR: &str = "RUNTARA_TEST_INVOCATION_CLEANUP_ENABLED_PARSE";
-        unsafe { std::env::remove_var(VAR) };
-        assert!(parse_enabled_env(VAR), "unset must be enabled");
-
-        for v in [
-            "true",
-            "1",
-            "yes",
-            "on",
-            "True",
-            "TRUE",
-            "anything-else",
-            "",
-        ] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
-        }
-        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
-            unsafe { std::env::set_var(VAR, v) };
-            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
-        }
-        unsafe { std::env::remove_var(VAR) };
     }
 
     #[tokio::test]

--- a/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
+++ b/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
@@ -39,7 +39,7 @@ impl Default for InvocationCleanupWorkerConfig {
         Self {
             enabled: true,
             poll_interval: Duration::from_secs(3600),
-            max_age: Duration::from_secs(7 * 24 * 3600),
+            max_age: Duration::from_secs(3 * 24 * 3600),
             metrics_max_age: Duration::from_secs(365 * 24 * 3600),
             batch_size: 500,
         }
@@ -52,7 +52,7 @@ impl InvocationCleanupWorkerConfig {
     /// Environment variables:
     /// - `RUNTARA_INVOCATION_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
     /// - `RUNTARA_INVOCATION_CLEANUP_POLL_INTERVAL_SECS`: seconds between cycles (default: 3600)
-    /// - `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS`: days before executions are deleted (default: 7)
+    /// - `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS`: days before executions are deleted (default: 3)
     /// - `RUNTARA_INVOCATION_CLEANUP_METRICS_MAX_AGE_DAYS`: days before metrics are deleted (default: 365)
     /// - `RUNTARA_INVOCATION_CLEANUP_BATCH_SIZE`: max executions per batch (default: 500)
     pub fn from_env() -> Self {
@@ -68,7 +68,7 @@ impl InvocationCleanupWorkerConfig {
         let max_age_days = std::env::var("RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(7);
+            .unwrap_or(3);
 
         let metrics_max_age_days = std::env::var("RUNTARA_INVOCATION_CLEANUP_METRICS_MAX_AGE_DAYS")
             .ok()
@@ -125,6 +125,23 @@ impl InvocationCleanupWorker {
             "Invocation cleanup worker started"
         );
 
+        // Eager first pass: run a cleanup cycle immediately on startup so that
+        // bounded retention is enforced even when the server restarts more
+        // frequently than `poll_interval`. Race against the shutdown signal so
+        // a slow cleanup (e.g. unreachable DB) cannot block shutdown.
+        tokio::select! {
+            biased;
+            _ = self.shutdown.clone().wait() => {
+                info!("Invocation cleanup worker exiting on shutdown signal");
+                return;
+            }
+            res = self.cleanup_once() => {
+                if let Err(e) = res {
+                    error!(error = %e, "Invocation cleanup cycle failed");
+                }
+            }
+        }
+
         loop {
             if self.shutdown.is_shutting_down() {
                 info!("Invocation cleanup worker exiting on shutdown signal");
@@ -168,8 +185,8 @@ impl InvocationCleanupWorker {
     async fn cleanup_old_executions(&self) -> Result<u64, sqlx::Error> {
         let cutoff = Utc::now()
             - chrono::Duration::from_std(self.config.max_age).unwrap_or_else(|_| {
-                warn!("Invalid max_age, falling back to 7 days");
-                chrono::Duration::days(7)
+                warn!("Invalid max_age, falling back to 3 days");
+                chrono::Duration::days(3)
             });
 
         let mut total = 0u64;
@@ -237,7 +254,7 @@ mod tests {
         let config = InvocationCleanupWorkerConfig::default();
         assert!(config.enabled);
         assert_eq!(config.poll_interval, Duration::from_secs(3600));
-        assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
         assert_eq!(config.metrics_max_age, Duration::from_secs(365 * 24 * 3600));
         assert_eq!(config.batch_size, 500);
     }
@@ -256,7 +273,7 @@ mod tests {
 
         let config = InvocationCleanupWorkerConfig::from_env();
         assert!(config.enabled, "Enabled-by-default expected");
-        assert_eq!(config.max_age.as_secs() / 86400, 7);
+        assert_eq!(config.max_age.as_secs() / 86400, 3);
         assert_eq!(config.metrics_max_age.as_secs() / 86400, 365);
     }
 

--- a/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
+++ b/crates/runtara-server/src/workers/invocation_cleanup_worker.rs
@@ -50,15 +50,16 @@ impl InvocationCleanupWorkerConfig {
     /// Load configuration from environment variables.
     ///
     /// Environment variables:
-    /// - `RUNTARA_INVOCATION_CLEANUP_ENABLED`: "true" or "1" to enable (default: true)
+    /// - `RUNTARA_INVOCATION_CLEANUP_ENABLED`: set to `false`/`0`/`no`/`off`
+    ///   (case-insensitive) to disable. **Any other value — including unset,
+    ///   typos, or `"yes"`/`"on"` — leaves cleanup enabled.** Cleanup is on
+    ///   by default; only an explicit opt-out turns it off.
     /// - `RUNTARA_INVOCATION_CLEANUP_POLL_INTERVAL_SECS`: seconds between cycles (default: 3600)
     /// - `RUNTARA_INVOCATION_CLEANUP_MAX_AGE_DAYS`: days before executions are deleted (default: 3)
     /// - `RUNTARA_INVOCATION_CLEANUP_METRICS_MAX_AGE_DAYS`: days before metrics are deleted (default: 365)
     /// - `RUNTARA_INVOCATION_CLEANUP_BATCH_SIZE`: max executions per batch (default: 500)
     pub fn from_env() -> Self {
-        let enabled = std::env::var("RUNTARA_INVOCATION_CLEANUP_ENABLED")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(true);
+        let enabled = parse_enabled_env("RUNTARA_INVOCATION_CLEANUP_ENABLED");
 
         let poll_interval_secs = std::env::var("RUNTARA_INVOCATION_CLEANUP_POLL_INTERVAL_SECS")
             .ok()
@@ -245,6 +246,20 @@ impl InvocationCleanupWorker {
     }
 }
 
+/// Resolve a `*_CLEANUP_ENABLED` env var with a "default-on, opt-out only"
+/// rule. Cleanup is enabled unless the env var is explicitly set to a
+/// recognised false-like value (case-insensitive). Misconfigurations like
+/// `"yes"`, `"on"`, or a typo do **not** silently disable cleanup.
+fn parse_enabled_env(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "false" | "0" | "no" | "off" | "disabled"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,6 +290,32 @@ mod tests {
         assert!(config.enabled, "Enabled-by-default expected");
         assert_eq!(config.max_age.as_secs() / 86400, 3);
         assert_eq!(config.metrics_max_age.as_secs() / 86400, 365);
+    }
+
+    #[test]
+    fn test_parse_enabled_env_default_on() {
+        const VAR: &str = "RUNTARA_TEST_INVOCATION_CLEANUP_ENABLED_PARSE";
+        unsafe { std::env::remove_var(VAR) };
+        assert!(parse_enabled_env(VAR), "unset must be enabled");
+
+        for v in [
+            "true",
+            "1",
+            "yes",
+            "on",
+            "True",
+            "TRUE",
+            "anything-else",
+            "",
+        ] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(parse_enabled_env(VAR), "{v:?} must NOT silently disable");
+        }
+        for v in ["false", "0", "no", "off", "disabled", "FALSE", "Off"] {
+            unsafe { std::env::set_var(VAR, v) };
+            assert!(!parse_enabled_env(VAR), "{v:?} must explicitly disable");
+        }
+        unsafe { std::env::remove_var(VAR) };
     }
 
     #[tokio::test]

--- a/crates/runtara-server/tests/invocation_cleanup_test.rs
+++ b/crates/runtara-server/tests/invocation_cleanup_test.rs
@@ -441,3 +441,82 @@ async fn test_run_loop_exits_on_coordinator_shutdown() {
         .expect("worker exited within 2s of shutdown")
         .expect("task did not panic");
 }
+
+/// `run()` must perform an eager cleanup pass *before* the first
+/// `poll_interval` elapses. This is the prod-shaped guard for the bug that
+/// motivated the 3-day default change: if the worker only cleaned up after
+/// `sleep(poll_interval)`, every server restart would push cleanup another
+/// hour out and tables would grow unboundedly on a churny box.
+///
+/// Test setup uses `poll_interval = 1h` and `max_age = 3d`, then seeds a
+/// 10-day-old terminal execution. If the eager pass works, the row is gone
+/// within a few hundred ms. If it doesn't, the test would hang for an hour
+/// (and time out at 5s with a clear regression message).
+#[tokio::test]
+async fn test_run_performs_eager_cleanup_on_startup() {
+    skip_if_no_db!();
+    let pool = get_test_pool().await.expect("pool");
+    let tenant_id = format!("test-eager-{}", Uuid::new_v4());
+    let workflow_id = format!("wf-{}", Uuid::new_v4());
+    insert_workflow(&pool, &tenant_id, &workflow_id).await;
+
+    let old = Utc::now() - ChronoDuration::days(10);
+    let old_completed = Uuid::new_v4();
+    insert_execution(
+        &pool,
+        old_completed,
+        &tenant_id,
+        &workflow_id,
+        "completed",
+        old,
+        Some(old),
+    )
+    .await;
+    assert!(
+        execution_exists(&pool, old_completed).await,
+        "seed precondition: old execution exists before worker starts"
+    );
+
+    let coord = std::sync::Arc::new(runtara_server::shutdown::ShutdownCoordinator::from_env(
+        std::sync::Arc::new(dashmap::DashMap::new()),
+        None,
+    ));
+    let signal = coord.signal();
+
+    // poll_interval is intentionally an hour: only the eager pass can fire
+    // within the 5s test budget. max_age matches the new prod default (3d).
+    let config = InvocationCleanupWorkerConfig {
+        enabled: true,
+        poll_interval: Duration::from_secs(3600),
+        max_age: Duration::from_secs(3 * 24 * 3600),
+        metrics_max_age: Duration::from_secs(365 * 24 * 3600),
+        batch_size: 100,
+    };
+    let worker = InvocationCleanupWorker::new(pool.clone(), config, signal);
+
+    let handle = tokio::spawn(async move { worker.run().await });
+
+    // Poll the DB until the row disappears. Locally this lands in <100ms;
+    // give CI runners 5s of headroom.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut deleted = false;
+    while std::time::Instant::now() < deadline {
+        if !execution_exists(&pool, old_completed).await {
+            deleted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    coord.request_shutdown();
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    cleanup_tenant(&pool, &tenant_id).await;
+
+    assert!(
+        deleted,
+        "Eager cleanup did not delete the 10-day-old terminal execution \
+         within 5s. The eager-first-pass behavior in `run()` may be \
+         regressed — without it, cleanup would not fire until \
+         `poll_interval` (1h) elapsed."
+    );
+}


### PR DESCRIPTION
## Description

Two real bugs were causing `workflow_executions` (and friends) to grow well past the intended 3-day window — ~3K rows visible on prod.

1. **All four cleanup workers defaulted to 7 days, not 3.** `.env` only overrode the DB and image workers, so the server-side `InvocationCleanupWorker` silently ran at the 7-day default. That alone roughly doubles row counts vs. policy.
2. **Every worker `sleep(poll_interval)`'d before its first run.** With `poll_interval = 3600s`, any restart inside an hour pushed cleanup another hour out — on a churny prod box, cleanup may have rarely fired at all.

This PR fixes both:

- Default `max_age` flipped from `7d` → `3d` in `InvocationCleanupWorker`, `DbCleanupWorker`, `ImageCleanupWorker`, run-dir `CleanupWorker`, and `EnvironmentRuntimeBuilder::cleanup_max_age`. Doc comments, fallback warn messages, and unit/integration tests updated to match.
- All four workers now perform an **eager first cleanup pass on startup**, before entering the poll loop. The eager pass is wrapped in `tokio::select!` against the shutdown signal so a slow or hanging cleanup (e.g. unreachable DB) cannot block shutdown.
- `CHANGELOG.md` `Unreleased` section updated to describe the new 3-day default and the eager-startup behavior.

`.env` is intentionally left alone — the existing `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS=3` / `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS=3` lines now match the new default and stay as documentation. Valkey stream retention (48h hardcoded) is already below 3 days, out of scope.

After this ships and prod restarts, the eager pass will sweep everything older than 3 days on startup — no manual `DELETE` needed.

## Related Issue

N/A — surfaced from prod observation that `workflow_executions` had ~3K rows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

> Operationally a behavior change — clusters relying on the implicit 7-day window will start retaining only 3 days after upgrade. The CHANGELOG entry already documents the override knobs (`RUNTARA_*_CLEANUP_MAX_AGE_DAYS`).

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's coding standards
- [x] I have run \`cargo fmt --all\` and \`cargo clippy --all-targets -- -D warnings\` (pre-commit hook ran clippy with \`SQLX_OFFLINE=true\` like CI)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (\`cargo test --lib\` for the touched crates)
- [x] I have updated the documentation if needed (CHANGELOG.md + doc comments on each worker)
- [x] My changes don't introduce new warnings

## Testing

- \`SQLX_OFFLINE=true cargo test --lib -p runtara-environment cleanup_worker\` → **20/20 pass** (covers `cleanup_worker`, `db_cleanup_worker`, `image_cleanup_worker`, including `test_run_responds_to_shutdown` which initially failed and surfaced the eager-pass-shutdown-aware bug).
- \`SQLX_OFFLINE=true cargo test --lib -p runtara-server invocation_cleanup_worker\` → **3/3 pass**.
- \`SQLX_OFFLINE=true cargo check --tests -p runtara-environment -p runtara-server\` → both crates' integration test files compile cleanly with the new eager-pass `run()` signatures.

After deploy, verify via server logs that:
- \`"Invocation cleanup worker started"\` reports \`max_age_days=3\`.
- A cleanup-cycle line appears within seconds of startup (proves the eager pass), not an hour later.

## Additional Notes

The `tokio::select!` wrapper on the eager pass uses `biased;` so the shutdown arm wins ties, matching the loop's existing pattern. For the run-dir / image / db workers (which use `Arc<Notify>`), this consumes any pre-signaled permit immediately on entry. For the invocation worker (which uses `ShutdownSignal` — atomic-backed), `wait()` returns instantly when the flag is already set.