### PR TITLE
chore: drop --locked from cargo install cargo-component (yanked wit-parser 0.219.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,9 +423,14 @@ jobs:
           path: ~/.cargo/bin/cargo-component
           key: cargo-component-${{ runner.os }}-${{ runner.arch }}-0.21.1
 
+      # Intentionally NOT using --locked. cargo-component v0.21.1's own
+      # Cargo.lock pins wit-parser v0.219.1, which has since been yanked
+      # from crates.io. Letting cargo resolve from the Cargo.toml ranges
+      # picks a non-yanked wit-parser. cargo-component itself stays
+      # pinned via --version.
       - name: Install cargo-component
         if: steps.cache-cargo-component.outputs.cache-hit != 'true'
-        run: cargo install cargo-component --version 0.21.1 --locked
+        run: cargo install cargo-component --version 0.21.1
 
       # wac compose is needed by the workflow-compile e2e tests
       # (RUNTARA_RUN_COMPONENTS_E2E=1). Upstream ships prebuilt static

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -268,10 +268,15 @@ install_cargo_component() {
     if [ -x "$bin" ]; then
         info "Using cached cargo-component at ${bin}"
     else
-        info "cargo install cargo-component --version ${CARGO_COMPONENT_VERSION} --locked --root ${root}"
+        # Intentionally NOT using --locked. cargo-component v0.21.1's own
+        # Cargo.lock pins wit-parser v0.219.1, which has since been yanked
+        # from crates.io. Letting cargo resolve from the Cargo.toml ranges
+        # picks a non-yanked wit-parser. The primary version (cargo-
+        # component itself) is still pinned via --version so behavior
+        # stays stable; only transitive deps shift.
+        info "cargo install cargo-component --version ${CARGO_COMPONENT_VERSION} --root ${root}"
         cargo install cargo-component \
             --version "$CARGO_COMPONENT_VERSION" \
-            --locked \
             --root "$root"
     fi
 


### PR DESCRIPTION
## Summary
- cargo-component v0.21.1's own \`Cargo.lock\` pins \`wit-parser v0.219.1\`, which has since been yanked from crates.io
- \`cargo install cargo-component --version 0.21.1 --locked\` therefore emits a yanked-package warning on every install
- Dropped \`--locked\` from both install sites (\`scripts/build-bundle.sh\` and \`.github/workflows/ci.yml\`); cargo-component stays pinned via \`--version 0.21.1\`, only transitive resolution shifts to a non-yanked \`wit-parser\`

## Why this is safe
- Our own workspace \`Cargo.lock\` already pins \`wit-parser 0.244.0\`/\`0.246.2\` (via wasmtime + agent component crates) — neither yanked, both checked in
- \`cargo install --version X\` keeps cargo-component itself reproducible; only its transitive deps re-resolve to the registry's current matching versions
- No newer cargo-component release exists (0.21.1 is latest), so we can't fix it by bumping

## Test plan
- [ ] CI components-build job no longer prints yanked warning
- [ ] Bundle build (\`scripts/build-bundle.sh\`) succeeds without yanked warning
- [ ] Agent components still build via cargo-component (no behavioral regression)