### PR TITLE
SYN-564: Remove the dead anthropic_api_key structured-output branch

### DIFF
--- a/crates/runtara-ai/README.md
+++ b/crates/runtara-ai/README.md
@@ -43,7 +43,7 @@ For proxied credentials, use `provider::create_openai_model_with_connection` wit
 
 - Consumed by `runtara-workflows` (workflow codegen emits calls against `CompletionModel`) and `runtara-workflow-stdlib` (stdlib helpers that wrap completions, structured output, and tool-using agent loops).
 - Built on `runtara-http::HttpClient` so the same binary runs natively and under WASI — no reqwest, no tokio.
-- `provider::structured_output_params` shapes JSON Schema into the provider-specific envelope (OpenAI's `response_format.json_schema`, Anthropic's `response_format.schema`).
+- `provider::structured_output_params` shapes JSON Schema into the provider-specific envelope (OpenAI's `response_format.json_schema`, Bedrock's `outputConfig.textFormat`).
 - Errors are surfaced through `CompletionError` (`HttpError`, `JsonError`, `RequestError`, `ResponseError`, `ProviderError`) so the workflow runtime can distinguish transport, parse, and upstream failures.
 - Designed to be called from the WASM guest; the host-side proxy resolves `connection_id` to real credentials, keeping API keys out of workflow code.
 

--- a/crates/runtara-ai/src/provider.rs
+++ b/crates/runtara-ai/src/provider.rs
@@ -110,7 +110,7 @@ pub fn create_openai_model_with_connection(
 /// Takes a standard JSON Schema and wraps it in the format required by
 /// each LLM provider's structured output feature:
 /// - OpenAI: `response_format: { type: "json_schema", json_schema: { ... } }`
-/// - Anthropic: `response_format: { type: "json", schema: { ... } }`
+/// - Bedrock: `outputConfig: { textFormat: { type: "json_schema", ... } }`
 ///
 /// Returns `None` for unsupported providers (structured output will be
 /// best-effort via prompt instructions).
@@ -124,12 +124,6 @@ pub fn structured_output_params(integration_id: &str, json_schema: Value) -> Opt
                     "strict": true,
                     "schema": json_schema
                 }
-            }
-        })),
-        "anthropic_api_key" => Some(json!({
-            "response_format": {
-                "type": "json",
-                "schema": json_schema
             }
         })),
         PROVIDER_BEDROCK | "aws_credentials" => Some(json!({
@@ -218,6 +212,33 @@ mod tests {
             "aws_credentials"
         ));
         assert!(compatible_integration_ids_for_provider("unknown").is_none());
+    }
+
+    #[test]
+    fn structured_output_is_offered_only_for_dispatchable_providers() {
+        // An id may carry a structured-output envelope only if the dispatcher
+        // can actually build a model for it. Anything else is dead shape: the
+        // request fails at model creation before structured output is reached.
+        let params = json!({ "api_key": "test-key" });
+        for id in [
+            PROVIDER_OPENAI,
+            PROVIDER_BEDROCK,
+            "openai_api_key",
+            "aws_credentials",
+            "anthropic_api_key",
+            "sqs_credentials",
+            "",
+        ] {
+            let has_envelope = structured_output_params(id, json!({"type": "object"})).is_some();
+            let dispatchable = !matches!(
+                create_completion_model_with_connection(id, &params, None, Some("conn-1")),
+                Err(ProviderError::UnsupportedProvider(_)),
+            );
+            assert_eq!(
+                has_envelope, dispatchable,
+                "structured-output support and provider dispatch disagree for '{id}'"
+            );
+        }
     }
 
     #[test]

--- a/crates/runtara-dsl/src/schema_types.rs
+++ b/crates/runtara-dsl/src/schema_types.rs
@@ -1239,7 +1239,7 @@ pub struct AiAgentStep {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// Connection ID for the LLM provider (e.g., OpenAI, Anthropic).
+    /// Connection ID for the LLM provider (e.g., OpenAI, Bedrock).
     ///
     /// A same-tenant literal id, pinned at author time (back-compat). Ignored
     /// when `connection_ref` is set — the ref then supplies the id at runtime.
@@ -1344,7 +1344,7 @@ pub struct AiAgentConfig {
     ///
     /// When set, the LLM is instructed to return JSON matching this schema
     /// via the provider's structured output feature (e.g., OpenAI `response_format`,
-    /// Anthropic `response_format`).
+    /// Bedrock `outputConfig`).
     ///
     /// Uses the same `SchemaField` format as workflow `inputSchema`/`outputSchema`.
     ///

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -584,7 +584,7 @@ export interface AiAgentConfig {
    *
    * When set, the LLM is instructed to return JSON matching this schema
    * via the provider's structured output feature (e.g., OpenAI `response_format`,
-   * Anthropic `response_format`).
+   * Bedrock `outputConfig`).
    *
    * Uses the same `SchemaField` format as workflow `inputSchema`/`outputSchema`.
    *
@@ -705,7 +705,7 @@ export interface AiAgentStep {
   /** AI Agent configuration */
   config?: null | AiAgentConfig;
   /**
-   * Connection ID for the LLM provider (e.g., OpenAI, Anthropic).
+   * Connection ID for the LLM provider (e.g., OpenAI, Bedrock).
    *
    * A same-tenant literal id, pinned at author time (back-compat). Ignored
    * when `connection_ref` is set — the ref then supplies the id at runtime.


### PR DESCRIPTION
`structured_output_params` carried a match arm keyed on the `anthropic_api_key` integration id, but no request could reach it. `run_completion` builds the model via `create_completion_model_with_connection` before it resolves structured output, and that dispatcher accepts only openai/openai_api_key and bedrock/aws_credentials. Upstream, the request's integration id comes from `require_provider`, which admits only providers with a compatible-integration entry — openai and bedrock. No Anthropic provider, integration, or client exists anywhere in the workspace.

Drop the arm and add a guard test asserting the invariant it violated: an id gets a structured-output envelope if and only if the dispatcher can build a model for it. The test fails on the previous code.

Also correct the doc comments that advertised Anthropic structured output as a supported path, and regenerate the TypeScript client that embeds them.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
