### PR TITLE
SYN-562: Share one reference-path tokenizer between the validator and…

### DIFF
--- a/crates/runtara-workflow-stdlib/src/direct_json.rs
+++ b/crates/runtara-workflow-stdlib/src/direct_json.rs
@@ -20,7 +20,7 @@ use crate::agent_input_validation::{
     AgentInputMissingReason, AgentInputValidationError, MissingAgentInput,
 };
 use crate::conditions::{is_truthy, to_number, values_equal};
-use crate::reference_path::{self, is_array_index_token};
+use crate::reference_path::{self, array_index, is_array_index_token};
 use crate::switch_helpers::process_switch_output;
 use crate::template::{CompiledTemplate, render_template};
 
@@ -6283,21 +6283,6 @@ fn resolve_lookup(lookup: Lookup, default: Option<Value>) -> Result<Value, Strin
         Lookup::Found(Value::Null) | Lookup::Absent => Ok(default.unwrap_or(Value::Null)),
         Lookup::Found(value) => Ok(value),
         Lookup::Mismatch(message) => default.ok_or(message),
-    }
-}
-
-/// Resolve a path segment to a concrete array index, supporting Python-style
-/// negative suffix indexing: `-1` is the last element, `-2` the second-to-last.
-/// Non-numeric segments and out-of-range negatives return `None`, so an unmatched
-/// index falls through to the resolver's null/default path exactly like an
-/// out-of-range positive index does.
-fn array_index(segment: &str, len: usize) -> Option<usize> {
-    let raw: i64 = segment.parse().ok()?;
-    if raw >= 0 {
-        usize::try_from(raw).ok()
-    } else {
-        // `unsigned_abs` avoids overflow at `i64::MIN`.
-        len.checked_sub(usize::try_from(raw.unsigned_abs()).ok()?)
     }
 }
 

--- a/crates/runtara-workflow-stdlib/src/direct_json.rs
+++ b/crates/runtara-workflow-stdlib/src/direct_json.rs
@@ -20,6 +20,7 @@ use crate::agent_input_validation::{
     AgentInputMissingReason, AgentInputValidationError, MissingAgentInput,
 };
 use crate::conditions::{is_truthy, to_number, values_equal};
+use crate::reference_path::{self, is_array_index_token};
 use crate::switch_helpers::process_switch_output;
 use crate::template::{CompiledTemplate, render_template};
 
@@ -4699,7 +4700,7 @@ fn apply_group_by(config: &Value, source: &Value) -> Result<Value, String> {
         .get("key")
         .and_then(Value::as_str)
         .ok_or_else(|| "GroupBy config missing key".to_string())?;
-    let pointer = path_to_json_pointer(key);
+    let pointer = reference_path::to_json_pointer(key);
 
     let mut groups = BTreeMap::<String, Vec<Value>>::new();
     let mut counts = BTreeMap::<String, usize>::new();
@@ -6097,19 +6098,17 @@ fn lookup_source_path(source: &Value, path: &str) -> Option<Value> {
     lookup_segments(source, &path_to_segments(path))
 }
 
-/// Pre-split a reference path into already-unescaped JSON-pointer segments.
+/// Pre-split a reference path into lookup segments.
 ///
-/// This is the expensive half of a reference lookup (the `['..']`/`["..]`
-/// bracket normalization, the `[N]` numeric-index scan, and the `~0`/`~1`
-/// escape round-trip). Hoisting it into a compiled reference means a per-element
-/// Filter/While/GroupBy reference parses its path **once** instead of on every
-/// evaluation. [`lookup_segments_detailed`] is the cheap walk over the result.
+/// This is the expensive half of a reference lookup (the bracket scan).
+/// Hoisting it into a compiled reference means a per-element Filter/While/GroupBy
+/// reference parses its path **once** instead of on every evaluation.
+/// [`lookup_segments_detailed`] is the cheap walk over the result.
+///
+/// Tokenization lives in [`crate::reference_path`] so the authoring-time
+/// validator splits paths exactly the same way.
 fn path_to_segments(path: &str) -> Vec<String> {
-    path_to_json_pointer(path)
-        .split('/')
-        .skip(1)
-        .map(unescape_pointer_segment)
-        .collect()
+    reference_path::reference_segments(path)
 }
 
 /// `Option`-returning walk over pre-split segments — a test-only `Some/None`
@@ -6300,64 +6299,6 @@ fn array_index(segment: &str, len: usize) -> Option<usize> {
         // `unsigned_abs` avoids overflow at `i64::MIN`.
         len.checked_sub(usize::try_from(raw.unsigned_abs()).ok()?)
     }
-}
-
-/// True when a `[..]` bracket body is an array index — an optional leading `-`
-/// followed by one or more ASCII digits (e.g. `0`, `12`, `-1`).
-fn is_array_index_token(token: &str) -> bool {
-    let digits = token.strip_prefix('-').unwrap_or(token);
-    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
-}
-
-/// Reverse the JSON-pointer escaping applied by [`path_to_json_pointer`].
-fn unescape_pointer_segment(segment: &str) -> String {
-    segment.replace("~1", "/").replace("~0", "~")
-}
-
-fn path_to_json_pointer(path: &str) -> String {
-    let normalized = path
-        .replace("['", ".")
-        .replace("']", "")
-        .replace("[\"", ".")
-        .replace("\"]", "");
-
-    let mut dotted = String::new();
-    let mut chars = normalized.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '[' {
-            let mut index = String::new();
-            while let Some(&next_ch) = chars.peek() {
-                if next_ch == ']' {
-                    chars.next();
-                    break;
-                }
-                index.push(chars.next().expect("peeked character exists"));
-            }
-            if is_array_index_token(&index) {
-                dotted.push('.');
-                dotted.push_str(&index);
-            } else {
-                dotted.push('[');
-                dotted.push_str(&index);
-                dotted.push(']');
-            }
-        } else {
-            dotted.push(ch);
-        }
-    }
-
-    let mut out = String::with_capacity(dotted.len() + 4);
-    for segment in dotted.split('.') {
-        out.push('/');
-        for ch in segment.chars() {
-            match ch {
-                '~' => out.push_str("~0"),
-                '/' => out.push_str("~1"),
-                _ => out.push(ch),
-            }
-        }
-    }
-    out
 }
 
 // ===========================================================================
