### PR TITLE
SYN-556: Surface and retry failed report block fetches

### DIFF
--- a/crates/runtara-server/frontend/src/features/reports/components/ReportBlockHost.test.tsx
+++ b/crates/runtara-server/frontend/src/features/reports/components/ReportBlockHost.test.tsx
@@ -1,0 +1,159 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReportBlockHost } from './ReportBlockHost';
+import type { ReportBlockDefinition } from '../types';
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { access_token: 'test-token' } }),
+}));
+
+const getReportBlockData = vi.fn();
+
+vi.mock('../queries', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../queries');
+  return {
+    ...actual,
+    getReportBlockData: (...args: unknown[]) => getReportBlockData(...args),
+  };
+});
+
+// Mirror main.tsx defaults exactly — this is what production runs with.
+// `useReportBlockData` overrides retry/retryDelay per-query on top of these.
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 10,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+// A lazy tile: needsBlockFetch === true, so it fetches its own data instead of
+// using the report-level render payload. The backend omits lazy blocks from
+// that payload, so there is no initialResult to fall back on.
+const lazyMetric: ReportBlockDefinition = {
+  id: 'revenue',
+  type: 'metric',
+  title: 'Revenue',
+  lazy: true,
+  source: { schema: 'orders', mode: 'aggregate' },
+} as ReportBlockDefinition;
+
+const networkError = () =>
+  Object.assign(new Error('Network Error'), { code: 'ERR_NETWORK' });
+
+const httpError = (status: number) =>
+  Object.assign(new Error(`Request failed with status ${status}`), {
+    response: { status, data: { message: 'Unknown block' } },
+  });
+
+beforeEach(() => {
+  getReportBlockData.mockReset();
+  // Every lazy block is immediately "visible" in jsdom.
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(private cb: (entries: unknown[]) => void) {
+        setTimeout(() => this.cb([{ isIntersecting: true }]), 0);
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+  );
+});
+
+function renderTile(client = makeClient()) {
+  return render(
+    <QueryClientProvider client={client}>
+      <ReportBlockHost reportId="rep_abc" block={lazyMetric} filters={{}} />
+    </QueryClientProvider>
+  );
+}
+
+const skeleton = () => screen.queryByLabelText('Loading report block');
+
+describe('lazy tile with a transient failure', () => {
+  it('self-heals with no user action once the network recovers', async () => {
+    // Fails once, then succeeds — a dropped connection.
+    getReportBlockData
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({
+        blockType: 'metric',
+        status: 'ok',
+        data: { value: 42 },
+      });
+
+    renderTile();
+
+    // No remount, no Retry click, no page reload — the retry policy alone
+    // brings it back.
+    await waitFor(() => expect(screen.queryByText('42')).not.toBeNull(), {
+      timeout: 10000,
+    });
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  }, 20000);
+
+  it('gives up on an error surface rather than an endless skeleton', async () => {
+    getReportBlockData.mockRejectedValue(networkError());
+
+    renderTile();
+
+    // 1 initial attempt + 3 retries, then the budget is spent.
+    await waitFor(
+      () => expect(getReportBlockData).toHaveBeenCalledTimes(4),
+      { timeout: 15000 }
+    );
+
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByRole('button', { name: /retry/i })
+        ).not.toBeNull(),
+      { timeout: 5000 }
+    );
+    expect(skeleton()).toBeNull();
+  }, 30000);
+});
+
+describe('lazy tile with a deterministic failure', () => {
+  it('surfaces the error immediately without burning retries', async () => {
+    getReportBlockData.mockRejectedValue(httpError(404));
+
+    renderTile();
+
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByRole('button', { name: /retry/i })
+        ).not.toBeNull(),
+      { timeout: 5000 }
+    );
+
+    // A 404 will never succeed — retrying it only delays the error.
+    expect(getReportBlockData).toHaveBeenCalledTimes(1);
+    expect(skeleton()).toBeNull();
+  }, 15000);
+
+  it('retries a 500, which may be load-related', async () => {
+    getReportBlockData
+      .mockRejectedValueOnce(httpError(500))
+      .mockResolvedValue({
+        blockType: 'metric',
+        status: 'ok',
+        data: { value: 7 },
+      });
+
+    renderTile();
+
+    await waitFor(() => expect(screen.queryByText('7')).not.toBeNull(), {
+      timeout: 10000,
+    });
+  }, 20000);
+});

