### PR TITLE
SYN-598: Make workflow-list pagination 0-based and stop the post-star…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `GET /api/runtime/workflows` now takes a 0-based `page`**, matching
+  every other paginated endpoint in the runtime API (`/executions`,
+  `/workflows/{id}/instances`, `/checkpoints`, `/actions`). It was the only
+  1-based one, while still reporting a 0-based `number` in the response — so
+  `number + 1` re-requested the page just read and never reached page 2, and
+  `?page=0` and `?page=1` both returned the first page. `number` now echoes the
+  page that was asked for. **Callers passing `page=1` for the first page must
+  change it to `page=0`, or they will silently skip the first page.** The MCP
+  `list_workflows` tool takes the same 0-based `page`.
 - **Encoding-sensitive agents (text, csv, xml) now share one encoding
   vocabulary** via the new `runtara-agent-encoding` crate. Their `encoding`
   inputs become a curated dropdown of standard names plus `Auto` (detect),

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
@@ -149,13 +149,13 @@ export function WorkflowsGrid({
     );
   }, []);
 
-  // Pagination state (API uses 1-based pages)
-  const [page, setPage] = useState(1);
+  // Pagination state (API uses 0-based pages)
+  const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   // Reset to first page when folder or search changes
   useEffect(() => {
-    setPage(1);
+    setPage(0);
   }, [folderPath, searchTerm]);
 
   // Fetch folders for move dialog