@@ -7277,6 +7218,49 @@ mod tests {
         // Out-of-range negative misses (None), like an out-of-range positive index.
         assert_eq!(lookup_source_path(&source, "items.-4"), None);
         assert_eq!(lookup_source_path(&source, "items.3"), None);
+    }
+
+    /// A bracket-quoted body is one opaque key, dots included. The runtime used
+    /// to rewrite `["a.b"]` to `.a.b` and split it, so a reference to a literal
+    /// dotted key resolved a nested path that wasn't there and fell through to
+    /// null — while the validator, reading it as a single key, had accepted it.
+    #[test]
+    fn lookup_treats_bracket_quoted_dotted_key_as_one_segment() {
+        reset_value_store();
+        let source = json!({
+            "data": {
+                "a.b": "flat",
+                "a": { "b": "nested" },
+            }
+        });
+
+        assert_eq!(
+            lookup_source_path(&source, r#"data["a.b"]"#),
+            Some(json!("flat"))
+        );
+        assert_eq!(
+            lookup_source_path(&source, "data['a.b']"),
+            Some(json!("flat"))
+        );
+        // The dotted form still descends, so both spellings stay addressable.
+        assert_eq!(
+            lookup_source_path(&source, "data.a.b"),
+            Some(json!("nested"))
+        );
+    }
+
+    /// An unquoted, non-numeric bracket body is a plain key. The runtime used to
+    /// keep the brackets inside the segment text and look for a key literally
+    /// named `data[key]`, while the validator read it as `data` then `key`.
+    #[test]
+    fn lookup_treats_unquoted_bracket_body_as_a_plain_key() {
+        reset_value_store();
+        let source = json!({ "data": { "key": "value" } });
+
+        assert_eq!(
+            lookup_source_path(&source, "data[key]"),
+            Some(json!("value"))
+        );
     }
 
     /// SYN-448: the negative index must reach the leaf through both reference

--- a/crates/runtara-workflow-stdlib/src/lib.rs
+++ b/crates/runtara-workflow-stdlib/src/lib.rs
@@ -64,6 +64,10 @@ pub mod template;
 // JSON helpers for direct-emitted workflow components
 pub mod direct_json;
 
+// Reference-path tokenization, shared with the authoring-time validator so both
+// agree on what a path's segments are.
+pub mod reference_path;
+
 // Child workflow input validation (runtime)
 pub mod child_input_validation;
 

--- a/crates/runtara-workflow-stdlib/src/reference_path.rs
+++ b/crates/runtara-workflow-stdlib/src/reference_path.rs
@@ -1,0 +1,223 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Reference-path tokenization — the single definition of how a reference path
+//! (`data.order.id`, `steps.fetch.outputs[0]`, `variables["a.b"]`) splits into
+//! lookup segments.
+//!
+//! The runtime resolver ([`crate::direct_json`]) and the authoring-time
+//! validator in `runtara-workflows` both tokenize through here, so a path that
+//! validates against a schema key resolves to that same key at runtime.
+//!
+//! They used to scan independently and disagreed on bracket bodies: the
+//! validator read `foo["a.b"]` as the single key `a.b`, while the runtime
+//! rewrote brackets to dots and split it into `a` then `b`. A reference to a
+//! literal dotted key therefore passed validation and then silently resolved to
+//! null, and a genuinely-nested path written in bracket form was rejected even
+//! though the runtime would have descended it.
+
+/// Split a reference path into lookup segments.
+///
+/// A dot separates segments; empty segments are dropped. A `[..]` body is one
+/// segment: quoted (`'..'` or `".."`) means an **opaque key** — dots inside it
+/// are part of the key, not separators — while an unquoted body is taken
+/// verbatim, covering both index tokens (`0`, `-1`) and bare keys.
+///
+/// Index-vs-key is decided by token shape at lookup time (see
+/// `direct_json::descend`), so both stay raw here.
+pub fn reference_segments(path: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut chars = path.chars();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '.' => {
+                if !current.is_empty() {
+                    segments.push(std::mem::take(&mut current));
+                }
+            }
+            '[' => {
+                if !current.is_empty() {
+                    segments.push(std::mem::take(&mut current));
+                }
+
+                // An unterminated `[` consumes the rest of the path, matching
+                // the historical scan (no error surface here — an unbalanced
+                // bracket simply yields whatever key text it holds).
+                let mut body = String::new();
+                for next in chars.by_ref() {
+                    if next == ']' {
+                        break;
+                    }
+                    body.push(next);
+                }
+
+                if let Some(segment) = bracket_segment(body.trim()) {
+                    segments.push(segment);
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        segments.push(current);
+    }
+
+    segments
+}
+
+/// Render a reference path as an RFC 6901 JSON pointer, escaping `~` and `/`
+/// inside segment text. Tokenization is [`reference_segments`], so bracket
+/// bodies stay opaque here too.
+pub fn to_json_pointer(path: &str) -> String {
+    let segments = reference_segments(path);
+    let mut out = String::with_capacity(path.len() + segments.len());
+
+    for segment in &segments {
+        out.push('/');
+        for ch in segment.chars() {
+            match ch {
+                '~' => out.push_str("~0"),
+                '/' => out.push_str("~1"),
+                _ => out.push(ch),
+            }
+        }
+    }
+
+    out
+}
+
+/// True when a `[..]` body is an array index — an optional leading `-` followed
+/// by one or more ASCII digits (e.g. `0`, `12`, `-1`).
+pub fn is_array_index_token(token: &str) -> bool {
+    let digits = token.strip_prefix('-').unwrap_or(token);
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Reduce a trimmed `[..]` body to its segment, dropping an empty one.
+fn bracket_segment(body: &str) -> Option<String> {
+    let key = strip_matching_quotes(body).unwrap_or(body);
+    (!key.is_empty()).then(|| key.to_string())
+}
+
+/// Strip one layer of quotes when the body opens and closes with the *same*
+/// quote character. A lone or mismatched quote is left in place, so it reads as
+/// part of the key rather than being silently peeled off.
+fn strip_matching_quotes(body: &str) -> Option<&str> {
+    let mut chars = body.chars();
+    let quote = chars.next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    chars.as_str().strip_suffix(quote)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segments(path: &str) -> Vec<String> {
+        reference_segments(path)
+    }
+
+    #[test]
+    fn splits_dotted_paths() {
+        assert_eq!(segments("data.order.id"), ["data", "order", "id"]);
+        assert_eq!(segments("data"), ["data"]);
+        assert_eq!(segments(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn bracket_quoted_body_is_one_opaque_key() {
+        // The divergence this module exists to remove: the dot belongs to the
+        // key, so this must NOT become ["data", "a", "b"].
+        assert_eq!(segments(r#"data["a.b"]"#), ["data", "a.b"]);
+        assert_eq!(segments("data['a.b']"), ["data", "a.b"]);
+        assert_eq!(segments(r#"data["plain"]"#), ["data", "plain"]);
+        assert_eq!(
+            segments(r#"data["a.b"]["c.d"]"#),
+            ["data", "a.b", "c.d"],
+            "consecutive quoted keys each stay whole"
+        );
+    }
+
+    #[test]
+    fn index_tokens_survive_as_raw_segments() {
+        assert_eq!(segments("items[0]"), ["items", "0"]);
+        assert_eq!(segments("items[-1]"), ["items", "-1"]);
+        assert_eq!(segments("items.0"), ["items", "0"]);
+        assert!(is_array_index_token("0"));
+        assert!(is_array_index_token("-1"));
+        assert!(!is_array_index_token("a"));
+        assert!(!is_array_index_token("-"));
+        assert!(!is_array_index_token(""));
+    }
+
+    #[test]
+    fn unquoted_non_numeric_body_is_a_plain_key() {
+        // Previously the validator read `bar` while the runtime kept the whole
+        // thing as the literal key `foo[bar]`.
+        assert_eq!(segments("foo[bar]"), ["foo", "bar"]);
+        assert_eq!(segments("foo[ bar ]"), ["foo", "bar"], "body is trimmed");
+    }
+
+    #[test]
+    fn mixes_dots_brackets_and_indices() {
+        assert_eq!(segments(r#"a["b.c"][0].d"#), ["a", "b.c", "0", "d"]);
+        assert_eq!(
+            segments(r#"steps.fetch.outputs[0]["order.id"]"#),
+            ["steps", "fetch", "outputs", "0", "order.id"]
+        );
+    }
+
+    #[test]
+    fn drops_empty_segments() {
+        assert_eq!(segments("data..order"), ["data", "order"]);
+        assert_eq!(segments("data."), ["data"]);
+        assert_eq!(segments("data[]"), ["data"]);
+        assert_eq!(segments(r#"data[""]"#), ["data"]);
+    }
+
+    #[test]
+    fn keeps_mismatched_quotes_as_key_text() {
+        assert_eq!(segments("foo['a\"]"), ["foo", "'a\""]);
+        assert_eq!(segments("foo[\"]"), ["foo", "\""]);
+    }
+
+    #[test]
+    fn unterminated_bracket_consumes_the_remainder() {
+        assert_eq!(segments("foo[bar"), ["foo", "bar"]);
+    }
+
+    #[test]
+    fn pointer_escapes_reserved_characters_in_segment_text() {
+        assert_eq!(to_json_pointer("data.order.id"), "/data/order/id");
+        assert_eq!(to_json_pointer("items[0]"), "/items/0");
+        assert_eq!(to_json_pointer(r#"data["a.b"]"#), "/data/a.b");
+        assert_eq!(to_json_pointer(r#"data["a/b"]"#), "/data/a~1b");
+        assert_eq!(to_json_pointer(r#"data["a~b"]"#), "/data/a~0b");
+        assert_eq!(to_json_pointer(""), "");
+    }
+
+    #[test]
+    fn pointer_segments_agree_with_the_tokenizer() {
+        // The pointer is a rendering of the same segments, so unescaping it has
+        // to reproduce them exactly.
+        for path in [
+            "data.order.id",
+            "items[0]",
+            r#"data["a.b"]"#,
+            r#"data["a/b"].c"#,
+            r#"a["b.c"][0].d"#,
+            "foo[bar]",
+        ] {
+            let from_pointer: Vec<String> = to_json_pointer(path)
+                .split('/')
+                .skip(1)
+                .map(|segment| segment.replace("~1", "/").replace("~0", "~"))
+                .collect();
+            assert_eq!(from_pointer, reference_segments(path), "path: {path}");
+        }
+    }
+}

--- a/crates/runtara-workflow-stdlib/src/reference_path.rs
+++ b/crates/runtara-workflow-stdlib/src/reference_path.rs
@@ -90,9 +90,28 @@ pub fn to_json_pointer(path: &str) -> String {
 
 /// True when a `[..]` body is an array index — an optional leading `-` followed
 /// by one or more ASCII digits (e.g. `0`, `12`, `-1`).
+///
+/// Shared with the validator so a segment that indexes an array at run time is
+/// also treated as an index at authoring time. A plain `parse::<usize>()` is
+/// *not* equivalent: it rejects the negative forms the resolver accepts.
 pub fn is_array_index_token(token: &str) -> bool {
     let digits = token.strip_prefix('-').unwrap_or(token);
     !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Resolve an index segment against an array of length `len`, supporting
+/// Python-style negative suffix indexing: `-1` is the last element, `-2` the
+/// second-to-last. Non-numeric segments and out-of-range negatives return
+/// `None`, so an unmatched index falls through to the resolver's null/default
+/// path exactly like an out-of-range positive index does.
+pub fn array_index(segment: &str, len: usize) -> Option<usize> {
+    let raw: i64 = segment.parse().ok()?;
+    if raw >= 0 {
+        usize::try_from(raw).ok()
+    } else {
+        // `unsigned_abs` avoids overflow at `i64::MIN`.
+        len.checked_sub(usize::try_from(raw.unsigned_abs()).ok()?)
+    }
 }
 
 /// Reduce a trimmed `[..]` body to its segment, dropping an empty one.
@@ -152,6 +171,28 @@ mod tests {
         assert!(!is_array_index_token("a"));
         assert!(!is_array_index_token("-"));
         assert!(!is_array_index_token(""));
+    }
+
+    #[test]
+    fn array_index_resolves_negatives_from_the_end() {
+        assert_eq!(array_index("0", 3), Some(0));
+        assert_eq!(array_index("2", 3), Some(2));
+        assert_eq!(array_index("-1", 3), Some(2));
+        assert_eq!(array_index("-3", 3), Some(0));
+        // Out of range in either direction is a miss, not a wrap-around.
+        assert_eq!(array_index("-4", 3), None);
+        assert_eq!(array_index("a", 3), None);
+    }
+
+    #[test]
+    fn negative_indices_are_index_tokens_not_keys() {
+        // The trap this pair exists to avoid: `parse::<usize>()` rejects the
+        // negative forms `array_index` resolves, so a validator using it would
+        // reject a reference the runtime happily resolves.
+        for token in ["-1", "-2", "-10"] {
+            assert!(is_array_index_token(token), "{token}");
+            assert!(token.parse::<usize>().is_err(), "{token}");
+        }
     }
 
     #[test]

--- a/crates/runtara-workflows/Cargo.toml
+++ b/crates/runtara-workflows/Cargo.toml
@@ -39,6 +39,11 @@ required-features = ["compiler"]
 
 [dependencies]
 runtara-dsl = { path = "../runtara-dsl", version = "8.7" }
+# Reference-path tokenization (`reference_path`), so validation splits a path
+# into exactly the segments the runtime will resolve. `default-features = false`
+# drops the SDK/HTTP runtime, leaving serde + serde_json + minijinja — all of
+# which this crate already depends on, so the dependency graph is unchanged.
+runtara-workflow-stdlib = { path = "../runtara-workflow-stdlib", version = "8.7", default-features = false }
 runtara-workflow-wit = { path = "../runtara-workflow-wit", version = "8.7", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -59,7 +64,6 @@ tempfile = "3"
 base64 = { workspace = true }
 wasmparser = "0.247"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-runtara-workflow-stdlib = { path = "../runtara-workflow-stdlib", version = "8.7", default-features = false }
 # Embedded-vs-CLI A/B in tests/direct_wasm_execute.rs: the composed component
 # must behave identically under the in-process WorkflowExecutor.
 runtara-component-host = { path = "../runtara-component-host" }

--- a/crates/runtara-workflows/src/validation.rs
+++ b/crates/runtara-workflows/src/validation.rs
@@ -76,7 +76,9 @@ use runtara_dsl::{
 // The runtime's own path tokenizer, so validation splits a reference into
 // exactly the segments a lookup will walk — in particular treating a
 // bracket-quoted body like `data["a.b"]` as one opaque key, not a nested path.
-use runtara_workflow_stdlib::reference_path::reference_segments;
+use runtara_workflow_stdlib::reference_path::{
+    array_index, is_array_index_token, reference_segments,
+};
 use std::collections::{HashMap, HashSet};
 
 // ============================================================================
@@ -4495,16 +4497,18 @@ fn extract_step_id_from_reference(ref_path: &str) -> Option<String> {
 }
 
 /// Extract variable name from a reference path like "variables.my_var" or "variables.counter.value"
+/// The variable a `variables.*` reference names, or `None` for any other root.
+///
+/// Tokenized rather than split on the first `.`, so a bracketed tail belongs to
+/// the path instead of the name: `variables.rows[-1].sku` names `rows`, not
+/// `rows[-1]`. Splitting naively here reported the whole `rows[-1]` as an
+/// unknown variable and stopped the reference ever reaching the path walk.
 fn extract_variable_name_from_reference(ref_path: &str) -> Option<String> {
-    if let Some(rest) = ref_path.strip_prefix("variables.") {
-        if let Some(dot_pos) = rest.find('.') {
-            return Some(rest[..dot_pos].to_string());
-        } else {
-            // Reference is just "variables.var_name"
-            return Some(rest.to_string());
-        }
+    let mut segments = reference_segments(ref_path).into_iter();
+    if segments.next().as_deref() != Some("variables") {
+        return None;
     }
-    None
+    segments.next()
 }
 
 /// Get the step type name for error messages.
@@ -4677,7 +4681,7 @@ fn validate_schema_reference_path(
         let segment = &segments[index];
 
         if current_field.field_type == SchemaFieldType::Array {
-            if segment.parse::<usize>().is_ok() {
+            if is_array_index_token(segment) {
                 if let Some(item_schema) = current_field.items.as_deref() {
                     current_field = item_schema;
                     known_prefix.push_str(&format!("[{}]", segment));
@@ -4796,7 +4800,10 @@ fn validate_variable_reference_path(
                 known_prefix.push_str(segment);
             }
             serde_json::Value::Array(items) => {
-                let Ok(index) = segment.parse::<usize>() else {
+                // Mirrors the runtime's `descend`: a non-index segment on an
+                // array is a shape error, while an index that lands out of
+                // range is a plain miss. Negative indices resolve from the end.
+                if !is_array_index_token(segment) {
                     result
                         .errors
                         .push(ValidationError::ReferenceNonObjectTraversal {
@@ -4807,8 +4814,10 @@ fn validate_variable_reference_path(
                             attempted_field: segment.clone(),
                         });
                     return;
-                };
-                let Some(next_value) = items.get(index) else {
+                }
+                let Some(next_value) =
+                    array_index(segment, items.len()).and_then(|index| items.get(index))
+                else {
                     result
                         .errors
                         .push(ValidationError::UndefinedReferenceField {
@@ -4821,7 +4830,7 @@ fn validate_variable_reference_path(
                     return;
                 };
                 current_value = next_value;
-                known_prefix.push_str(&format!("[{}]", index));
+                known_prefix.push_str(&format!("[{}]", segment));
             }
             other => {
                 result
@@ -9856,16 +9865,31 @@ mod tests {
 
     #[test]
     fn test_extract_variable_name_bracket_notation() {
-        // Note: Bracket notation is not yet supported for variable extraction.
-        // This test documents the current behavior. Supporting bracket notation
-        // could be added in the future if needed.
+        // Bracket notation now resolves through the shared tokenizer, so a
+        // quoted name is the variable and a bracketed tail stays part of the
+        // path. Previously every one of these returned `None`, so the variable
+        // went unchecked entirely.
         assert_eq!(
             extract_variable_name_from_reference("variables['my-var']"),
-            None // Bracket notation not supported
+            Some("my-var".to_string())
         );
         assert_eq!(
             extract_variable_name_from_reference("variables[\"my-var\"]"),
-            None // Bracket notation not supported
+            Some("my-var".to_string())
+        );
+        // A quoted name keeps its dots instead of being split.
+        assert_eq!(
+            extract_variable_name_from_reference("variables[\"a.b\"]"),
+            Some("a.b".to_string())
+        );
+        // An indexed tail belongs to the path, not the name.
+        assert_eq!(
+            extract_variable_name_from_reference("variables.rows[-1].sku"),
+            Some("rows".to_string())
+        );
+        assert_eq!(
+            extract_variable_name_from_reference("variables.rows[0]"),
+            Some("rows".to_string())
         );
     }
 
@@ -9961,16 +9985,119 @@ mod tests {
         );
     }
 
-    /// A bracket-quoted body is one opaque key, so `data["a.b"]` addresses the
-    /// literal field `a.b` rather than descending `a` then `b`. Validation and
-    /// the runtime resolver share one tokenizer
+    /// A bracket-quoted body is one opaque key, so `data.nested["a.b"]`
+    /// addresses the literal field `a.b` under `nested` rather than descending
+    /// `a` then `b`. Validation and the runtime resolver share one tokenizer
     /// (`runtara_workflow_stdlib::reference_path`), so what validates here is
     /// what resolves at run time — previously the runtime split this path and
     /// silently produced null for a reference the validator had accepted.
+    ///
+    /// Anchored one level down deliberately: a *root*-level bracket reference
+    /// like `data["a.b"]` never reaches schema validation at all, because
+    /// `parse_reference` splits on `.` and sees the root as `data["a`. That
+    /// bypass is a separate gap — testing this here against `data[..]` would
+    /// pass no matter what the schema says.
     #[test]
     fn test_data_reference_bracket_quoted_dotted_key_resolves_flat() {
+        // Both halves run against the same schema, so the assertions can only
+        // both hold if the bracket body is genuinely matched as one key.
+        let declared = validate_nested_bracket_reference(r#"data.nested["a.b"]"#);
+        assert!(
+            !declared.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UndefinedReferenceField { .. }
+                    | ValidationError::InvalidReferencePath { .. }
+            )),
+            "declared key `a.b` must validate: {:?}",
+            declared.errors
+        );
+
+        // The discriminating half: an undeclared key must be rejected, proving
+        // the reference actually reached the schema walk.
+        let undeclared = validate_nested_bracket_reference(r#"data.nested["a.c"]"#);
+        assert!(
+            undeclared.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UndefinedReferenceField { missing_field, .. }
+                    if missing_field == "a.c"
+            )),
+            "undeclared key `a.c` must be rejected: {:?}",
+            undeclared.errors
+        );
+    }
+
+    /// Validate a single-mapping workflow whose only reference is `reference`,
+    /// against an input schema declaring exactly `nested: { "a.b": string }`.
+    fn validate_nested_bracket_reference(reference: &str) -> ValidationResult {
         let mut mapping = HashMap::new();
-        mapping.insert("value".to_string(), ref_value(r#"data["a.b"]"#));
+        mapping.insert("value".to_string(), ref_value(reference));
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "agent".to_string(),
+            create_agent_step("agent", "transform", Some(mapping)),
+        );
+
+        let mut nested_props = HashMap::new();
+        nested_props.insert("a.b".to_string(), schema_field(SchemaFieldType::String));
+
+        let mut graph = create_basic_graph(steps, "agent");
+        graph
+            .input_schema
+            .insert("nested".to_string(), object_schema_field(nested_props));
+
+        validate_workflow(&graph, &test_catalog())
+    }
+
+    /// Negative array indices resolve Python-style at run time, so authoring
+    /// must accept them too. The schema walk previously gated on
+    /// `parse::<usize>()`, which rejects `-1`, so a declared array raised a
+    /// bogus traversal error for a reference the runtime resolves fine.
+    #[test]
+    fn test_data_reference_negative_array_index_is_accepted() {
+        let mut mapping = HashMap::new();
+        mapping.insert("last".to_string(), ref_value("data.items[-1].sku"));
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "agent".to_string(),
+            create_agent_step("agent", "transform", Some(mapping)),
+        );
+
+        let mut item_props = HashMap::new();
+        item_props.insert("sku".to_string(), schema_field(SchemaFieldType::String));
+        let mut items = schema_field(SchemaFieldType::Array);
+        items.items = Some(Box::new(object_schema_field(item_props)));
+
+        let mut graph = create_basic_graph(steps, "agent");
+        graph.input_schema.insert("items".to_string(), items);
+
+        let result = validate_workflow(&graph, &test_catalog());
+
+        assert!(
+            !result.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::ReferenceNonObjectTraversal { .. }
+                    | ValidationError::UndefinedReferenceField { .. }
+            )),
+            "negative index must validate against a declared array: {:?}",
+            result.errors
+        );
+    }
+
+    /// The same rule on the concrete-value walk used for `variables.*`, where
+    /// the index is resolved against the literal array rather than a schema.
+    ///
+    /// Spelled with dots rather than `rows[-1]` because `parse_reference` still
+    /// splits the variable name on the first `.`, so the bracket form is
+    /// reported as the unknown variable `rows[-1]` and never reaches this walk.
+    #[test]
+    fn test_variable_reference_negative_array_index_resolves_from_the_end() {
+        use runtara_dsl::{Variable, VariableType};
+
+        let mut mapping = HashMap::new();
+        mapping.insert("last".to_string(), ref_value("variables.rows.-1.sku"));
+        mapping.insert("past".to_string(), ref_value("variables.rows.-4.sku"));
 
         let mut steps = HashMap::new();
         steps.insert(
@@ -9979,19 +10106,35 @@ mod tests {
         );
 
         let mut graph = create_basic_graph(steps, "agent");
-        graph
-            .input_schema
-            .insert("a.b".to_string(), schema_field(SchemaFieldType::String));
+        graph.variables.insert(
+            "rows".to_string(),
+            Variable {
+                var_type: VariableType::Array,
+                value: serde_json::json!([{ "sku": "a" }, { "sku": "b" }, { "sku": "c" }]),
+                description: None,
+            },
+        );
 
         let result = validate_workflow(&graph, &test_catalog());
 
+        // `-1` is the last element, so `.sku` beyond it is a real field.
         assert!(
             !result.errors.iter().any(|error| matches!(
                 error,
-                ValidationError::UndefinedReferenceField { .. }
-                    | ValidationError::InvalidReferencePath { .. }
+                ValidationError::ReferenceNonObjectTraversal { attempted_field, .. }
+                    if attempted_field == "-1"
             )),
-            "{:?}",
+            "`-1` must resolve to the last element: {:?}",
+            result.errors
+        );
+        // `-4` is past the front of a 3-element array — still out of range.
+        assert!(
+            result.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UndefinedReferenceField { missing_field, .. }
+                    if missing_field == "-4"
+            )),
+            "`-4` must stay out of range: {:?}",
             result.errors
         );
     }

--- a/crates/runtara-workflows/src/validation.rs
+++ b/crates/runtara-workflows/src/validation.rs
@@ -73,6 +73,10 @@ use crate::dependency_analysis::{DependencyGraph, WorkflowReference};
 use runtara_dsl::{
     CompositeInner, ExecutionGraph, InputMapping, MappingValue, SchemaField, SchemaFieldType, Step,
 };
+// The runtime's own path tokenizer, so validation splits a reference into
+// exactly the segments a lookup will walk — in particular treating a
+// bracket-quoted body like `data["a.b"]` as one opaque key, not a nested path.
+use runtara_workflow_stdlib::reference_path::reference_segments;
 use std::collections::{HashMap, HashSet};
 
 // ============================================================================
@@ -4629,50 +4633,6 @@ const LEGAL_REFERENCE_ROOTS: &[&str] = &[
 fn reference_root(reference: &str) -> &str {
     let end = reference.find(['.', '[']).unwrap_or(reference.len());
     &reference[..end]
-}
-
-fn reference_segments(reference: &str) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let mut chars = reference.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        match ch {
-            '.' => {
-                if !current.is_empty() {
-                    segments.push(std::mem::take(&mut current));
-                }
-            }
-            '[' => {
-                if !current.is_empty() {
-                    segments.push(std::mem::take(&mut current));
-                }
-
-                let mut bracket = String::new();
-                for next in chars.by_ref() {
-                    if next == ']' {
-                        break;
-                    }
-                    bracket.push(next);
-                }
-
-                let bracket = bracket
-                    .trim()
-                    .trim_matches(|c| c == '\'' || c == '"')
-                    .to_string();
-                if !bracket.is_empty() {
-                    segments.push(bracket);
-                }
-            }
-            _ => current.push(ch),
-        }
-    }
-
-    if !current.is_empty() {
-        segments.push(current);
-    }
-
-    segments
 }
 
 /// True when `segments` begins with exactly `prefix` (caller has already
@@ -9995,6 +9955,72 @@ mod tests {
                     missing_field,
                     ..
                 } if known_prefix == "data.a" && missing_field == "d"
+            )),
+            "{:?}",
+            result.errors
+        );
+    }
+
+    /// A bracket-quoted body is one opaque key, so `data["a.b"]` addresses the
+    /// literal field `a.b` rather than descending `a` then `b`. Validation and
+    /// the runtime resolver share one tokenizer
+    /// (`runtara_workflow_stdlib::reference_path`), so what validates here is
+    /// what resolves at run time — previously the runtime split this path and
+    /// silently produced null for a reference the validator had accepted.
+    #[test]
+    fn test_data_reference_bracket_quoted_dotted_key_resolves_flat() {
+        let mut mapping = HashMap::new();
+        mapping.insert("value".to_string(), ref_value(r#"data["a.b"]"#));
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "agent".to_string(),
+            create_agent_step("agent", "transform", Some(mapping)),
+        );
+
+        let mut graph = create_basic_graph(steps, "agent");
+        graph
+            .input_schema
+            .insert("a.b".to_string(), schema_field(SchemaFieldType::String));
+
+        let result = validate_workflow(&graph, &test_catalog());
+
+        assert!(
+            !result.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UndefinedReferenceField { .. }
+                    | ValidationError::InvalidReferencePath { .. }
+            )),
+            "{:?}",
+            result.errors
+        );
+    }
+
+    /// The counterpart: with only a flat `a.b` key in the schema, the dotted
+    /// spelling is a genuine miss — it asks for a nested `a`, which is absent.
+    #[test]
+    fn test_data_reference_dotted_path_does_not_match_flat_key() {
+        let mut mapping = HashMap::new();
+        mapping.insert("value".to_string(), ref_value("data.a.b"));
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "agent".to_string(),
+            create_agent_step("agent", "transform", Some(mapping)),
+        );
+
+        let mut graph = create_basic_graph(steps, "agent");
+        graph
+            .input_schema
+            .insert("a.b".to_string(), schema_field(SchemaFieldType::String));
+
+        let result = validate_workflow(&graph, &test_catalog());
+
+        assert!(
+            result.errors.iter().any(|error| matches!(
+                error,
+                ValidationError::UndefinedDataReference { field_name, .. }
+                    if field_name == "a"
             )),
             "{:?}",
             result.errors

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -33,6 +33,7 @@ const FILTER_SIMPLE: &str = include_str!("fixtures/filter_simple.json");
 const SWITCH_VALUE_SIMPLE: &str = include_str!("fixtures/switch_value_simple.json");
 const SWITCH_ROUTING_SIMPLE: &str = include_str!("fixtures/switch_routing_simple.json");
 const GROUP_BY_SIMPLE: &str = include_str!("fixtures/group_by_simple.json");
+const BRACKET_QUOTED_DOTTED_KEY: &str = include_str!("fixtures/bracket_quoted_dotted_key.json");
 const DELAY_DYNAMIC: &str = include_str!("fixtures/delay_dynamic.json");
 const LOG_ALL_LEVELS: &str = include_str!("fixtures/log_all_levels.json");
 const ERROR_DIRECT_SIMPLE: &str = include_str!("fixtures/error_direct_simple.json");
@@ -2334,6 +2335,32 @@ fn direct_wasm_execute_finish_passthrough_reports_completion() {
     );
 
     assert_eq!(output, serde_json::json!({ "result": "direct-finish" }));
+}
+
+/// A bracket-quoted body is one opaque key, dots included, all the way through
+/// compile → compose → execute in the guest. The runtime used to rewrite
+/// `["a.b"]` to `.a.b` and split it, so a reference the validator had accepted
+/// as the literal field `a.b` resolved the (absent) nested path instead and
+/// silently produced null.
+#[test]
+fn direct_wasm_execute_resolves_bracket_quoted_dotted_key() {
+    let components_dir = direct_e2e_components_dir();
+
+    let output = run_direct_workflow(
+        &components_dir,
+        "direct-wasm-execute-bracket-quoted-dotted-key",
+        BRACKET_QUOTED_DOTTED_KEY,
+        br#"{"a.b":"flat-value","a":{"b":"nested-value"}}"#,
+    );
+
+    assert_eq!(
+        output,
+        serde_json::json!({
+            "flat": "flat-value",
+            "flatSingleQuoted": "flat-value",
+            "nested": "nested-value"
+        })
+    );
 }
 
 /// A single-Finish workflow that binds `data.count` under an `integer` type

--- a/crates/runtara-workflows/tests/fixtures/bracket_quoted_dotted_key.json
+++ b/crates/runtara-workflows/tests/fixtures/bracket_quoted_dotted_key.json
@@ -1,0 +1,29 @@
+{
+  "name": "Bracket Quoted Dotted Key",
+  "description": "Reads a literal dotted key via the bracket-quoted form alongside the equivalent nested path, so both spellings stay addressable",
+  "steps": {
+    "finish": {
+      "stepType": "Finish",
+      "id": "finish",
+      "inputMapping": {
+        "flat": {
+          "valueType": "reference",
+          "value": "data[\"a.b\"]"
+        },
+        "flatSingleQuoted": {
+          "valueType": "reference",
+          "value": "data['a.b']"
+        },
+        "nested": {
+          "valueType": "reference",
+          "value": "data.a.b"
+        }
+      }
+    }
+  },
+  "entryPoint": "finish",
+  "executionPlan": [],
+  "variables": {},
+  "inputSchema": {},
+  "outputSchema": {}
+}


### PR DESCRIPTION
… runtime

The validator and the runtime each scanned reference paths with their own tokenizer, and they disagreed on bracket bodies. The validator read `foo["a.b"]` as the single key `a.b`; the runtime rewrote the brackets to dots and split the result, yielding `a` then `b`. A reference to a literal dotted key therefore passed schema validation and then silently resolved to null at run time, and a genuinely-nested path written in bracket form was rejected even though the runtime would have descended it. Unquoted non-numeric bodies diverged the same way: `foo[bar]` was the key `bar` to the validator and the literal key `foo[bar]` to the runtime.

Extract the tokenizer into `runtara_workflow_stdlib::reference_path` and have both call it, so a path that validates against a schema key resolves to that same key. A bracket-quoted body is now one opaque key, dots included; an unquoted body is taken verbatim, covering both index tokens and bare keys. Index-vs-key is still decided by token shape at lookup time.

`runtara-workflows` promotes its existing stdlib dev-dependency to a real one. With `default-features = false` that is serde, serde_json and minijinja, all already present, so the dependency graph is unchanged.

Verified end to end through compile -> compose -> execute in the guest, not just at the unit level.