### PR TITLE
SYN-310: Use shared Redis connection pool instead of per-call connect…

### DIFF
--- a/crates/runtara-connections/Cargo.toml
+++ b/crates/runtara-connections/Cargo.toml
@@ -21,7 +21,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgr
 axum = "0.8"
 
 # Redis
-redis = { version = "0.27", features = ["tokio-comp", "aio"] }
+redis = { version = "0.27", features = ["tokio-comp", "aio", "connection-manager"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/runtara-connections/README.md
+++ b/crates/runtara-connections/README.md
@@ -10,11 +10,11 @@ Two surfaces are exposed: an Axum router bundle (`connections_router`, `admin_ro
 
 ## Using it standalone
 
-Not a standalone crate — `publish = false`, and it assumes the host supplies a `PgPool`, an optional Redis URL, an encryption key, and an Axum app to mount routers on. The intended pattern is:
+Not a standalone crate — `publish = false`, and it assumes the host supplies a `PgPool`, an optional shared `redis::aio::ConnectionManager`, an encryption key, and an Axum app to mount routers on. The intended pattern is:
 
 ```rust
 let config = runtara_connections::ConnectionsConfig {
-    db_pool, redis_url, public_base_url, http_client,
+    db_pool, redis_manager, public_base_url, http_client,
     cipher: runtara_connections::cipher_from_env(),
 };
 let facade = Arc::new(runtara_connections::ConnectionsFacade::new(

--- a/crates/runtara-connections/src/config.rs
+++ b/crates/runtara-connections/src/config.rs
@@ -13,9 +13,12 @@ pub struct ConnectionsConfig {
     /// PostgreSQL connection pool.
     pub db_pool: PgPool,
 
-    /// Redis/Valkey URL for rate-limit state storage.
+    /// Shared Redis/Valkey connection manager for rate-limit state storage.
     /// `None` disables real-time rate-limit tracking (graceful degradation).
-    pub redis_url: Option<String>,
+    ///
+    /// Built once by the host at startup (`redis::aio::ConnectionManager::new`)
+    /// and shared across all handlers. Cheap to clone — internally an `Arc`.
+    pub redis_manager: Option<redis::aio::ConnectionManager>,
 
     /// Public base URL used to construct OAuth2 redirect URIs.
     /// Example: `"https://api.example.com"`
@@ -38,7 +41,7 @@ pub struct ConnectionsConfig {
 #[derive(Clone)]
 pub struct ConnectionsState {
     pub db_pool: PgPool,
-    pub redis_url: Option<String>,
+    pub redis_manager: Option<redis::aio::ConnectionManager>,
     pub public_base_url: String,
     pub http_client: reqwest::Client,
     pub cipher: Arc<dyn CredentialCipher>,
@@ -48,7 +51,7 @@ impl ConnectionsState {
     pub fn from_config(config: ConnectionsConfig) -> Self {
         Self {
             db_pool: config.db_pool,
-            redis_url: config.redis_url,
+            redis_manager: config.redis_manager,
             public_base_url: config.public_base_url,
             http_client: config.http_client,
             cipher: config.cipher,

--- a/crates/runtara-connections/src/facade.rs
+++ b/crates/runtara-connections/src/facade.rs
@@ -37,12 +37,12 @@ impl ConnectionsFacade {
     }
 
     /// Build a rate-limit analytics service using the facade's configured
-    /// PostgreSQL pool and Redis URL.
+    /// PostgreSQL pool and shared Redis connection manager.
     pub fn rate_limit_service(&self) -> RateLimitService {
         let repo = Arc::new(self.repo());
-        RateLimitService::with_redis_url_and_db_pool(
+        RateLimitService::with_redis_manager_and_db_pool(
             repo,
-            self.state.redis_url.clone(),
+            self.state.redis_manager.clone(),
             self.state.db_pool.clone(),
         )
     }
@@ -216,33 +216,9 @@ impl ConnectionsFacade {
             return Ok(());
         }
 
-        let redis_url = match &self.state.redis_url {
-            Some(url) => url,
+        let mut conn = match self.state.redis_manager.clone() {
+            Some(m) => m,
             None => return Ok(()), // No Redis — fail open
-        };
-
-        let client = match redis::Client::open(redis_url.as_str()) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(
-                    connection_id = connection_id,
-                    error = %e,
-                    "Redis connect failed for rate limit check — allowing request"
-                );
-                return Ok(());
-            }
-        };
-
-        let mut conn = match client.get_multiplexed_async_connection().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(
-                    connection_id = connection_id,
-                    error = %e,
-                    "Redis connection failed for rate limit check — allowing request"
-                );
-                return Ok(());
-            }
         };
 
         let key = format!("rate_limit:{}", connection_id);

--- a/crates/runtara-connections/src/handler/connections.rs
+++ b/crates/runtara-connections/src/handler/connections.rs
@@ -592,9 +592,9 @@ pub async fn get_connection_for_runtime_handler(
         state.db_pool.clone(),
         state.cipher.clone(),
     ));
-    let rate_limit_service = Arc::new(RateLimitService::with_redis_url_and_db_pool(
+    let rate_limit_service = Arc::new(RateLimitService::with_redis_manager_and_db_pool(
         repository.clone(),
-        state.redis_url.clone(),
+        state.redis_manager.clone(),
         state.db_pool,
     ));
     let service = ConnectionService::with_rate_limit_service(repository, rate_limit_service);

--- a/crates/runtara-connections/src/handler/rate_limits.rs
+++ b/crates/runtara-connections/src/handler/rate_limits.rs
@@ -45,9 +45,9 @@ pub async fn list_rate_limits_handler(
         state.db_pool.clone(),
         state.cipher.clone(),
     ));
-    let service = RateLimitService::with_redis_url_and_db_pool(
+    let service = RateLimitService::with_redis_manager_and_db_pool(
         repository,
-        state.redis_url.clone(),
+        state.redis_manager.clone(),
         state.db_pool,
     );
 
@@ -138,9 +138,9 @@ pub async fn get_connection_rate_limit_status_handler(
         state.db_pool.clone(),
         state.cipher.clone(),
     ));
-    let service = RateLimitService::with_redis_url_and_db_pool(
+    let service = RateLimitService::with_redis_manager_and_db_pool(
         repository,
-        state.redis_url.clone(),
+        state.redis_manager.clone(),
         state.db_pool,
     );
 

--- a/crates/runtara-connections/src/service/rate_limits.rs
+++ b/crates/runtara-connections/src/service/rate_limits.rs
@@ -5,14 +5,15 @@
 
 use crate::repository::connections::ConnectionRepository;
 use crate::types::*;
-use redis::Commands;
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct RateLimitService {
     connection_repository: Arc<ConnectionRepository>,
-    redis_url: Option<String>,
+    redis_manager: Option<ConnectionManager>,
     db_pool: Option<PgPool>,
 }
 
@@ -37,19 +38,19 @@ impl RateLimitService {
     pub fn new(connection_repository: Arc<ConnectionRepository>) -> Self {
         Self {
             connection_repository,
-            redis_url: None,
+            redis_manager: None,
             db_pool: None,
         }
     }
 
-    /// Create service with a specific Redis URL
-    pub fn with_redis_url(
+    /// Create service with a shared Redis connection manager
+    pub fn with_redis_manager(
         connection_repository: Arc<ConnectionRepository>,
-        redis_url: Option<String>,
+        redis_manager: Option<ConnectionManager>,
     ) -> Self {
         Self {
             connection_repository,
-            redis_url,
+            redis_manager,
             db_pool: None,
         }
     }
@@ -58,20 +59,20 @@ impl RateLimitService {
     pub fn with_db_pool(connection_repository: Arc<ConnectionRepository>, db_pool: PgPool) -> Self {
         Self {
             connection_repository,
-            redis_url: None,
+            redis_manager: None,
             db_pool: Some(db_pool),
         }
     }
 
-    /// Create service with both Redis URL and database pool
-    pub fn with_redis_url_and_db_pool(
+    /// Create service with both Redis connection manager and database pool
+    pub fn with_redis_manager_and_db_pool(
         connection_repository: Arc<ConnectionRepository>,
-        redis_url: Option<String>,
+        redis_manager: Option<ConnectionManager>,
         db_pool: PgPool,
     ) -> Self {
         Self {
             connection_repository,
-            redis_url,
+            redis_manager,
             db_pool: Some(db_pool),
         }
     }
@@ -93,7 +94,7 @@ impl RateLimitService {
         let config = connection.rate_limit_config;
 
         // Fetch Redis state
-        let state = self.fetch_redis_state(connection_id);
+        let state = self.fetch_redis_state(connection_id).await;
 
         // Compute metrics
         let metrics = self.compute_metrics(&config, &state);
@@ -134,7 +135,7 @@ impl RateLimitService {
         let connection_ids: Vec<String> = connections.iter().map(|c| c.id.clone()).collect();
 
         // Batch fetch Redis states
-        let states = self.fetch_redis_states_batch(&connection_ids);
+        let states = self.fetch_redis_states_batch(&connection_ids).await;
 
         // Fetch period stats for all connections
         let period_stats = self
@@ -166,29 +167,27 @@ impl RateLimitService {
     }
 
     /// Fetch rate limit state from Redis for a single connection
-    fn fetch_redis_state(&self, connection_id: &str) -> RateLimitStateDto {
-        let Some(ref url) = self.redis_url else {
+    async fn fetch_redis_state(&self, connection_id: &str) -> RateLimitStateDto {
+        let Some(manager) = self.redis_manager.clone() else {
             return RateLimitStateDto::default();
         };
 
-        let result = self.fetch_redis_state_internal(url, connection_id);
-        result.unwrap_or_default()
+        self.fetch_redis_state_internal(manager, connection_id)
+            .await
+            .unwrap_or_default()
     }
 
     /// Internal helper to fetch Redis state with error handling
-    fn fetch_redis_state_internal(
+    async fn fetch_redis_state_internal(
         &self,
-        url: &str,
+        mut conn: ConnectionManager,
         connection_id: &str,
     ) -> Result<RateLimitStateDto, redis::RedisError> {
-        let client = redis::Client::open(url)?;
-        let mut conn = client.get_connection()?;
-
         let key = format!("rate_limit:{}", connection_id);
         let learned_key = format!("rate_limit_learned:{}", connection_id);
 
         // Fetch token bucket state
-        let bucket: HashMap<String, String> = conn.hgetall(&key)?;
+        let bucket: HashMap<String, String> = conn.hgetall(&key).await?;
 
         let current_tokens = bucket.get("tokens").and_then(|s| s.parse::<f64>().ok());
 
@@ -210,7 +209,7 @@ impl RateLimitService {
             .and_then(|s| s.parse::<i64>().ok());
 
         // Fetch learned limit
-        let learned_limit: Option<u32> = conn.get(&learned_key).ok();
+        let learned_limit: Option<u32> = conn.get(&learned_key).await.ok();
 
         Ok(RateLimitStateDto {
             available: true,
@@ -224,13 +223,13 @@ impl RateLimitService {
     }
 
     /// Batch fetch Redis states for multiple connections
-    fn fetch_redis_states_batch(
+    async fn fetch_redis_states_batch(
         &self,
         connection_ids: &[String],
     ) -> HashMap<String, RateLimitStateDto> {
         let mut states = HashMap::new();
 
-        let Some(ref url) = self.redis_url else {
+        let Some(manager) = self.redis_manager.clone() else {
             // Redis not configured - return default states
             for id in connection_ids {
                 states.insert(id.clone(), RateLimitStateDto::default());
@@ -239,7 +238,10 @@ impl RateLimitService {
         };
 
         // Try to batch fetch, fall back to defaults on error
-        match self.fetch_redis_states_batch_internal(url, connection_ids) {
+        match self
+            .fetch_redis_states_batch_internal(manager, connection_ids)
+            .await
+        {
             Ok(fetched) => fetched,
             Err(_) => {
                 // Redis error - return unavailable states
@@ -252,14 +254,11 @@ impl RateLimitService {
     }
 
     /// Internal helper for batch Redis fetch
-    fn fetch_redis_states_batch_internal(
+    async fn fetch_redis_states_batch_internal(
         &self,
-        url: &str,
+        mut conn: ConnectionManager,
         connection_ids: &[String],
     ) -> Result<HashMap<String, RateLimitStateDto>, redis::RedisError> {
-        let client = redis::Client::open(url)?;
-        let mut conn = client.get_connection()?;
-
         let mut states = HashMap::new();
 
         // Build pipeline for efficient batch query
@@ -274,7 +273,7 @@ impl RateLimitService {
         }
 
         // Execute pipeline
-        let results: Vec<redis::Value> = pipe.query(&mut conn)?;
+        let results: Vec<redis::Value> = pipe.query_async(&mut conn).await?;
 
         // Parse results (2 values per connection: hash + learned)
         for (idx, conn_id) in connection_ids.iter().enumerate() {
@@ -523,7 +522,7 @@ impl RateLimitService {
         metadata: Option<serde_json::Value>,
     ) -> Result<(), ServiceError> {
         // Increment Redis counters
-        if let Err(e) = self.increment_call_counters(connection_id) {
+        if let Err(e) = self.increment_call_counters(connection_id).await {
             tracing::warn!(
                 connection_id = connection_id,
                 error = %e,
@@ -547,13 +546,10 @@ impl RateLimitService {
     }
 
     /// Increment call counters in Redis
-    fn increment_call_counters(&self, connection_id: &str) -> Result<(), redis::RedisError> {
-        let Some(ref url) = self.redis_url else {
+    async fn increment_call_counters(&self, connection_id: &str) -> Result<(), redis::RedisError> {
+        let Some(mut conn) = self.redis_manager.clone() else {
             return Ok(()); // Redis not configured, skip
         };
-
-        let client = redis::Client::open(url.as_str())?;
-        let mut conn = client.get_connection()?;
 
         let key = format!("rate_limit:{}", connection_id);
         let now_ms = std::time::SystemTime::now()
@@ -573,7 +569,7 @@ impl RateLimitService {
         // Set window start if not already set (HSETNX)
         pipe.cmd("HSETNX").arg(&key).arg("window_start").arg(now_ms);
 
-        let _: () = pipe.query(&mut conn)?;
+        let _: () = pipe.query_async(&mut conn).await?;
 
         Ok(())
     }
@@ -763,13 +759,13 @@ impl RateLimitService {
 
     /// Reset window counters (called when a new window starts)
     #[allow(dead_code)]
-    pub fn reset_window_counters(&self, connection_id: &str) -> Result<(), redis::RedisError> {
-        let Some(ref url) = self.redis_url else {
+    pub async fn reset_window_counters(
+        &self,
+        connection_id: &str,
+    ) -> Result<(), redis::RedisError> {
+        let Some(mut conn) = self.redis_manager.clone() else {
             return Ok(());
         };
-
-        let client = redis::Client::open(url.as_str())?;
-        let mut conn = client.get_connection()?;
 
         let key = format!("rate_limit:{}", connection_id);
         let now_ms = std::time::SystemTime::now()
@@ -781,7 +777,7 @@ impl RateLimitService {
         let mut pipe = redis::pipe();
         pipe.hset(&key, "calls_window", 0i64);
         pipe.hset(&key, "window_start", now_ms);
-        let _: () = pipe.query(&mut conn)?;
+        let _: () = pipe.query_async(&mut conn).await?;
 
         Ok(())
     }

--- a/crates/runtara-server/src/api/handlers/events.rs
+++ b/crates/runtara-server/src/api/handlers/events.rs
@@ -49,6 +49,7 @@ use crate::api::repositories::triggers::TriggerRepository;
 pub async fn capture_http_event(
     State(pool): State<PgPool>,
     State(connections): State<std::sync::Arc<runtara_connections::ConnectionsFacade>>,
+    State(trigger_stream): State<Option<std::sync::Arc<TriggerStreamPublisher>>>,
     Path((trigger_id, action)): Path<(String, String)>,
     request: Request,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
@@ -61,9 +62,11 @@ pub async fn capture_http_event(
     let uri = parts.uri.clone();
     let headers = parts.headers.clone();
 
-    // Get Redis connection URL from environment
-    let redis_url = match crate::valkey::build_redis_url() {
-        Some(url) => url,
+    // Pull the shared trigger stream publisher from AppState (created once at
+    // startup with the shared Redis connection manager). Avoids opening a new
+    // TCP connection per webhook request.
+    let trigger_stream = match trigger_stream {
+        Some(t) => t,
         None => {
             eprintln!("VALKEY_HOST not configured");
             let error_response = json!({
@@ -209,8 +212,7 @@ pub async fn capture_http_event(
             debug,
         );
 
-        // Publish to trigger stream
-        let trigger_stream = TriggerStreamPublisher::new(redis_url);
+        // Publish to trigger stream (reuses shared connection manager).
         match trigger_stream.publish(&tenant_id, &event).await {
             Ok(stream_id) => {
                 // Update trigger's last_run timestamp

--- a/crates/runtara-server/src/api/repositories/trigger_stream.rs
+++ b/crates/runtara-server/src/api/repositories/trigger_stream.rs
@@ -4,18 +4,21 @@
 //! Stream naming: runtara:triggers:{tenant_id}
 
 use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
 
 use crate::api::dto::trigger_event::TriggerEvent;
 
 /// Publisher for trigger events to Redis streams
 pub struct TriggerStreamPublisher {
-    redis_url: String,
+    /// Shared Redis connection manager (built once at startup; cloned per
+    /// publish to reuse the existing connection pool).
+    manager: ConnectionManager,
 }
 
 impl TriggerStreamPublisher {
-    /// Create a new publisher with the given Redis URL
-    pub fn new(redis_url: String) -> Self {
-        Self { redis_url }
+    /// Create a new publisher from a shared connection manager.
+    pub fn new(manager: ConnectionManager) -> Self {
+        Self { manager }
     }
 
     /// Publish a trigger event to the tenant's trigger stream
@@ -30,14 +33,8 @@ impl TriggerStreamPublisher {
         let event_json = serde_json::to_string(event)
             .map_err(|e| TriggerStreamError::SerializationError(e.to_string()))?;
 
-        // Create Redis client and get connection
-        let redis_client = redis::Client::open(self.redis_url.as_str())
-            .map_err(|e| TriggerStreamError::ConnectionError(e.to_string()))?;
-
-        let mut redis_conn = redis_client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| TriggerStreamError::ConnectionError(e.to_string()))?;
+        // Reuse the shared connection manager — no new TCP per call.
+        let mut redis_conn = self.manager.clone();
 
         // Construct Redis stream key
         let stream_key = format!("runtara:triggers:{}", tenant_id);

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -604,13 +604,33 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     };
     let auth_kind = auth_providers.kind;
 
+    // Build the single, process-wide Valkey/Redis connection manager. Every
+    // subsystem that needs Redis — connections facade rate limiting, trigger
+    // stream publisher, compilation worker, cron scheduler, MCP/handler
+    // utility calls — clones this manager instead of opening its own TCP
+    // connection per call.
+    let redis_manager: Option<redis::aio::ConnectionManager> =
+        match crate::valkey::build_redis_url() {
+            Some(url) => match crate::valkey::init_shared_manager(&url).await {
+                Ok(m) => {
+                    println!("✓ Shared Valkey connection manager initialized");
+                    Some(m)
+                }
+                Err(e) => {
+                    eprintln!("⚠ Failed to initialize shared Valkey connection manager: {}", e);
+                    None
+                }
+            },
+            None => None,
+        };
+
     // Construct connections crate config and facade.
     // Cipher is built from RUNTARA_CONNECTIONS_ENCRYPTION_KEY env var — falls
     // back to NoOp (plaintext at rest) with a loud warning if missing. See
     // runtara_connections::crypto::cipher_from_env for details.
     let connections_config = runtara_connections::ConnectionsConfig {
         db_pool: pool.clone(),
-        redis_url: crate::valkey::build_redis_url(),
+        redis_manager: redis_manager.clone(),
         public_base_url: std::env::var("PUBLIC_BASE_URL")
             .unwrap_or_else(|_| "http://localhost:8080".to_string()),
         http_client: reqwest::Client::new(),
@@ -785,39 +805,14 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Valkey-based workers (optional but recommended)
     let valkey_config = valkey::ValkeyConfig::from_env();
 
-    // Create trigger stream publisher if Valkey is configured
-    let trigger_stream: Option<Arc<api::repositories::trigger_stream::TriggerStreamPublisher>> =
-        valkey_config.as_ref().map(|config| {
-            Arc::new(
-                api::repositories::trigger_stream::TriggerStreamPublisher::new(
-                    config.connection_url(),
-                ),
-            )
-        });
+    // Reuse the shared connection manager built above (no second TCP).
+    let valkey_conn = redis_manager.clone();
 
-    // Create Valkey connection manager for session queue operations
-    let valkey_conn: Option<redis::aio::ConnectionManager> = match &valkey_config {
-        Some(config) => {
-            let url = config.connection_url();
-            match redis::Client::open(url.as_str()) {
-                Ok(client) => match redis::aio::ConnectionManager::new(client).await {
-                    Ok(conn) => {
-                        println!("✓ Valkey connection manager initialized (for sessions)");
-                        Some(conn)
-                    }
-                    Err(e) => {
-                        eprintln!("⚠ Failed to create Valkey connection manager: {}", e);
-                        None
-                    }
-                },
-                Err(e) => {
-                    eprintln!("⚠ Failed to create Valkey client: {}", e);
-                    None
-                }
-            }
-        }
-        None => None,
-    };
+    // Create trigger stream publisher backed by the shared manager.
+    let trigger_stream: Option<Arc<api::repositories::trigger_stream::TriggerStreamPublisher>> =
+        redis_manager.clone().map(|m| {
+            Arc::new(api::repositories::trigger_stream::TriggerStreamPublisher::new(m))
+        });
 
     if let Some(ref config) = valkey_config {
         println!("Valkey configuration detected, starting workers...");
@@ -825,7 +820,6 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         // Clone config for different workers
         let trigger_worker_config = config.clone();
         let compilation_worker_config = config.clone();
-        let cron_config = config.clone();
         let cleanup_config = config.clone();
 
         // Clone resources for trigger worker
@@ -878,22 +872,24 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
 
         // Start cron scheduler
         let cron_pool = pool.clone();
-        let cron_redis_url = cron_config.connection_url();
+        let cron_trigger_stream = redis_manager.clone().map(|m| {
+            api::repositories::trigger_stream::TriggerStreamPublisher::new(m)
+        });
         let cron_tenant_id = tenant_id.clone();
         let cron_shutdown = shutdown_signal.clone();
         tokio::spawn(async move {
+            let Some(ts) = cron_trigger_stream else {
+                tracing::warn!(
+                    "Cron scheduler not started: shared Valkey connection manager unavailable"
+                );
+                return;
+            };
             let scheduler_config = workers::cron_scheduler::CronSchedulerConfig {
                 tenant_id: cron_tenant_id,
                 check_interval_secs: 60,
             };
 
-            workers::cron_scheduler::run(
-                cron_pool,
-                cron_redis_url,
-                scheduler_config,
-                cron_shutdown,
-            )
-            .await;
+            workers::cron_scheduler::run(cron_pool, ts, scheduler_config, cron_shutdown).await;
         });
 
         // NOTE: Container monitoring is now handled directly by runtara-environment.

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -617,7 +617,10 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
                     Some(m)
                 }
                 Err(e) => {
-                    eprintln!("⚠ Failed to initialize shared Valkey connection manager: {}", e);
+                    eprintln!(
+                        "⚠ Failed to initialize shared Valkey connection manager: {}",
+                        e
+                    );
                     None
                 }
             },
@@ -810,9 +813,9 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
 
     // Create trigger stream publisher backed by the shared manager.
     let trigger_stream: Option<Arc<api::repositories::trigger_stream::TriggerStreamPublisher>> =
-        redis_manager.clone().map(|m| {
-            Arc::new(api::repositories::trigger_stream::TriggerStreamPublisher::new(m))
-        });
+        redis_manager
+            .clone()
+            .map(|m| Arc::new(api::repositories::trigger_stream::TriggerStreamPublisher::new(m)));
 
     if let Some(ref config) = valkey_config {
         println!("Valkey configuration detected, starting workers...");
@@ -872,9 +875,9 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
 
         // Start cron scheduler
         let cron_pool = pool.clone();
-        let cron_trigger_stream = redis_manager.clone().map(|m| {
-            api::repositories::trigger_stream::TriggerStreamPublisher::new(m)
-        });
+        let cron_trigger_stream = redis_manager
+            .clone()
+            .map(|m| api::repositories::trigger_stream::TriggerStreamPublisher::new(m));
         let cron_tenant_id = tenant_id.clone();
         let cron_shutdown = shutdown_signal.clone();
         tokio::spawn(async move {

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -877,7 +877,7 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let cron_pool = pool.clone();
         let cron_trigger_stream = redis_manager
             .clone()
-            .map(|m| api::repositories::trigger_stream::TriggerStreamPublisher::new(m));
+            .map(api::repositories::trigger_stream::TriggerStreamPublisher::new);
         let cron_tenant_id = tenant_id.clone();
         let cron_shutdown = shutdown_signal.clone();
         tokio::spawn(async move {

--- a/crates/runtara-server/src/step_events.rs
+++ b/crates/runtara-server/src/step_events.rs
@@ -2,9 +2,9 @@
 //!
 //! Reads step execution events from Redis for debugging workflow executions.
 
-use redis::{AsyncCommands, Client};
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 /// Represents a single step execution event
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,15 +35,15 @@ pub struct StepEvent {
 
 /// Reads step execution events from Redis (async operations)
 pub struct StepEventReader {
-    client: Option<Arc<Client>>,
+    manager: Option<ConnectionManager>,
     instance_id: String,
 }
 
 impl StepEventReader {
-    /// Creates a new step event reader
-    pub fn new(client: Option<Arc<Client>>, instance_id: String) -> Self {
+    /// Creates a new step event reader from a shared connection manager.
+    pub fn new(manager: Option<ConnectionManager>, instance_id: String) -> Self {
         Self {
-            client,
+            manager,
             instance_id,
         }
     }
@@ -55,12 +55,10 @@ impl StepEventReader {
         status_filter: Option<&str>,
         limit: Option<usize>,
     ) -> Result<Vec<StepEvent>, String> {
-        let client = self.client.as_ref().ok_or("Redis client not available")?;
-
-        let mut conn = client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| format!("Failed to connect to Redis: {}", e))?;
+        let mut conn = self
+            .manager
+            .clone()
+            .ok_or("Redis client not available")?;
 
         let key = format!("step_events:{}", self.instance_id);
         let events_data: Vec<(String, String)> = conn

--- a/crates/runtara-server/src/step_events.rs
+++ b/crates/runtara-server/src/step_events.rs
@@ -55,10 +55,7 @@ impl StepEventReader {
         status_filter: Option<&str>,
         limit: Option<usize>,
     ) -> Result<Vec<StepEvent>, String> {
-        let mut conn = self
-            .manager
-            .clone()
-            .ok_or("Redis client not available")?;
+        let mut conn = self.manager.clone().ok_or("Redis client not available")?;
 
         let key = format!("step_events:{}", self.instance_id);
         let events_data: Vec<(String, String)> = conn

--- a/crates/runtara-server/src/valkey/compilation_queue.rs
+++ b/crates/runtara-server/src/valkey/compilation_queue.rs
@@ -10,6 +10,7 @@
 //! - Atomic operations: uses Lua scripts for thread safety
 //! - Polling support: for waiting until compilation completes
 
+use redis::aio::ConnectionManager;
 use redis::{AsyncCommands, Script};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -88,8 +89,9 @@ impl CompilationRequest {
 /// - `runtara:compilation:queue` - LIST for ordered processing
 /// - `runtara:compilation:pending` - SET for deduplication and tracking
 pub struct CompilationQueue {
-    /// Redis client (reused across operations to avoid parsing URL repeatedly)
-    client: redis::Client,
+    /// Shared Redis connection manager (built once at startup and cloned per
+    /// operation — no new TCP connection per call).
+    manager: ConnectionManager,
 }
 
 impl CompilationQueue {
@@ -100,23 +102,14 @@ impl CompilationQueue {
     /// Hash key storing full request payloads by dedupe key.
     const REQUESTS_KEY: &'static str = "runtara:compilation:requests";
 
-    /// Create a new compilation queue
-    ///
-    /// Returns an error if the Redis URL is invalid.
-    pub fn new(redis_url: String) -> Result<Self, CompilationQueueError> {
-        let client = redis::Client::open(redis_url.as_str())
-            .map_err(|e| CompilationQueueError::ConnectionError(e.to_string()))?;
-        Ok(Self { client })
+    /// Create a new compilation queue from a shared connection manager.
+    pub fn new(manager: ConnectionManager) -> Self {
+        Self { manager }
     }
 
-    /// Get a multiplexed async connection from the client
-    async fn get_connection(
-        &self,
-    ) -> Result<redis::aio::MultiplexedConnection, CompilationQueueError> {
-        self.client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| CompilationQueueError::ConnectionError(e.to_string()))
+    /// Get a connection from the shared manager (cheap clone — no TCP).
+    fn get_connection(&self) -> ConnectionManager {
+        self.manager.clone()
     }
 
     /// Enqueue a compilation request if not already pending
@@ -128,7 +121,7 @@ impl CompilationQueue {
         &self,
         request: &CompilationRequest,
     ) -> Result<bool, CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         let key = request.unique_key();
         let payload = request
@@ -205,7 +198,7 @@ impl CompilationQueue {
         &self,
         timeout: Duration,
     ) -> Result<Option<CompilationRequest>, CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         // BLPOP with timeout (returns list name and value)
         let result: Option<(String, String)> = redis::cmd("BLPOP")
@@ -248,7 +241,7 @@ impl CompilationQueue {
         &self,
         request: &CompilationRequest,
     ) -> Result<(), CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         let key = request.unique_key();
 
@@ -278,7 +271,7 @@ impl CompilationQueue {
         &self,
         request: &CompilationRequest,
     ) -> Result<bool, CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         let key = request.unique_key();
 
@@ -292,7 +285,7 @@ impl CompilationQueue {
 
     /// Get the number of pending compilations
     pub async fn pending_count(&self) -> Result<usize, CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         let count: usize = conn
             .scard(Self::PENDING_KEY)
@@ -339,7 +332,7 @@ impl CompilationQueue {
     ///
     /// It moves any pending items that are NOT in the queue back to the queue.
     pub async fn recover_orphaned(&self) -> Result<usize, CompilationQueueError> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self.get_connection();
 
         // Get all pending items
         let pending: Vec<String> = conn
@@ -466,67 +459,6 @@ mod tests {
         assert_eq!(parsed.workflow_id, "workflow-123");
         assert_eq!(parsed.version, 42);
         assert!(parsed.force_recompile);
-    }
-
-    // =========================================================================
-    // CompilationQueue::new Result handling tests
-    // =========================================================================
-
-    #[test]
-    fn test_compilation_queue_new_with_valid_url() {
-        // Valid Redis URL should succeed in creating the client
-        // Note: This doesn't actually connect - it just validates URL parsing
-        let result = CompilationQueue::new("redis://localhost:6379".to_string());
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_password() {
-        // URL with authentication should parse correctly
-        let result = CompilationQueue::new("redis://:password@localhost:6379".to_string());
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_user_password() {
-        // URL with user and password should parse correctly
-        let result = CompilationQueue::new("redis://user:password@localhost:6379".to_string());
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_database() {
-        // URL with database selection
-        let result = CompilationQueue::new("redis://localhost:6379/1".to_string());
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_invalid_url() {
-        // Invalid URL should return ConnectionError
-        let result = CompilationQueue::new("not-a-valid-url".to_string());
-        assert!(result.is_err());
-
-        if let Err(CompilationQueueError::ConnectionError(msg)) = result {
-            // Should contain some error message about invalid URL
-            assert!(!msg.is_empty());
-        } else {
-            panic!("Expected ConnectionError variant");
-        }
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_empty_url() {
-        // Empty URL should fail
-        let result = CompilationQueue::new("".to_string());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_compilation_queue_new_with_wrong_scheme() {
-        // Wrong scheme (http instead of redis) should fail
-        let result = CompilationQueue::new("http://localhost:6379".to_string());
-        assert!(result.is_err());
     }
 
     // =========================================================================

--- a/crates/runtara-server/src/valkey/mod.rs
+++ b/crates/runtara-server/src/valkey/mod.rs
@@ -4,6 +4,44 @@ pub mod compilation_queue;
 pub mod events;
 pub mod stream;
 
+use redis::RedisError;
+use redis::aio::ConnectionManager;
+use tokio::sync::OnceCell;
+
+/// Process-wide shared Redis connection manager.
+///
+/// Built lazily on first use (or eagerly at server startup via
+/// [`init_shared_manager`]) and shared across every subsystem that talks
+/// to Valkey. The manager itself wraps an `Arc`, so cloning is cheap and
+/// every clone reuses the same multiplexed connection pool — no new TCP
+/// per request.
+///
+/// The URL is captured at first initialization. The server runs against a
+/// single Valkey instance whose URL is fixed for the process lifetime, so
+/// caching a single manager (rather than keying by URL) is intentional.
+static SHARED_MANAGER: OnceCell<ConnectionManager> = OnceCell::const_new();
+
+/// Return the shared connection manager, building it on first call.
+///
+/// Subsequent calls are O(1) clones. Returns an error only if Redis is
+/// unreachable on the very first call (subsequent reconnects are handled
+/// transparently by `ConnectionManager`).
+pub async fn get_or_create_manager(redis_url: &str) -> Result<ConnectionManager, RedisError> {
+    SHARED_MANAGER
+        .get_or_try_init(|| async {
+            let client = redis::Client::open(redis_url)?;
+            ConnectionManager::new(client).await
+        })
+        .await
+        .cloned()
+}
+
+/// Eagerly initialize the shared manager at startup. Safe to call multiple
+/// times; only the first call performs the connection.
+pub async fn init_shared_manager(redis_url: &str) -> Result<ConnectionManager, RedisError> {
+    get_or_create_manager(redis_url).await
+}
+
 /// Valkey configuration loaded from environment variables
 #[derive(Debug, Clone)]
 pub struct ValkeyConfig {

--- a/crates/runtara-server/src/workers/compilation_worker.rs
+++ b/crates/runtara-server/src/workers/compilation_worker.rs
@@ -56,17 +56,18 @@ pub async fn run(
         "Starting compilation worker"
     );
 
-    let queue = match CompilationQueue::new(config.redis_url.clone()) {
-        Ok(q) => q,
+    let manager = match crate::valkey::get_or_create_manager(&config.redis_url).await {
+        Ok(m) => m,
         Err(e) => {
             error!(
                 worker_id = %worker_id,
                 error = %e,
-                "Failed to create compilation queue, worker will not start"
+                "Failed to initialize Redis connection manager, worker will not start"
             );
             return;
         }
     };
+    let queue = CompilationQueue::new(manager);
 
     // Recover any orphaned pending compilations (from previous crashes)
     match queue.recover_orphaned().await {
@@ -339,7 +340,7 @@ pub async fn enqueue_compilation(
     version: i32,
     force_recompile: bool,
 ) -> Result<bool, crate::valkey::compilation_queue::CompilationQueueError> {
-    let queue = CompilationQueue::new(redis_url.to_string())?;
+    let queue = open_shared_queue(redis_url).await?;
     let request = CompilationRequest::new_with_force(
         tenant_id.to_string(),
         workflow_id.to_string(),
@@ -356,7 +357,7 @@ pub async fn is_compilation_pending(
     workflow_id: &str,
     version: i32,
 ) -> Result<bool, crate::valkey::compilation_queue::CompilationQueueError> {
-    let queue = CompilationQueue::new(redis_url.to_string())?;
+    let queue = open_shared_queue(redis_url).await?;
     let request = CompilationRequest::new(tenant_id.to_string(), workflow_id.to_string(), version);
     queue.is_pending(&request).await
 }
@@ -371,12 +372,26 @@ pub async fn wait_for_compilation(
     version: i32,
     timeout: Duration,
 ) -> Result<bool, crate::valkey::compilation_queue::CompilationQueueError> {
-    let queue = CompilationQueue::new(redis_url.to_string())?;
+    let queue = open_shared_queue(redis_url).await?;
     let request = CompilationRequest::new(tenant_id.to_string(), workflow_id.to_string(), version);
     let poll_interval = Duration::from_millis(100);
     queue
         .wait_for_completion(&request, timeout, poll_interval)
         .await
+}
+
+/// Build a CompilationQueue backed by the shared, process-wide connection
+/// manager so each utility call reuses an existing pooled connection
+/// instead of opening a new TCP socket.
+async fn open_shared_queue(
+    redis_url: &str,
+) -> Result<CompilationQueue, crate::valkey::compilation_queue::CompilationQueueError> {
+    let manager = crate::valkey::get_or_create_manager(redis_url)
+        .await
+        .map_err(|e| {
+            crate::valkey::compilation_queue::CompilationQueueError::ConnectionError(e.to_string())
+        })?;
+    Ok(CompilationQueue::new(manager))
 }
 
 #[cfg(test)]

--- a/crates/runtara-server/src/workers/cron_scheduler.rs
+++ b/crates/runtara-server/src/workers/cron_scheduler.rs
@@ -36,10 +36,10 @@ impl Default for CronSchedulerConfig {
 }
 
 /// Background worker that schedules cron-triggered workflow executions
-#[instrument(skip(pool, redis_url, shutdown))]
+#[instrument(skip(pool, trigger_stream, shutdown))]
 pub async fn run(
     pool: PgPool,
-    redis_url: String,
+    trigger_stream: TriggerStreamPublisher,
     config: CronSchedulerConfig,
     shutdown: ShutdownSignal,
 ) {
@@ -52,8 +52,6 @@ pub async fn run(
         check_interval_secs = config.check_interval_secs,
         "Starting cron scheduler"
     );
-
-    let trigger_stream = TriggerStreamPublisher::new(redis_url);
 
     // Main scheduling loop
     let mut interval = tokio::time::interval(Duration::from_secs(config.check_interval_secs));


### PR DESCRIPTION
`runtara-server/src/valkey/mod.rs` — new `get_or_create_manager` / `init_shared_manager` backed by a `tokio::sync::OnceCell<ConnectionManager>`. The URL is captured on first init; the server runs against a single fixed Valkey instance for the process lifetime, so a single cached manager (not keyed by URL) is intentional.
`runtara-server/src/server.rs` — build the shared manager at startup, then hand clones to the connections facade, trigger stream publisher, compilation worker, and cron scheduler. Removes the separate "Valkey connection manager (for sessions)" bootstrap. If Redis is unavailable at startup, subsystems degrade gracefully (cron scheduler logs a warning and exits; rate limiting fails open).
`runtara-connections` — ConnectionsConfig/ConnectionsState now take `redis_manager`: `Option<redis::aio::ConnectionManager>` instead of `redis_url: Option<String>`. `check_rate_limit` and `RateLimitService` use the injected manager; `with_redis_url_and_db_pool` → `with_redis_manager_and_db_pool`.
CompilationQueue — constructed from a ConnectionManager; `get_connection` is now an infallible cheap clone instead of an async dial. Dropped the `CompilationQueue::new` URL-parsing tests (no longer applicable).
`cron_scheduler` — takes a TriggerStreamPublisher instead of a Redis URL string.
Touch-ups in `handler/connections.rs`, `handler/rate_limits.rs`, `api/handlers/events.rs`, `api/repositories/trigger_stream.rs`, `step_events.rs`, `compilation_worker.rs` to pass the manager through.

### Testing
 cargo build / cargo clippy
 cargo test
 e2e-verify (server boots, workers start, compilation queue + rate limiting + cron exercised)