### PR TITLE
chore(deps): bump dompurify override to ^3.4.0

### DIFF
--- a/crates/runtara-server/frontend/package-lock.json
+++ b/crates/runtara-server/frontend/package-lock.json
@@ -7962,12 +7962,11 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/crates/runtara-server/frontend/package.json
+++ b/crates/runtara-server/frontend/package.json
@@ -143,7 +143,7 @@
   },
   "overrides": {
     "flatted": "3.4.2",
-    "dompurify": "3.3.2",
+    "dompurify": "^3.4.0",
     "serialize-javascript": "7.0.5"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

Bumps the `dompurify` override in [crates/runtara-server/frontend/package.json](crates/runtara-server/frontend/package.json) from `3.3.2` to `^3.4.0`. Resolves to `3.4.1` after `npm install`.

Clears 4 medium-severity advisories — all fixed in 3.4.0:

- [GHSA-39q2-94rc-95cp](https://github.com/runtarahq/runtara/security/dependabot/16) — ADD_TAGS function form bypasses FORBID_TAGS
- [GHSA-v9jr-rg53-9pgp](https://github.com/runtarahq/runtara/security/dependabot/17) — Prototype Pollution to XSS
- [GHSA-h7mw-gpvr-xq4m](https://github.com/runtarahq/runtara/security/dependabot/18) — FORBID_TAGS bypass via function-based ADD_TAGS
- [GHSA-crv5-9vww-q3g8](https://github.com/runtarahq/runtara/security/dependabot/19) — SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode

DOMPurify still reaches the project transitively through `swagger-typescript-api → yummies` — there is no direct app usage, but the override ensures any path resolves to the patched version.

## Test plan

- [x] `npm install` succeeds and `npm ls dompurify` reports `3.4.1`
- [ ] Frontend `build` and `lint` jobs pass in CI