### PR TITLE
SYN-559: Default MCP session store to local (avoid rmcp restore race)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ rustup target add wasm32-wasip2
 
 - PostgreSQL for platform, environment, and core state.
 - A separate PostgreSQL database for the object model when running `runtara-server`.
-- Valkey or Redis for `runtara-server` checkpoint storage during workflow execution and MCP session recovery.
+- Valkey or Redis for `runtara-server` checkpoint storage during workflow execution (and, optionally, opt-in cross-instance MCP session recovery — process-local sessions are the default).
 - `crun` and Linux container support only if you enable the OCI runner.
 
 ### Start The Local Runtime

--- a/crates/runtara-server/src/config.rs
+++ b/crates/runtara-server/src/config.rs
@@ -432,7 +432,12 @@ fn secs_to_opt_duration(secs: u64) -> Option<Duration> {
 
 fn mcp_session_store_from_raw(raw: Option<&str>) -> Result<McpSessionStore, ConfigError> {
     match raw.map(str::trim) {
-        None => Ok(McpSessionStore::Valkey),
+        // Default to process-local sessions. The Valkey recovery store is
+        // opt-in: it only helps cross-instance restore (irrelevant to a
+        // single-instance-per-tenant deployment), and rmcp's restore path
+        // currently races on concurrent requests to a cold instance — killing
+        // the session and returning 500 — so it must not be the silent default.
+        None => Ok(McpSessionStore::Local),
         Some("local") => Ok(McpSessionStore::Local),
         Some("valkey") => Ok(McpSessionStore::Valkey),
         Some(_) => Err(ConfigError::Invalid(
@@ -752,10 +757,10 @@ mod tests {
     }
 
     #[test]
-    fn mcp_session_store_defaults_to_valkey() {
+    fn mcp_session_store_defaults_to_local() {
         assert_eq!(
             mcp_session_store_from_raw(None).unwrap(),
-            McpSessionStore::Valkey
+            McpSessionStore::Local
         );
     }
 

--- a/docs/deployment/auth-modes.md
+++ b/docs/deployment/auth-modes.md
@@ -20,7 +20,7 @@ For SaaS multi-tenant deployments, per-user **roles and permissions** (Owner / A
 
 The MCP Streamable HTTP endpoint validates the inbound `Host` header before MCP auth and tool dispatch. Local loopback hosts are allowed by default. Public or proxied deployments must set `RUNTARA_MCP_ALLOWED_HOSTS` to the comma-separated public host authorities clients use, for example `runtara.example.com,runtara.example.com:7001`.
 
-MCP session recovery uses Valkey by default (`RUNTARA_MCP_SESSION_STORE=valkey`). Valkey mode requires `VALKEY_HOST` and a working shared Valkey connection at startup; the server exits instead of falling back to process-local sessions. Set `RUNTARA_MCP_SESSION_STORE=local` only for explicit single-process development. `RUNTARA_MCP_SESSION_TTL_SECONDS` controls the persisted recovery-state TTL and defaults to `86400`.
+MCP sessions are process-local by default (`RUNTARA_MCP_SESSION_STORE=local`). Set `RUNTARA_MCP_SESSION_STORE=valkey` to opt into cross-instance session recovery, where each session's `initialize` state is persisted so another process can transparently restore it. Valkey mode requires `VALKEY_HOST` and a working shared Valkey connection at startup; the server exits instead of falling back to process-local sessions. `RUNTARA_MCP_SESSION_TTL_SECONDS` controls the persisted recovery-state TTL (valkey mode only) and defaults to `86400`. Cross-instance recovery only matters when several processes serve a single tenant; it is not recommended at present, because the underlying rmcp restore path can race on concurrent requests to a process holding no in-memory copy of the session and drop the session with a 500.
 
 ## `AUTH_PROVIDER=oidc`
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -403,7 +403,7 @@ write_config() {
     local tenant_id="${TENANT_ID:-}"
     local server_port="${SERVER_PORT:-7001}"
     local mcp_allowed_hosts="${RUNTARA_MCP_ALLOWED_HOSTS:-}"
-    local mcp_session_store="${RUNTARA_MCP_SESSION_STORE:-valkey}"
+    local mcp_session_store="${RUNTARA_MCP_SESSION_STORE:-local}"
     local mcp_session_ttl_seconds="${RUNTARA_MCP_SESSION_TTL_SECONDS:-86400}"
     local auth_provider="${AUTH_PROVIDER:-oidc}"
 


### PR DESCRIPTION
The Valkey MCP session store enables rmcp's cross-instance session restore, whose restore path races on concurrent requests to a process holding no in-memory copy of the session: the session handle is published to has_session before the initialize handshake replays, so a concurrent request sends a Resume to a worker still awaiting initialize, the worker quits fatally, and the request 500s while the session is destroyed. That surfaces as intermittent GET /mcp 500s after every restart/deploy.

Cross-instance restore is irrelevant to a single-instance-per-tenant deployment, so default the store to local everywhere: the config-level default when the env var is unset, and the value scripts/install.sh writes into generated configs. Existing operators who set RUNTARA_MCP_SESSION_STORE=valkey are unaffected. Also removes the unset-env footgun where the old valkey default hard-failed startup without VALKEY_HOST.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
