### PR TITLE
chore(deps): bump rand to patched versions (0.8.6 / 0.9.3 / 0.10.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2449,7 +2449,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2755,7 +2755,7 @@ dependencies = [
  "glob",
  "opentelemetry 0.28.0",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -2774,7 +2774,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.31.0",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -3007,7 +3007,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -3189,7 +3189,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3244,9 +3244,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3255,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3578,7 +3578,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -3659,7 +3659,7 @@ dependencies = [
  "md-5 0.10.6",
  "minijinja",
  "openssl",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "roxmltree",
  "runtara-agent-macro",
@@ -3702,7 +3702,7 @@ dependencies = [
  "dashmap",
  "hex",
  "hmac 0.12.1",
- "rand 0.9.2",
+ "rand 0.9.3",
  "redis",
  "reqwest",
  "runtara-dsl",
@@ -3887,7 +3887,7 @@ dependencies = [
  "opentelemetry-otlp 0.31.1",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.31.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "regex",
  "reqwest",
@@ -4035,7 +4035,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -4713,7 +4713,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -4754,7 +4754,7 @@ dependencies = [
  "md-5 0.10.6",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -5327,7 +5327,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
## Summary

Cargo.lock-only patch bumps for the three `rand` versions resolved in the workspace:

| Was | Now | Patches |
|---|---|---|
| 0.8.5 | 0.8.6 | [GHSA-cq8v-f236-94qc](https://github.com/runtarahq/runtara/security/dependabot/26) |
| 0.9.2 | 0.9.3 | [GHSA-cq8v-f236-94qc](https://github.com/runtarahq/runtara/security/dependabot/20) |
| 0.10.0 | 0.10.1 | [GHSA-cq8v-f236-94qc](https://github.com/runtarahq/runtara/security/dependabot/10) |

All three are the same low-severity soundness issue (`rand::rng()` with a custom logger). Not exploitable in our usage but clears the alerts.

Cargo.toml requirements (`rand = "0.8"`, `rand = "0.9"`) are unchanged — the lockfile already accepts these patches.

## Test plan

- [x] `cargo check --workspace` passes locally
- [ ] Full CI passes (lint/build/test-core/test-sdk/test-environment/test-workflows/test-server)