### PR TITLE
SYN-583: Represent unsaved draft rows as drafts and exclude them from…

### DIFF
--- a/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/ObjectInstancesColumns.test.tsx
+++ b/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/ObjectInstancesColumns.test.tsx
@@ -1,6 +1,31 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Schema } from '@/generated/RuntaraRuntimeApi';
+import { render, screen } from '@testing-library/react';
+import type { Instance, Schema } from '@/generated/RuntaraRuntimeApi';
 import { objectInstancesColumns } from './ObjectInstancesColumns';
+import { DRAFT_ID_PREFIX, makeDraftInstance } from './draft-row';
+
+function renderIdCell(instance: Instance) {
+  const columns = objectInstancesColumns({
+    objectSchemaDto: {
+      id: 'schema-1',
+      name: 'Orders',
+      tableName: 'orders',
+      tenantId: 'tenant-1',
+      createdAt: '2026-07-27T00:00:00Z',
+      updatedAt: '2026-07-27T00:00:00Z',
+      columns: [],
+    } satisfies Schema,
+    onUpdate: vi.fn(),
+    editingCellId: null,
+    setEditingCellId: vi.fn(),
+  });
+
+  const idColumn = columns.find((column) => column.id === '_id')!;
+  const cell = idColumn.cell as (props: {
+    row: { original: Instance };
+  }) => React.ReactElement;
+  render(cell({ row: { original: instance } }));
+}
 
 describe('objectInstancesColumns', () => {
   it('omits generated tsvector columns from the instance grid', () => {
@@ -33,5 +58,25 @@ describe('objectInstancesColumns', () => {
     expect(columns.map((column) => column.id)).toContain('name');
     expect(columns.map((column) => column.id)).toContain('search_blob');
     expect(columns.map((column) => column.id)).not.toContain('search_tsv');
+  });
+
+  it('marks a draft row as Draft instead of offering to copy its placeholder id', () => {
+    renderIdCell(makeDraftInstance(`${DRAFT_ID_PREFIX}1753600000000`));
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders the copy-id button for a persisted row', () => {
+    renderIdCell({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      tenantId: 'tenant-1',
+      createdAt: '2026-07-27T00:00:00Z',
+      updatedAt: '2026-07-27T00:00:00Z',
+      properties: {},
+    });
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
   });
 });

--- a/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/ObjectInstancesColumns.tsx
+++ b/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/ObjectInstancesColumns.tsx
@@ -1,6 +1,7 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { Checkbox } from '@/shared/components/ui/checkbox';
 import { Instance, Schema } from '@/generated/RuntaraRuntimeApi';
+import { isDraftRow } from './draft-row';
 import { EditableCell } from './EditableCell';
 import { formatDate } from '@/lib/utils';
 import { IdColumnCell } from '@/shared/components/table/IdColumnCell';
@@ -47,7 +48,7 @@ export const objectInstancesColumns = ({
         />
       ),
       cell: ({ row }) => {
-        if (row.original.id?.startsWith('PENDING_')) return null;
+        if (isDraftRow(row.original.id)) return null;
         return (
           <Checkbox
             checked={row.getIsSelected()}
@@ -68,7 +69,14 @@ export const objectInstancesColumns = ({
     size: 80,
     enableSorting: false,
     enableHiding: false,
-    cell: ({ row }) => <IdColumnCell id={row.original.id!} />,
+    cell: ({ row }) =>
+      // A draft has no server id yet; offering to copy its placeholder id
+      // would present it as an existing record.
+      isDraftRow(row.original.id) ? (
+        <div className="pl-3 text-xs italic text-muted-foreground">Draft</div>
+      ) : (
+        <IdColumnCell id={row.original.id!} />
+      ),
     meta: {
       cellClassName: '!px-3',
       headerClassName: '!px-3',

--- a/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/draft-row.test.ts
+++ b/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/draft-row.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DRAFT_ID_PREFIX,
+  computeRecordTotals,
+  isDraftRow,
+  makeDraftInstance,
+} from './draft-row';
+
+describe('isDraftRow', () => {
+  it('recognizes draft ids and rejects server ids', () => {
+    expect(isDraftRow(`${DRAFT_ID_PREFIX}1753600000000`)).toBe(true);
+    expect(isDraftRow('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+    expect(isDraftRow(undefined)).toBe(false);
+    expect(isDraftRow(null)).toBe(false);
+    expect(isDraftRow('')).toBe(false);
+  });
+});
+
+describe('makeDraftInstance', () => {
+  it('carries no fabricated timestamps and no properties', () => {
+    const draft = makeDraftInstance(`${DRAFT_ID_PREFIX}1`);
+
+    expect(draft.id).toBe(`${DRAFT_ID_PREFIX}1`);
+    expect(draft.properties).toEqual({});
+    expect(draft.createdAt).toBe('');
+    expect(draft.updatedAt).toBe('');
+  });
+});
+
+describe('computeRecordTotals', () => {
+  it('reports an empty table as empty; drafts are not part of the input', () => {
+    expect(
+      computeRecordTotals({ content: [], totalPages: 0, totalElements: 0 }, 20)
+    ).toEqual({ totalPages: 1, totalElements: 0 });
+  });
+
+  it('uses the API totals when present', () => {
+    expect(
+      computeRecordTotals(
+        { content: new Array(20).fill({}), totalPages: 3, totalElements: 42 },
+        20
+      )
+    ).toEqual({ totalPages: 3, totalElements: 42 });
+  });
+
+  it('derives the page count from totalElements when totalPages is absent', () => {
+    expect(
+      computeRecordTotals(
+        { content: new Array(20).fill({}), totalPages: 0, totalElements: 42 },
+        20
+      )
+    ).toEqual({ totalPages: 3, totalElements: 42 });
+  });
+
+  it('falls back to the server rows on the page when totals are absent', () => {
+    expect(computeRecordTotals({ content: new Array(5).fill({}) }, 20)).toEqual(
+      {
+        totalPages: 1,
+        totalElements: 5,
+      }
+    );
+  });
+
+  it('defaults to one empty page before any data has loaded', () => {
+    expect(computeRecordTotals(undefined, 20)).toEqual({
+      totalPages: 1,
+      totalElements: 0,
+    });
+  });
+});

--- a/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/draft-row.ts
+++ b/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/draft-row.ts
@@ -1,0 +1,46 @@
+import { Instance } from '@/generated/RuntaraRuntimeApi';
+
+/** Prefix that marks a client-only draft row not yet persisted to the server. */
+export const DRAFT_ID_PREFIX = 'PENDING_';
+
+/** Whether a row id belongs to an unsaved draft rather than a server record. */
+export function isDraftRow(id: string | null | undefined): boolean {
+  return !!id && id.startsWith(DRAFT_ID_PREFIX);
+}
+
+/**
+ * Build the client-side draft that "+ Add row" inserts. The draft carries no
+ * timestamps — those belong to the server record it may become; fabricating
+ * them would present the draft as data that already exists.
+ */
+export function makeDraftInstance(id: string): Instance {
+  return {
+    id,
+    properties: {},
+    tenantId: '',
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+/**
+ * Footer totals for the grid, derived from the server page alone. Draft rows
+ * are appended client-side and must never count: the totals describe records
+ * that exist, and a draft does not exist until it is committed.
+ */
+export function computeRecordTotals(
+  page:
+    | { content?: unknown[]; totalPages?: number; totalElements?: number }
+    | undefined,
+  pageSize: number
+): { totalPages: number; totalElements: number } {
+  const serverRowCount = page?.content?.length ?? 0;
+  const totalElements = page?.totalElements || serverRowCount;
+  const totalPages =
+    page?.totalPages && page.totalPages > 0
+      ? page.totalPages
+      : totalElements > 0 && pageSize > 0
+        ? Math.ceil(totalElements / pageSize)
+        : 1;
+  return { totalPages, totalElements };
+}

--- a/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/index.tsx
+++ b/crates/runtara-server/frontend/src/features/objects/components/ObjectInstancesTable/index.tsx
@@ -5,6 +5,12 @@ import { Can } from '@/shared/components/Can';
 import { Download, Pencil, Plus, Trash2, Upload } from 'lucide-react';
 import { DataTable } from '@/shared/components/table';
 import { clickLandedInGrid } from './click-target';
+import {
+  DRAFT_ID_PREFIX,
+  computeRecordTotals,
+  isDraftRow,
+  makeDraftInstance,
+} from './draft-row';
 import { dropEditsForRows } from './pending-edits';
 import {
   Breadcrumb,
@@ -182,15 +188,8 @@ export function ObjectInstanceDtosTable({
     return [...contentWithDirtyData, ...pendingWithDirtyData];
   }, [data?.content, pendingRecords, dirtyRows]);
 
-  const totalPages =
-    data?.totalPages && data.totalPages > 0
-      ? data.totalPages
-      : data?.totalElements && pageSize > 0
-        ? Math.ceil(data.totalElements / pageSize)
-        : records.length > 0
-          ? Math.ceil(records.length / pageSize)
-          : 1;
-  const totalElements = data?.totalElements || records.length || 0;
+  // Totals come from the server page alone; draft rows must not count.
+  const { totalPages, totalElements } = computeRecordTotals(data, pageSize);
   const currentPage = page;
 
   const [showImportDialog, setShowImportDialog] = useState(false);
@@ -299,7 +298,7 @@ export function ObjectInstanceDtosTable({
         return;
       }
 
-      if (rowId.startsWith('PENDING_')) {
+      if (isDraftRow(rowId)) {
         // Save pending record
         try {
           const newInstance = await createRecord.mutateAsync({
@@ -362,7 +361,7 @@ export function ObjectInstanceDtosTable({
     const propertyEntries = Object.entries(data.properties || {});
     const hasChanges = propertyEntries.length > 0;
 
-    if (instanceId.startsWith('PENDING_')) {
+    if (isDraftRow(instanceId)) {
       // Update pending record immediately in state
       setPendingRecords((prev) => {
         let didUpdate = false;
@@ -443,17 +442,8 @@ export function ObjectInstanceDtosTable({
       saveDirtyRow(lastFocusedRowRef.current);
     }
 
-    const newId = `PENDING_${Date.now()}`;
-    setPendingRecords((prev) => [
-      ...prev,
-      {
-        id: newId,
-        properties: {},
-        tenantId: '',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      } as Instance,
-    ]);
+    const newId = `${DRAFT_ID_PREFIX}${Date.now()}`;
+    setPendingRecords((prev) => [...prev, makeDraftInstance(newId)]);
   }, [saveDirtyRow]);
 
   const handleFilterChange = (condition: Condition | null) => {
@@ -750,6 +740,12 @@ export function ObjectInstanceDtosTable({
           <TableStatusFooter
             left={`${totalElements.toLocaleString()} record${
               totalElements === 1 ? '' : 's'
+            }${
+              pendingRecords.length > 0
+                ? ` (+${pendingRecords.length} draft${
+                    pendingRecords.length === 1 ? '' : 's'
+                  })`
+                : ''
             }`}
             right={
               <TablePagination


### PR DESCRIPTION
… record counts

+ Add row used to insert a client-only row that looked persisted: it carried fabricated created/updated timestamps, its ID cell offered copy-to-clipboard of the placeholder id, and the footer's totals fell back to a row list that included drafts, so an empty table showed a record count for data that did not exist.

The draft now renders as what it is. It carries no timestamps (the timestamp cells show an em dash), the ID cell shows a Draft marker instead of a copy button, and footer totals are computed from the server page alone via computeRecordTotals, with drafts surfaced separately as a "(+N draft)" suffix. The draft helpers live in draft-row.ts alongside the other extracted grid logic.

Verified against a live local tenant: adding a draft leaves the record count unchanged, committing it issues the create and the row becomes a real record with server timestamps, and a reload shows no phantom rows.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
