### PR TITLE
SYN-560: Pre-parse template mappings in the compiled expression fast …

### DIFF
--- a/crates/runtara-workflow-stdlib/src/direct_json.rs
+++ b/crates/runtara-workflow-stdlib/src/direct_json.rs
@@ -21,7 +21,7 @@ use crate::agent_input_validation::{
 };
 use crate::conditions::{is_truthy, to_number, values_equal};
 use crate::switch_helpers::process_switch_output;
-use crate::template::render_template;
+use crate::template::{CompiledTemplate, render_template};
 
 // ===========================================================================
 // Value interning ("scope handles").
@@ -6310,12 +6310,14 @@ fn path_to_json_pointer(path: &str) -> String {
 // Compiled expressions
 //
 // A condition/mapping/reference is parsed ONCE into a reusable evaluable form
-// and evaluated per element/iteration with no JSON re-walk and no path
-// re-parse. This is a structural mirror of the interpreter
+// and evaluated per element/iteration with no JSON re-walk, no path re-parse,
+// and no template re-parse. This is a structural mirror of the interpreter
 // (`eval_condition_expression` / `apply_mapping_value` / `apply_reference` /
 // `lookup_source_path`); leaf comparison/coercion delegate to the SAME helpers
-// (`values_equal` / `is_truthy` / `to_number` / `apply_type_hint` /
-// `render_template`), so results are bit-identical. Compilation is infallible:
+// (`values_equal` / `is_truthy` / `to_number` / `apply_type_hint`), and a
+// template leaf renders through a pre-parsed `CompiledTemplate` that shares
+// minijinja's render path and error text with `render_template`, so results are
+// bit-identical. Compilation is infallible:
 // any error the interpreter would raise at eval time is carried as an
 // `Error(String)` node holding the exact message and re-raised on eval, so
 // error parity (incl. message text) is preserved.
@@ -6393,9 +6395,15 @@ enum CompiledMapping {
     Reference(CompiledReference),
     Immediate(Value),
     Composite(Box<CompiledComposite>),
-    Template(String),
+    /// Template lexed and parsed once at compile time, then rendered per
+    /// evaluation with no re-parse (see `CompiledTemplate`). Boxed because a
+    /// `CompiledTemplate` owns a minijinja `Environment` (~200 bytes); boxing
+    /// keeps `CompiledMapping` (held in every `Vec<CompiledMapping>` and
+    /// condition node) small for the common non-template variants.
+    Template(Box<CompiledTemplate>),
     /// Deferred error (not an object / missing valueType / bad reference path /
-    /// non-string template / unsupported valueType / bad composite).
+    /// non-string template / template parse error / unsupported valueType /
+    /// bad composite).
     Error(String),
 }
 
@@ -6544,7 +6552,12 @@ fn compile_mapping(value: &Value) -> CompiledMapping {
         "immediate" => CompiledMapping::Immediate(map.get("value").cloned().unwrap_or(Value::Null)),
         "composite" => compile_composite(map.get("value").unwrap_or(&Value::Null)),
         "template" => match map.get("value").and_then(Value::as_str) {
-            Some(template) => CompiledMapping::Template(template.to_string()),
+            // Parse once here; a syntax error is deferred as an `Error` node
+            // carrying the same message the interpreter raises at eval time.
+            Some(template) => match CompiledTemplate::parse(template) {
+                Ok(compiled) => CompiledMapping::Template(Box::new(compiled)),
+                Err(err) => CompiledMapping::Error(err),
+            },
             None => CompiledMapping::Error("template mapping value must be a string".to_string()),
         },
         other => CompiledMapping::Error(format!("unsupported mapping valueType '{other}'")),
@@ -6721,7 +6734,13 @@ impl CompiledMapping {
             CompiledMapping::Immediate(value) => Ok(value.clone()),
             CompiledMapping::Composite(composite) => composite.eval(source),
             CompiledMapping::Template(template) => {
-                render_template(template, &materialize(source.clone())).map(Value::String)
+                // Reuse the pre-parsed template; only `materialize` + render run
+                // per evaluation. `materialize` hands minijinja a handle-free
+                // view of the source (see the interpreter arm in
+                // `apply_mapping_value` for why).
+                template
+                    .render(&materialize(source.clone()))
+                    .map(Value::String)
             }
             CompiledMapping::Error(message) => Err(message.clone()),
         }
@@ -7230,6 +7249,62 @@ mod tests {
             compile_mapping(&reference).eval(&source).unwrap(),
             json!("c"),
             "compiled reference must resolve -1 to the last element"
+        );
+    }
+
+    /// A `template` mapping is parsed once by `compile_mapping` and rendered per
+    /// eval with no re-parse. It must match the interpreter (`apply_mapping_value`)
+    /// and stay correct across repeated evals with different sources — the
+    /// Split/While/Filter per-element shape the compiled node exists to serve.
+    #[test]
+    fn template_mapping_compiled_once_matches_interpreter() {
+        reset_value_store();
+        let mapping = json!({
+            "valueType": "template",
+            "value": "Hi {{ data.name | upper }}",
+        });
+        // Compiled once, reused for every element below.
+        let compiled = compile_mapping(&mapping);
+
+        for name in ["ada", "grace"] {
+            let source = json!({ "data": { "name": name } });
+            let expected = json!(format!("Hi {}", name.to_uppercase()));
+            // Interpreter path.
+            assert_eq!(
+                apply_mapping_value(&mapping, &source).unwrap(),
+                expected,
+                "interpreter template render mismatch"
+            );
+            // Compiled path, reusing the pre-parsed template.
+            assert_eq!(
+                compiled.eval(&source).unwrap(),
+                expected,
+                "compiled template render mismatch"
+            );
+        }
+    }
+
+    /// A malformed template keeps compilation infallible: `compile_mapping`
+    /// produces an `Error` node, and eval re-raises the exact `Template parse
+    /// error` message the interpreter raises at eval time.
+    #[test]
+    fn template_mapping_parse_error_deferred_to_error_node() {
+        reset_value_store();
+        let mapping = json!({
+            "valueType": "template",
+            "value": "{{ unclosed",
+        });
+        let source = json!({});
+
+        let interpreter_err = apply_mapping_value(&mapping, &source).unwrap_err();
+        let compiled_err = compile_mapping(&mapping).eval(&source).unwrap_err();
+        assert!(
+            interpreter_err.contains("Template parse error"),
+            "{interpreter_err}"
+        );
+        assert_eq!(
+            compiled_err, interpreter_err,
+            "compiled path must re-raise the identical parse-error message"
         );
     }
 

--- a/crates/runtara-workflow-stdlib/src/template.rs
+++ b/crates/runtara-workflow-stdlib/src/template.rs
@@ -6,11 +6,21 @@
 
 use minijinja::{Environment, ErrorKind};
 
+/// Name under which the single inline template is registered in the
+/// environment. Shared by [`render_template`] and [`CompiledTemplate`] so both
+/// paths key on the same name.
+const INLINE_TEMPLATE_NAME: &str = "__inline";
+
 /// Render a minijinja template string with the given JSON context.
 ///
 /// The context should be a JSON object containing the execution state
 /// (data, variables, steps, workflow). Template expressions can reference
 /// any path in this context using dot notation.
+///
+/// This parses the template from scratch on every call. Callers that render the
+/// same template repeatedly (e.g. a compiled mapping evaluated per element of a
+/// Split/While/Filter body) should parse it once with [`CompiledTemplate::parse`]
+/// and reuse the result instead.
 ///
 /// # Examples
 ///
@@ -24,13 +34,61 @@ use minijinja::{Environment, ErrorKind};
 /// ```
 pub fn render_template(template_str: &str, context: &serde_json::Value) -> Result<String, String> {
     let mut env = Environment::new();
-    env.add_template("__inline", template_str)
+    env.add_template(INLINE_TEMPLATE_NAME, template_str)
         .map_err(|e| format!("Template parse error: {e}"))?;
     let tmpl = env
-        .get_template("__inline")
+        .get_template(INLINE_TEMPLATE_NAME)
         .map_err(|e| format!("Template retrieval error: {e}"))?;
     tmpl.render(context)
         .map_err(|e| format!("Template render error: {e}{}", unknown_helper_hint(&e)))
+}
+
+/// A minijinja template lexed and compiled once, ready to render many times
+/// without re-parsing the source.
+///
+/// [`render_template`] rebuilds an [`Environment`] and re-parses the template on
+/// every call. Where the same template is rendered repeatedly — the compiled
+/// mapping fast path evaluates one per element/iteration of a Split/While/Filter
+/// body — that parse cost is paid on every element. `CompiledTemplate` hoists the
+/// parse out of the hot loop: [`parse`](CompiledTemplate::parse) compiles the
+/// template once (minijinja compiles eagerly at `add_template_owned` time), and
+/// each [`render`](CompiledTemplate::render) reuses the pre-compiled instructions.
+///
+/// Rendering is byte-identical to [`render_template`]: same engine, same error
+/// text (including the unknown-helper hint).
+#[derive(Debug, Clone)]
+pub struct CompiledTemplate {
+    /// Owns the single compiled template, registered under
+    /// [`INLINE_TEMPLATE_NAME`]. `'static` because the source is owned (via
+    /// `add_template_owned`), so no borrow ties the environment to the caller.
+    env: Environment<'static>,
+}
+
+impl CompiledTemplate {
+    /// Parse and compile `template_str` up front.
+    ///
+    /// On a syntax error this returns the same `"Template parse error: …"`
+    /// message [`render_template`] would produce at render time, so callers that
+    /// defer parse failures keep identical error text.
+    pub fn parse(template_str: &str) -> Result<Self, String> {
+        let mut env = Environment::new();
+        env.add_template_owned(INLINE_TEMPLATE_NAME, template_str.to_owned())
+            .map_err(|e| format!("Template parse error: {e}"))?;
+        Ok(Self { env })
+    }
+
+    /// Render the pre-compiled template with `context`.
+    ///
+    /// Reuses the instructions compiled by [`parse`](CompiledTemplate::parse) —
+    /// no re-lex, no re-parse. Errors match [`render_template`].
+    pub fn render(&self, context: &serde_json::Value) -> Result<String, String> {
+        let tmpl = self
+            .env
+            .get_template(INLINE_TEMPLATE_NAME)
+            .map_err(|e| format!("Template retrieval error: {e}"))?;
+        tmpl.render(context)
+            .map_err(|e| format!("Template render error: {e}{}", unknown_helper_hint(&e)))
+    }
 }
 
 /// When a render fails because the template referenced a filter/function/test/
@@ -143,6 +201,76 @@ mod tests {
     fn test_unknown_function_error_mentions_docs() {
         let ctx = json!({});
         let err = render_template("{{ now() }}", &ctx).unwrap_err();
+        assert!(err.contains("unknown function"), "{err}");
+        assert!(err.contains("docs/templating.md"), "{err}");
+    }
+
+    /// A `CompiledTemplate` parses once and renders many times, producing a fresh
+    /// result for each distinct context.
+    #[test]
+    fn test_compiled_template_renders_repeatedly() {
+        let tmpl = CompiledTemplate::parse("Hello {{ data.name }}").unwrap();
+        assert_eq!(
+            tmpl.render(&json!({"data": {"name": "World"}})).unwrap(),
+            "Hello World"
+        );
+        assert_eq!(
+            tmpl.render(&json!({"data": {"name": "Ada"}})).unwrap(),
+            "Hello Ada"
+        );
+        // Re-rendering the original context still works (no per-render mutation).
+        assert_eq!(
+            tmpl.render(&json!({"data": {"name": "World"}})).unwrap(),
+            "Hello World"
+        );
+    }
+
+    /// The pre-parsed path is byte-identical to `render_template` — same engine,
+    /// same filters, same output.
+    #[test]
+    fn test_compiled_template_matches_render_template() {
+        let cases = [
+            ("{{ data.name | upper }}", json!({"data": {"name": "hi"}})),
+            (
+                "{{ data.obj | tojson }}",
+                json!({"data": {"obj": {"a": 1}}}),
+            ),
+            (
+                "{% if data.active %}yes{% else %}no{% endif %}",
+                json!({"data": {"active": false}}),
+            ),
+            ("Hello {{ data.missing }}", json!({"data": {}})),
+        ];
+        for (src, ctx) in cases {
+            let compiled = CompiledTemplate::parse(src).unwrap();
+            assert_eq!(
+                compiled.render(&ctx).unwrap(),
+                render_template(src, &ctx).unwrap(),
+                "mismatch for template {src:?}"
+            );
+        }
+    }
+
+    /// A syntax error surfaces at `parse` time with the same `Template parse
+    /// error` message `render_template` produces, so callers that defer the
+    /// failure keep identical text.
+    #[test]
+    fn test_compiled_template_parse_error() {
+        let err = CompiledTemplate::parse("{{ unclosed").unwrap_err();
+        assert!(err.contains("Template parse error"), "{err}");
+        assert_eq!(
+            err,
+            render_template("{{ unclosed", &json!({})).unwrap_err(),
+            "parse-time error text must match render_template"
+        );
+    }
+
+    /// An unknown helper parses fine but fails at render time, and the compiled
+    /// path still appends the supported-helper hint.
+    #[test]
+    fn test_compiled_template_render_error_mentions_docs() {
+        let tmpl = CompiledTemplate::parse("{{ now() }}").unwrap();
+        let err = tmpl.render(&json!({})).unwrap_err();
         assert!(err.contains("unknown function"), "{err}");
         assert!(err.contains("docs/templating.md"), "{err}");
     }


### PR DESCRIPTION
…path

CompiledMapping::Template stored the raw template string and re-lexed and re-parsed it via render_template on every evaluation. In a Split/While/Filter body that parse cost was paid per element/iteration, defeating the compiled-expressions "parse once" design.

Introduce CompiledTemplate, which owns a minijinja Environment with the template compiled once (add_template_owned) and rendered per call via a cheap get_template lookup with no re-parse. Parse at compile time; a syntax error is deferred to an Error node carrying the identical message, so compilation stays infallible and interpreter/compiled error parity is preserved. Box the variant so the common non-template mappings stay small.

The interpreter path (apply_mapping_value) still parses per call; it handles one-shot auxiliary mappings, not the per-element hot loop, and has no persistent node to cache into.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
