### PR TITLE
test(reports): regenerate render corpus snapshots for staged-view nav…

### DIFF
--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_01_markdown_minimal.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_01_markdown_minimal.snap
@@ -13,6 +13,7 @@ expression: snapshot_body
     }
   },
   "errors": [],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_01_markdown_minimal"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_02_table_filter_object_model.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_02_table_filter_object_model.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_02_table_filter_object_model"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_03_chart_aggregate_object_model.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_03_chart_aggregate_object_model.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_03_chart_aggregate_object_model"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_04_metric_aggregate_object_model.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_04_metric_aggregate_object_model.snap
@@ -37,6 +37,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_04_metric_aggregate_object_model"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_05_card_with_subcards.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_05_card_with_subcards.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Customer"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_05_card_with_subcards"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_06_workflow_actions_with_row_conditions.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_06_workflow_actions_with_row_conditions.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_06_workflow_actions_with_row_conditions"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_07_workflow_runtime_instances.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_07_workflow_runtime_instances.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Workflow runtime report sources require the execution engine"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_07_workflow_runtime_instances"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_08_system_rate_limit_status.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_08_system_rate_limit_status.snap
@@ -107,6 +107,7 @@ expression: snapshot_body
     }
   },
   "errors": [],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_08_system_rate_limit_status"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_09_table_with_cross_schema_join.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_09_table_with_cross_schema_join.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_09_table_with_cross_schema_join"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_10_datasets_with_block_queries.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_10_datasets_with_block_queries.snap
@@ -67,6 +67,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_10_datasets_with_block_queries"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_11_views_with_interactions.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_11_views_with_interactions.snap
@@ -4,26 +4,6 @@ expression: snapshot_body
 ---
 {
   "blocks": {
-    "order_header": {
-      "error": {
-        "blockId": "order_header",
-        "code": "BLOCK_RENDER_FAILED",
-        "message": "Schema not found: Order"
-      },
-      "status": "error",
-      "title": "Order",
-      "type": "card"
-    },
-    "order_lines": {
-      "error": {
-        "blockId": "order_lines",
-        "code": "BLOCK_RENDER_FAILED",
-        "message": "Schema not found: OrderLine"
-      },
-      "status": "error",
-      "title": "Order lines",
-      "type": "table"
-    },
     "orders_overview": {
       "error": {
         "blockId": "orders_overview",
@@ -40,18 +20,11 @@ expression: snapshot_body
       "blockId": "orders_overview",
       "code": "BLOCK_RENDER_FAILED",
       "message": "Schema not found: Order"
-    },
-    {
-      "blockId": "order_header",
-      "code": "BLOCK_RENDER_FAILED",
-      "message": "Schema not found: Order"
-    },
-    {
-      "blockId": "order_lines",
-      "code": "BLOCK_RENDER_FAILED",
-      "message": "Schema not found: OrderLine"
     }
   ],
+  "navigation": {
+    "activeViewId": "default"
+  },
   "report": {
     "definitionVersion": 1,
     "id": "rep_11_views_with_interactions"

--- a/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_12_chart_scatter_object_model.snap
+++ b/crates/runtara-server/tests/fixtures/reports/__snapshots__/render_12_chart_scatter_object_model.snap
@@ -22,6 +22,7 @@ expression: snapshot_body
       "message": "Schema not found: Order"
     }
   ],
+  "navigation": {},
   "report": {
     "definitionVersion": 1,
     "id": "rep_12_chart_scatter_object_model"


### PR DESCRIPTION
…igation

The reports_render_corpus render_report_snapshots baseline predates three shipped reports features — resolve/scope staged views (c163ad0f), field-controlled stage navigation (10961ea4), and refreshed workflow-action render (5759e83c) — none of which regenerated this corpus. The render response now carries a `navigation` object (activeViewId), and view-scoped rendering only emits the active view's blocks. Every fixture drifted on the added `navigation` field, and render_11_views_with_interactions additionally stopped rendering blocks scoped to a non-default view.

Regenerate the snapshots to match the current, intentional output. Pure test baseline update — no product code changes.