--- a/crates/runtara-server/frontend/src/features/reports/components/ReportBlockHost.tsx
+++ b/crates/runtara-server/frontend/src/features/reports/components/ReportBlockHost.tsx
@@ -168,6 +168,7 @@ export function ReportBlockHost({
   const {
     data: fetchedResult,
     isFetching,
+    error: fetchError,
     refetch,
   } = useReportBlockData(reportId, block.id, request, needsBlockFetch);
   const explorePath = useMemo(
@@ -182,6 +183,14 @@ export function ReportBlockHost({
   const result = needsBlockFetch
     ? (fetchedResult ?? initialResult)
     : initialResult;
+  // A failed block fetch leaves `result` undefined. Without this the block
+  // renders its loading skeleton forever: the query is settled so nothing
+  // refetches, and `refetchOnWindowFocus` is off, so only a remount recovers
+  // it. Lazy blocks are the common casualty — the report-level render omits
+  // them, so they have no `initialResult` to fall back on. Guarded on
+  // `!result` so a block that already has data keeps showing it when a
+  // refetch fails, rather than blanking out.
+  const showFetchError = Boolean(fetchError) && !result;
   const refreshAfterActionSubmit = () => {
     void refetch();
     void onReportRefresh?.();
@@ -324,10 +333,12 @@ export function ReportBlockHost({
       )}
       {!isVisible || (!result && isFetching) ? (
         <BlockSkeleton block={block} />
+      ) : showFetchError ? (
+        <BlockError message={fetchError?.message} onRetry={() => refetch()} />
       ) : !result ? (
         <BlockSkeleton block={block} />
       ) : result.status === 'error' ? (
-        <BlockError result={result} onRetry={() => refetch()} />
+        <BlockError message={result.error?.message} onRetry={() => refetch()} />
       ) : (
         <RenderedBlock
           reportId={reportId}
@@ -621,16 +632,16 @@ function BlockSkeleton({ block }: { block: ReportBlockDefinition }) {
 }
 
 function BlockError({
-  result,
+  message,
   onRetry,
 }: {
-  result: ReportBlockResult;
+  message?: string;
   onRetry: () => void;
 }) {
   return (
     <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
       <p className="text-sm font-semibold text-destructive">
-        {result.error?.message ?? 'This report block could not be rendered.'}
+        {message ?? 'This report block could not be rendered.'}
       </p>
       <Button
         className="report-print-hidden mt-3"

--- a/crates/runtara-server/frontend/src/features/reports/components/ReportRenderer.test.tsx
+++ b/crates/runtara-server/frontend/src/features/reports/components/ReportRenderer.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReportRenderer } from './ReportRenderer';
+import type { ReportDefinition, ReportRenderResponse } from '../types';
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { access_token: 'test-token' } }),
+}));
+
+// The renderer suspends on the report-DSL WASM bundle; stub it out.
+vi.mock('../hooks/useReportDsl', () => ({
+  useReportDsl: () => undefined,
+}));
+
+const getReportBlockData = vi.fn();
+
+vi.mock('../queries', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../queries');
+  return {
+    ...actual,
+    getReportBlockData: (...args: unknown[]) => getReportBlockData(...args),
+  };
+});
+
+const TILE_COUNT = 12;
+// The tiles whose request fails. These use a deterministic (non-retryable)
+// failure so the dashboard settles fast — `ReportBlockHost.test.tsx` covers
+// the transient/retry path in detail.
+const FAILING_TILES = new Set(['tile_3', 'tile_7', 'tile_10']);
+
+function buildDefinition(): ReportDefinition {
+  const blocks = Array.from({ length: TILE_COUNT }, (_, i) => ({
+    id: `tile_${i}`,
+    type: 'metric' as const,
+    title: `Tile ${i}`,
+    // A wide dashboard: heavy tiles are authored lazy so the initial
+    // report render stays fast. Lazy blocks are excluded from the
+    // report-level render payload, so they have no fallback result.
+    lazy: true,
+    source: { schema: 'orders', mode: 'aggregate' as const },
+  }));
+
+  return {
+    definitionVersion: 1,
+    layout: {
+      id: 'root',
+      columns: 4,
+      items: blocks.map((block, i) => ({
+        id: `root_i${i}`,
+        child: { id: `n_${block.id}`, type: 'block' as const, blockId: block.id },
+      })),
+    },
+    filters: [],
+    blocks,
+  } as unknown as ReportDefinition;
+}
+
+const definition = buildDefinition();
+
+// The report-level render response: lazy blocks are absent, exactly as the
+// backend's `requested_blocks` filter produces.
+const renderResponse: ReportRenderResponse = {
+  success: true,
+  report: { id: 'rep_abc', definitionVersion: 1 },
+  resolvedFilters: {},
+  blocks: {},
+  errors: [],
+} as unknown as ReportRenderResponse;
+
+beforeEach(() => {
+  getReportBlockData.mockReset();
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(private cb: (entries: unknown[]) => void) {
+        setTimeout(() => this.cb([{ isIntersecting: true }]), 0);
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+  );
+});
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 10,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+describe('wide dashboard under latency + flaky connections', () => {
+  it('renders every tile, not a permanent skeleton on the ones that failed', async () => {
+    getReportBlockData.mockImplementation(
+      async (_token: unknown, context: { queryKey: readonly unknown[] }) => {
+        const blockId = context.queryKey[4] as string;
+        // High latency on every tile.
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        if (FAILING_TILES.has(blockId)) {
+          throw Object.assign(new Error('Request failed with status 404'), {
+            response: { status: 404, data: { message: 'Unknown block' } },
+          });
+        }
+        return { blockType: 'metric', status: 'ok', data: { value: 100 } };
+      }
+    );
+
+    render(
+      <QueryClientProvider client={makeClient()}>
+        <ReportRenderer
+          reportId="rep_abc"
+          definition={definition}
+          renderResponse={renderResponse}
+          filters={{}}
+        />
+      </QueryClientProvider>
+    );
+
+    // Healthy tiles settle.
+    await waitFor(
+      () =>
+        expect(screen.getAllByText('100')).toHaveLength(
+          TILE_COUNT - FAILING_TILES.size
+        ),
+      { timeout: 10000 }
+    );
+
+    // The failed tiles must offer a way back without a page reload.
+    await waitFor(
+      () =>
+        expect(screen.getAllByRole('button', { name: /retry/i })).toHaveLength(
+          FAILING_TILES.size
+        ),
+      { timeout: 10000 }
+    );
+
+    const stuck = screen.queryAllByLabelText('Loading report block');
+    expect(
+      stuck.length,
+      `${stuck.length} tile(s) are still showing a loading skeleton with no error and no retry affordance`
+    ).toBe(0);
+
+    // A 404 is deterministic — no retries were burned on it.
+    expect(getReportBlockData).toHaveBeenCalledTimes(TILE_COUNT);
+  }, 20000);
+});

--- a/crates/runtara-server/frontend/src/features/reports/hooks/useReports.ts
+++ b/crates/runtara-server/frontend/src/features/reports/hooks/useReports.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useCustomMutation, useCustomQuery } from '@/shared/hooks/api';
+import { ApiError, useCustomMutation, useCustomQuery } from '@/shared/hooks/api';
 import { queryKeys } from '@/shared/queries/query-keys';
 import {
   createReport,
@@ -72,6 +72,19 @@ export function useReportPreview(
   });
 }
 
+/** True for failures worth retrying: the request never got a response, or the
+ *  server answered with something load- or timing-related. Deterministic
+ *  failures (400/401/403/404) are excluded — retrying them just delays the
+ *  error the user needs to see. */
+export function isTransientBlockError(error: unknown): boolean {
+  const apiError = error as ApiError | undefined;
+  if (apiError?.code === 'ERR_NETWORK') return true;
+  const status = apiError?.response?.status ?? apiError?.status;
+  // No status at all means no response came back — treat as transient.
+  if (status == null) return true;
+  return status === 408 || status === 429 || status >= 500;
+}
+
 export function useReportBlockData(
   reportId: string | undefined,
   blockId: string | undefined,
@@ -91,6 +104,16 @@ export function useReportBlockData(
     ),
     queryFn: (token, context) => getReportBlockData(token, context),
     enabled: Boolean(reportId && blockId && request && enabled),
+    // Every tile fetches independently, so one dropped connection strands one
+    // tile with no other signal that anything went wrong. Retry the transient
+    // shapes past the global `retry: 1` so a blip self-heals; `ReportBlockHost`
+    // surfaces an error card once this budget is spent.
+    retry: (failureCount, error) =>
+      failureCount < 3 && isTransientBlockError(error),
+    // Exponential with jitter: a wide dashboard would otherwise retry all its
+    // tiles in lockstep against a server that is already struggling.
+    retryDelay: (attempt) =>
+      Math.min(1000 * 2 ** attempt, 8000) * (0.5 + Math.random() / 2),
   });
 }
 


### PR DESCRIPTION
Report tiles sat on their loading skeleton forever when their data request failed. ReportBlockHost read only data/isFetching/refetch from useReportBlockData and never checked isError, so a failure left `result` undefined and rendering fell into the `!result -> BlockSkeleton` branch, visually identical to still-loading. Nothing recovered it: the query was settled, the global `retry: 1` was spent, and refetchOnWindowFocus is off, so only a remount re-ran it.

The already-handled `result.status === 'error'` case is a server-reported error carried on an HTTP 200 body. A transport failure produces no result at all, so it could never reach that branch.

Lazy blocks are fully exposed: the report-level render omits them, so they have no initialResult to fall back on and depend entirely on their own per-block request.

Surface the error as a terminal state with a working Retry, guarded on `!result` so a block that already has data keeps showing it when a refetch fails. Separately, give block fetches a transient-only retry policy (up to 3 retries, exponential with jitter, gated on network errors, 408, 429 and 5xx) so a dropped connection self-heals instead of stranding a tile; deterministic 4xx failures still surface immediately. Jitter keeps a wide dashboard from retrying every tile in lockstep against a server that is already struggling.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