@@ -379,8 +379,8 @@ export function WorkflowsGrid({
   const hasContent = hasFolders || hasWorkflows;
 
   // Pagination display values
-  const startRow = totalElements === 0 ? 0 : (page - 1) * pageSize + 1;
-  const endRow = Math.min(page * pageSize, totalElements);
+  const startRow = totalElements === 0 ? 0 : page * pageSize + 1;
+  const endRow = Math.min((page + 1) * pageSize, totalElements);
 
   let body: ReactNode;
   if (isFetching) {
@@ -523,13 +523,13 @@ export function WorkflowsGrid({
               }`}
               right={
                 <TablePagination
-                  pageIndex={page - 1}
+                  pageIndex={page}
                   pageSize={pageSize}
                   pageCount={totalPages}
-                  onPageChange={(p) => setPage(p + 1)}
+                  onPageChange={setPage}
                   onPageSizeChange={(size) => {
                     setPageSize(size);
-                    setPage(1);
+                    setPage(0);
                   }}
                 />
               }

--- a/crates/runtara-server/frontend/src/features/workflows/pages/Workflow/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/pages/Workflow/index.tsx
@@ -34,6 +34,9 @@ import {
   setCurrentVersion,
   updateWorkflow,
   getWorkflowInstance,
+  queuedInstancePlaceholder,
+  holdForQueuedRow,
+  type QueuedRun,
   getStepEvents,
   toggleTrackEvents,
   resumeInstance,
@@ -668,6 +671,9 @@ export function Workflow() {
     resetExecution,
   } = useExecutionStore();
 
+  // The run this page started, and when — read by the instance query below.
+  const queuedRunRef = useRef<QueuedRun | null>(null);
+
   const scheduleMutation = useCustomMutation({
     mutationFn: (
       token: string,
@@ -699,6 +705,19 @@ export function Workflow() {
       const instanceId = response?.data?.instanceId;
 
       if (instanceId && variables.workflowId) {
+        // Show the queued status the response already carries, and note when the
+        // run was queued so the first read of its row can wait for the runtime
+        // to write one.
+        queryClient.setQueryData(
+          queryKeys.workflows.instance(variables.workflowId, instanceId),
+          queuedInstancePlaceholder(
+            variables.workflowId,
+            instanceId,
+            variables.version
+          )
+        );
+        queuedRunRef.current = { instanceId, queuedAt: Date.now() };
+
         // Start execution visualization (debugMode enables step-event polling)
         startExecution(
           instanceId,
@@ -717,9 +736,19 @@ export function Workflow() {
         workflowId ?? '',
         executingInstanceId ?? ''
       ),
-      queryFn: (token: string) =>
-        getWorkflowInstance(token, workflowId!, executingInstanceId!),
+      queryFn: async (token: string) => {
+        // Reading a run this page has only just queued would 404 — the runtime
+        // has not written its row yet. Only that run waits; anything else,
+        // including an instance attached to on load, reads straight away.
+        await holdForQueuedRow(queuedRunRef.current, executingInstanceId!);
+        return getWorkflowInstance(token, workflowId!, executingInstanceId!);
+      },
       enabled: !!executingInstanceId,
+      // The seeded queued status is for display only. Without this it would
+      // count as fresh under the client's 5-minute default and suppress the
+      // read that follows, leaving the run's real status to the poll below —
+      // which a hidden tab skips entirely.
+      staleTime: 0,
       refetchInterval: (query: any) => {
         const status = query.state.data?.status;
         const isActive =

--- a/crates/runtara-server/frontend/src/features/workflows/queries/get-workflows-pagination.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/queries/get-workflows-pagination.test.ts
@@ -29,12 +29,15 @@ function page(items: number, totalElements: number, totalPages: number) {
   };
 }
 
-/** Serve `total` workflows across 100-row pages, keyed by requested page. */
+/**
+ * Serve `total` workflows across 100-row pages, keyed by requested page.
+ * Pages are 0-based, matching the runtime API.
+ */
 function serve(total: number) {
   const totalPages = Math.max(1, Math.ceil(total / 100));
   listWorkflowsHandler.mockImplementation((params: { page?: number }) => {
-    const requested = params?.page ?? 1;
-    const remaining = total - (requested - 1) * 100;
+    const requested = params?.page ?? 0;
+    const remaining = total - requested * 100;
     return Promise.resolve(
       page(Math.max(0, Math.min(100, remaining)), total, totalPages)
     );
@@ -57,13 +60,13 @@ describe('getWorkflows', () => {
     expect(listWorkflowsHandler).toHaveBeenCalledTimes(2);
   });
 
-  it('asks for each page in turn', async () => {
+  it('asks for each page in turn, starting at page 0', async () => {
     serve(124);
 
     await getWorkflows('token');
 
     const pages = listWorkflowsHandler.mock.calls.map((call) => call[0].page);
-    expect(pages).toEqual([1, 2]);
+    expect(pages).toEqual([0, 1]);
   });
 
   it('makes a single request when everything fits on one page', async () => {

--- a/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
@@ -109,13 +109,13 @@ async function fetchWorkflowPage(token: string, page: number) {
  * `pageSize` cannot be raised past 100, so a single request silently omitted
  * every workflow beyond the first 100 — they became unselectable, and the
  * trigger list fell back to rendering raw workflow UUIDs. Walk the pages
- * instead: page 1 reports `totalPages`, and the remainder are fetched together.
+ * instead: page 0 reports `totalPages`, and the remainder are fetched together.
  *
  * Returns the same `{ data: { content, … }, message, success }` envelope as a
  * single page, with the pagination fields restated to describe the aggregate.
  */
 export async function getWorkflows(token: string) {
-  const first = await fetchWorkflowPage(token, 1);
+  const first = await fetchWorkflowPage(token, 0);
   const firstPage = (first as { data?: Record<string, any> } | undefined)?.data;
   const totalPages: number = firstPage?.totalPages ?? 1;
 
@@ -133,7 +133,7 @@ export async function getWorkflows(token: string) {
 
   const laterPages = await Promise.all(
     Array.from({ length: pagesToFetch - 1 }, (_, index) =>
-      fetchWorkflowPage(token, index + 2)
+      fetchWorkflowPage(token, index + 1)
     )
   );
 
@@ -206,6 +206,65 @@ export interface WorkflowInstanceWithMetadata extends WorkflowInstanceDto {
     heartbeatAt?: string;
     additionalMetadata?: Record<string, unknown>;
   };
+}
+
+/**
+ * Stand-in for a run that has been queued but whose instance row does not exist
+ * yet.
+ *
+ * Starting a workflow publishes it to the trigger stream and hands back an
+ * instance id right away; the row itself is written later, when the runtime
+ * picks the event up. Until then the caller has an id it cannot read, so this
+ * supplies the status the execute response already reported.
+ */
+export function queuedInstancePlaceholder(
+  workflowId: string,
+  instanceId: string,
+  version?: number
+): WorkflowInstanceWithMetadata {
+  const now = new Date().toISOString();
+  return {
+    id: instanceId,
+    workflowId,
+    status: 'queued',
+    inputs: {} as WorkflowInstanceDto['inputs'],
+    created: now,
+    updated: now,
+    usedVersion: version ?? 0,
+  };
+}
+
+/** A run queued by this page, and when — see {@link holdForQueuedRow}. */
+export interface QueuedRun {
+  instanceId: string;
+  queuedAt: number;
+}
+
+/**
+ * How long to give the runtime to write the row of a just-queued run. Generous
+ * next to the observed lag (a few tens of ms) and still far below the point
+ * where a user would notice the first status arriving late.
+ */
+const QUEUED_ROW_GRACE_MS = 1200;
+
+/**
+ * Hold a read of `instanceId` until its row can be expected to exist.
+ *
+ * A read issued in the gap between `execute` returning and the runtime writing
+ * the row is a genuine 404, which the browser logs on every single run. Waiting
+ * here rather than gating the query keeps the query's own scheduling — when it
+ * runs, when it polls, when it gives up — exactly as it was; only the request
+ * leaves a moment later. Returns immediately for any instance this page did not
+ * just queue.
+ */
+export async function holdForQueuedRow(
+  queued: QueuedRun | null | undefined,
+  instanceId: string
+): Promise<void> {
+  if (!queued || queued.instanceId !== instanceId) return;
+  const remaining = QUEUED_ROW_GRACE_MS - (Date.now() - queued.queuedAt);
+  if (remaining <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, remaining));
 }
 
 export async function getWorkflowInstance(

--- a/crates/runtara-server/frontend/src/features/workflows/queries/queued-row-hold.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/queries/queued-row-hold.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { holdForQueuedRow, queuedInstancePlaceholder } from './index';
+
+/**
+ * Reading a just-queued run 404s: `execute` returns an instance id before the
+ * runtime has written the row. `holdForQueuedRow` waits out that window — but
+ * only for the run the caller queued, since every other read (attaching to an
+ * existing instance, revisiting a finished one) must stay immediate.
+ */
+describe('holdForQueuedRow', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not wait when nothing was queued', async () => {
+    vi.useFakeTimers();
+    let settled = false;
+    void holdForQueuedRow(null, 'inst_1').then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(true);
+  });
+
+  it('does not wait for an instance other than the queued one', async () => {
+    vi.useFakeTimers();
+    const queued = { instanceId: 'inst_1', queuedAt: Date.now() };
+    let settled = false;
+    void holdForQueuedRow(queued, 'inst_2').then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(true);
+  });
+
+  it('holds the queued instance until the grace window has passed', async () => {
+    vi.useFakeTimers();
+    const queued = { instanceId: 'inst_1', queuedAt: Date.now() };
+    let settled = false;
+    void holdForQueuedRow(queued, 'inst_1').then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toBe(true);
+  });
+
+  it('does not wait once the grace window has already elapsed', async () => {
+    vi.useFakeTimers();
+    // A poll several seconds into the run must not be delayed again.
+    const queued = { instanceId: 'inst_1', queuedAt: Date.now() - 10_000 };
+    let settled = false;
+    void holdForQueuedRow(queued, 'inst_1').then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(true);
+  });
+});
+
+describe('queuedInstancePlaceholder', () => {
+  it('reports the run as queued under the id execute handed back', () => {
+    const placeholder = queuedInstancePlaceholder('wf_1', 'inst_1', 3);
+
+    expect(placeholder.id).toBe('inst_1');
+    expect(placeholder.workflowId).toBe('wf_1');
+    expect(placeholder.status).toBe('queued');
+    expect(placeholder.usedVersion).toBe(3);
+  });
+});

--- a/crates/runtara-server/src/api/dto/workflows.rs
+++ b/crates/runtara-server/src/api/dto/workflows.rs
@@ -1006,7 +1006,7 @@ impl PageWorkflowDto {
     /// # Arguments
     /// * `content` - The workflows for this page
     /// * `total_elements` - Total number of workflows across all pages
-    /// * `page` - Current page number (1-based from API, converted to 0-based internally)
+    /// * `page` - Current page number (0-based, as requested)
     /// * `size` - Page size
     pub fn new(content: Vec<WorkflowDto>, total_elements: i64, page: i32, size: i32) -> Self {
         let total_pages = if total_elements == 0 {
@@ -1014,7 +1014,8 @@ impl PageWorkflowDto {
         } else {
             ((total_elements as f64) / (size as f64)).ceil() as i32
         };
-        let number = (page - 1).max(0); // Convert 1-based to 0-based
+        // Echoes the requested page so `number + 1` is the next page.
+        let number = page.max(0);
         let number_of_elements = content.len() as i32;
 
         Self {
@@ -1596,5 +1597,28 @@ mod tests {
         let err = validate_workflow_inputs(input).unwrap_err();
 
         assert!(err.message.contains("data"));
+    }
+
+    /// `number` has to echo the page that was asked for, otherwise a client
+    /// advancing with `number + 1` re-requests the page it just read. The
+    /// workflow list used to report `page - 1` here while reading `page` as
+    /// 1-based, which is exactly that loop.
+    #[test]
+    fn page_number_round_trips_the_requested_page() {
+        for page in 0..4 {
+            let dto = PageWorkflowDto::new(vec![], 100, page, 20);
+            assert_eq!(dto.number, page, "page {page} should echo back");
+        }
+
+        let first = PageWorkflowDto::new(vec![], 100, 0, 20);
+        assert!(first.first);
+        assert!(!first.last);
+
+        // Negative pages clamp to the first page rather than a negative offset.
+        assert_eq!(PageWorkflowDto::new(vec![], 100, -3, 20).number, 0);
+
+        let last = PageWorkflowDto::new(vec![], 100, 4, 20);
+        assert!(last.last);
+        assert!(!last.first);
     }
 }

--- a/crates/runtara-server/src/api/handlers/workflows.rs
+++ b/crates/runtara-server/src/api/handlers/workflows.rs
@@ -96,6 +96,7 @@ pub struct UpdateWorkflowRequest {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListWorkflowsQuery {
+    /// Page number (0-based, default: 0)
     pub page: Option<i32>,
     #[serde(rename = "pageSize")]
     pub page_size: Option<i32>,
@@ -792,7 +793,7 @@ pub async fn publish_workflow_agent_handler(
     get,
     path = "/api/runtime/workflows",
     params(
-        ("page" = Option<i32>, Query, description = "Page number (1-based, default: 1)"),
+        ("page" = Option<i32>, Query, description = "Page number (0-based, default: 0)"),
         ("pageSize" = Option<i32>, Query, description = "Page size (default: 20, max: 100)"),
         ("path" = Option<String>, Query, description = "Filter by folder path (e.g., '/Sales/'). If not provided, returns all workflows."),
         ("recursive" = bool, Query, description = "If true and path is provided, includes workflows in subfolders (default: false)"),
@@ -819,8 +820,8 @@ pub async fn list_workflows_handler(
     let repository = Arc::new(WorkflowRepository::new(pool.clone()));
     let service = WorkflowService::new(repository, connections.clone(), agent_catalog.clone());
 
-    // Delegate to service with pagination
-    let page = query.page.unwrap_or(1);
+    // Delegate to service with pagination (0-based pages; the service normalizes)
+    let page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(20);
 
     let query_start = std::time::Instant::now();
@@ -2118,7 +2119,7 @@ pub async fn list_instance_checkpoints_handler(
     };
 
     // Normalize pagination
-    let page = query.page.unwrap_or(0).max(0);
+    let page = crate::api::utils::pagination::normalize_page(query.page);
     let size = query.size.unwrap_or(20).clamp(1, 100) as u32;
 
     // Fetch checkpoints via runtara management SDK

--- a/crates/runtara-server/src/api/repositories/workflows.rs
+++ b/crates/runtara-server/src/api/repositories/workflows.rs
@@ -347,6 +347,7 @@ impl WorkflowRepository {
     /// Note: name/description are extracted from the execution graph (definition)
     ///
     /// # Arguments
+    /// * `page` - 0-based page number; page 0 is the first page.
     /// * `path` - Optional folder path filter. If None, returns all workflows (backward compatible).
     ///   If Some, filters by exact path match (recursive=false) or prefix match (recursive=true).
     /// * `recursive` - If true and path is provided, includes workflows in subfolders.
@@ -360,7 +361,7 @@ impl WorkflowRepository {
         recursive: bool,
         search: Option<&str>,
     ) -> Result<(Vec<WorkflowDto>, i64), sqlx::Error> {
-        let offset = (page - 1) * page_size;
+        let offset = page * page_size;
 
         // Build path filter value
         let (_, _, path_value) = match (path, recursive) {

--- a/crates/runtara-server/src/api/services/workflow_runtime.rs
+++ b/crates/runtara-server/src/api/services/workflow_runtime.rs
@@ -235,7 +235,7 @@ pub async fn list_workflow_actions(
     page: Option<i32>,
     size: Option<i32>,
 ) -> Result<WorkflowRuntimeActionPage, WorkflowRuntimeError> {
-    let page_number = page.unwrap_or(0).max(0);
+    let page_number = crate::api::utils::pagination::normalize_page(page);
     let page_size = size.unwrap_or(25).clamp(1, 100);
     let instances = engine
         .list_executions(tenant_id, workflow_id, Some(page_number), Some(page_size))

--- a/crates/runtara-server/src/api/services/workflows.rs
+++ b/crates/runtara-server/src/api/services/workflows.rs
@@ -423,6 +423,7 @@ impl WorkflowService {
     /// List workflows with pagination and optional folder filtering
     ///
     /// # Arguments
+    /// * `page` - 0-based page number; page 0 is the first page.
     /// * `path` - Optional folder path to filter by. If None, returns all workflows (backward compatible).
     /// * `recursive` - If true and path is provided, includes workflows in subfolders.
     pub async fn list_workflows(

--- a/crates/runtara-server/src/api/utils/pagination.rs
+++ b/crates/runtara-server/src/api/utils/pagination.rs
@@ -1,6 +1,17 @@
-/// Validate and normalize page number (minimum 1)
+//! Page/size normalization for the paginated list endpoints.
+//!
+//! Pages are **0-based** across the whole runtime API: page 0 is the first page,
+//! and the `number` field a page response carries back is the page that was
+//! asked for, so `number + 1` fetches the next one.
+//!
+//! The workflow list used to be the exception — it read `page` as 1-based while
+//! still reporting a 0-based `number`, so `number + 1` re-requested the page the
+//! caller had just read and `?page=0` and `?page=1` both returned the first
+//! page. Normalizing here keeps that from drifting apart again.
+
+/// Validate and normalize a page number (0-based, minimum 0).
 pub fn normalize_page(page: Option<i32>) -> i32 {
-    page.unwrap_or(1).max(1)
+    page.unwrap_or(0).max(0)
 }
 
 /// Validate and normalize page size (between 1 and 100)
@@ -14,11 +25,11 @@ mod tests {
 
     #[test]
     fn test_normalize_page() {
-        assert_eq!(normalize_page(None), 1);
-        assert_eq!(normalize_page(Some(1)), 1);
+        assert_eq!(normalize_page(None), 0); // Default is the first page
+        assert_eq!(normalize_page(Some(0)), 0);
+        assert_eq!(normalize_page(Some(1)), 1); // The *second* page
         assert_eq!(normalize_page(Some(5)), 5);
-        assert_eq!(normalize_page(Some(0)), 1); // Minimum 1
-        assert_eq!(normalize_page(Some(-5)), 1); // Minimum 1
+        assert_eq!(normalize_page(Some(-5)), 0); // Minimum 0
     }
 
     #[test]

--- a/crates/runtara-server/src/mcp/tools/workflows.rs
+++ b/crates/runtara-server/src/mcp/tools/workflows.rs
@@ -237,7 +237,7 @@ pub struct GetWorkflowAuthoringSchemaParams {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ListWorkflowsParams {
-    #[schemars(description = "Page number (1-based)")]
+    #[schemars(description = "Page number (0-based)")]
     pub page: Option<i64>,
     #[schemars(description = "Items per page")]
     pub page_size: Option<i64>,

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -1447,7 +1447,7 @@ impl ExecutionEngine {
         page: Option<i32>,
         size: Option<i32>,
     ) -> Result<PageWorkflowInstanceHistoryDto, ExecutionError> {
-        let page = page.unwrap_or(0).max(0);
+        let page = crate::api::utils::pagination::normalize_page(page);
         let size = size.unwrap_or(10).clamp(1, 100);
 
         let client = self.require_runtime_client()?;
@@ -1572,7 +1572,7 @@ impl ExecutionEngine {
         size: Option<i32>,
         filters: ExecutionFilters,
     ) -> Result<PageWorkflowInstanceHistoryDto, ExecutionError> {
-        let page = page.unwrap_or(0).max(0);
+        let page = crate::api::utils::pagination::normalize_page(page);
         let size = size.unwrap_or(20).clamp(1, 100);
 
         let client = self.require_runtime_client()?;


### PR DESCRIPTION
…t 404

The workflow list was the only 1-indexed paginated endpoint, while still reporting a 0-based `number`, so `number + 1` re-requested the page just read and `?page=0` and `?page=1` both returned the first page. It now takes a 0-based page like `/executions`, the instance list, checkpoints and actions, and `number` echoes what was asked for. `normalize_page` holds the rule and the endpoints that open-coded it now call it.

Starting a run returned an instance id before the runtime had written its row, so the editor's first read of it was a guaranteed 404 on every run. The status the execute response already carries is shown while that first read waits for the row.

BREAKING: callers passing page=1 to GET /api/runtime/workflows for the first page must pass page=0, or they will silently skip it.