### PR TITLE
SYN-591: Paginate workflow folders with the workflow list

### DIFF
--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.test.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.test.tsx
@@ -1,0 +1,205 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowDto } from '@/generated/RuntaraRuntimeApi';
+import { WorkflowsGrid } from './index';
+
+const FOLDER_COUNT = 12;
+const WORKFLOW_COUNT = 43;
+const PAGE_SIZE = 10;
+
+const mocks = vi.hoisted(() => ({
+  getWorkflowsInFolder: vi.fn(),
+}));
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { access_token: 'test-token' } }),
+}));
+
+vi.mock('@/main.tsx', () => ({
+  queryClient: { invalidateQueries: vi.fn() },
+}));
+
+vi.mock('../../hooks/useFolders', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useFolders')>()),
+  useFolders: () => ({ data: undefined }),
+}));
+
+vi.mock('@/features/workflows/queries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/features/workflows/queries')>()),
+  getWorkflowsInFolder: mocks.getWorkflowsInFolder,
+}));
+
+/** Workflow N is the Nth most recent, so the default "updated desc" sort keeps 1…43 order. */
+function buildWorkflow(index: number): WorkflowDto {
+  const updated = new Date(
+    Date.UTC(2026, 0, 1) - index * 3_600_000
+  ).toISOString();
+
+  return {
+    id: `wf-${index}`,
+    name: `Workflow ${String(index).padStart(2, '0')}`,
+    description: '',
+    created: updated,
+    updated,
+    currentVersionNumber: 1,
+    lastVersionNumber: 1,
+    executionGraph: {},
+    inputSchema: {},
+    outputSchema: {},
+    path: '/',
+  } as unknown as WorkflowDto;
+}
+
+const allWorkflows = Array.from({ length: WORKFLOW_COUNT }, (_, i) =>
+  buildWorkflow(i + 1)
+);
+
+const allFolders = Array.from({ length: FOLDER_COUNT }, (_, i) => {
+  const name = `folder-${String(i + 1).padStart(2, '0')}`;
+  return { name, path: `/${name}/` };
+});
+
+/** Stands in for GET /api/runtime/workflows, honouring its page/pageSize contract. */
+function serveWorkflowPage(_token: string, params: Record<string, any>) {
+  const pageSize = params.pageSize ?? 20;
+  const page = params.page ?? 0;
+  const start = page * pageSize;
+  const content = allWorkflows.slice(start, start + pageSize);
+
+  return Promise.resolve({
+    data: {
+      content,
+      first: page === 0,
+      last: start + pageSize >= WORKFLOW_COUNT,
+      number: page,
+      numberOfElements: content.length,
+      size: pageSize,
+      totalElements: WORKFLOW_COUNT,
+      totalPages: Math.ceil(WORKFLOW_COUNT / pageSize),
+    },
+  });
+}
+
+function renderGrid() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/workflows']}>
+        <WorkflowsGrid searchTerm="" folderPath="/" folders={allFolders} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function folderRowNames(): string[] {
+  return allFolders
+    .map((folder) => folder.name)
+    .filter((name) => screen.queryByText(name) !== null);
+}
+
+async function goToNextPage() {
+  await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+}
+
+describe('WorkflowsGrid pagination', () => {
+  beforeEach(() => {
+    mocks.getWorkflowsInFolder.mockReset();
+    mocks.getWorkflowsInFolder.mockImplementation(serveWorkflowPage);
+  });
+
+  it('pages folders and workflows as one row set instead of repeating folders', async () => {
+    renderGrid();
+
+    // Page 1 — 12 folders overflow a 10-row page, so it is folders only.
+    await screen.findByText('folder-01');
+    expect(folderRowNames()).toEqual([
+      'folder-01',
+      'folder-02',
+      'folder-03',
+      'folder-04',
+      'folder-05',
+      'folder-06',
+      'folder-07',
+      'folder-08',
+      'folder-09',
+      'folder-10',
+    ]);
+    expect(screen.queryByText('Workflow 01')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(`Rows 1–10 of 55 · ${FOLDER_COUNT} folders`)
+    ).toBeInTheDocument();
+
+    // Page 2 — the last two folders, then workflows from the very beginning.
+    await goToNextPage();
+    await screen.findByText('Workflow 01');
+    expect(folderRowNames()).toEqual(['folder-11', 'folder-12']);
+    expect(screen.getByText('Workflow 08')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow 09')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Rows 11–20 of 55 · 12 folders')
+    ).toBeInTheDocument();
+
+    // Page 3 — no folder rows at all: the bug rendered all 12 again right here.
+    await goToNextPage();
+    await screen.findByText('Workflow 09');
+    expect(folderRowNames()).toEqual([]);
+    expect(screen.getByText('Workflow 18')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow 08')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workflow 19')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Rows 21–30 of 55 · 12 folders')
+    ).toBeInTheDocument();
+  });
+
+  it('stitches the two server pages a folder-shifted window straddles', async () => {
+    renderGrid();
+
+    await screen.findByText('folder-01');
+    await goToNextPage();
+    await goToNextPage();
+    await screen.findByText('Workflow 09');
+
+    // Workflows 9–18 live across server pages 0 and 1 of a 10-row page size.
+    const requestedPages = mocks.getWorkflowsInFolder.mock.calls
+      .filter(([, params]) => params.pageSize === PAGE_SIZE)
+      .map(([, params]) => params.page);
+    expect(requestedPages).toContain(0);
+    expect(requestedPages).toContain(1);
+  });
+
+  it('fills the first page with workflows when the folder list is short', async () => {
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter initialEntries={['/workflows']}>
+          <WorkflowsGrid
+            searchTerm=""
+            folderPath="/"
+            folders={allFolders.slice(0, 3)}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await screen.findByText('Workflow 01');
+    expect(folderRowNames()).toEqual(['folder-01', 'folder-02', 'folder-03']);
+    expect(screen.getByText('Workflow 07')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow 08')).not.toBeInTheDocument();
+    expect(screen.getByText('Rows 1–10 of 46 · 3 folders')).toBeInTheDocument();
+
+    await goToNextPage();
+    await screen.findByText('Workflow 08');
+    expect(folderRowNames()).toEqual([]);
+    expect(screen.getByText('Workflow 17')).toBeInTheDocument();
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
@@ -19,6 +19,11 @@ import { queryKeys } from '@/shared/queries/query-keys.ts';
 import { queryClient } from '@/main.tsx';
 import { folderCountLabel } from './folder-count-label';
 import {
+  folderWorkflowWindow,
+  rowPageCount,
+  workflowServerSlice,
+} from './row-window';
+import {
   cloneWorkflow,
   getWorkflowsInFolder,
   moveWorkflowToFolder,
@@ -161,6 +166,24 @@ export function WorkflowsGrid({
   // Fetch folders for move dialog
   const { data: foldersData } = useFolders();
 
+  // Folders and workflows are one row set, folders first: this page's folder
+  // slice comes off the client-side folder list, and whatever room is left is
+  // filled with workflows continuing from where the folders end.
+  const folderCount = folders.length;
+  const rowWindow = useMemo(
+    () => folderWorkflowWindow(folderCount, page, pageSize),
+    [folderCount, page, pageSize]
+  );
+  const workflowSlice = useMemo(
+    () =>
+      workflowServerSlice(
+        rowWindow.workflowOffset,
+        rowWindow.workflowLimit,
+        pageSize
+      ),
+    [rowWindow.workflowOffset, rowWindow.workflowLimit, pageSize]
+  );
+
   const {
     data: response,
     isFetching,
@@ -169,27 +192,55 @@ export function WorkflowsGrid({
   } = useCustomQuery({
     queryKey: [
       ...queryKeys.workflows.inFolder(folderPath ?? '/', false),
-      page,
+      workflowSlice.page,
+      workflowSlice.skip,
+      workflowSlice.take,
       pageSize,
       searchTerm,
     ],
-    queryFn: (token: string) =>
-      getWorkflowsInFolder(token, {
-        path: folderPath,
-        recursive: false,
-        page,
-        pageSize,
-        search: searchTerm?.trim() || undefined,
-      }),
+    queryFn: async (token: string) => {
+      const requestPage = (serverPage: number) =>
+        getWorkflowsInFolder(token, {
+          path: folderPath,
+          recursive: false,
+          page: serverPage,
+          pageSize,
+          search: searchTerm?.trim() || undefined,
+        });
+
+      const first = await requestPage(workflowSlice.page);
+      const content = (first.data?.content ?? []).slice(
+        workflowSlice.skip,
+        workflowSlice.skip + workflowSlice.take
+      );
+
+      // A folder block that is not a multiple of pageSize leaves every later
+      // window starting mid-page, so the tail of the page comes from the next one.
+      if (
+        content.length < workflowSlice.take &&
+        workflowSlice.page + 1 < (first.data?.totalPages ?? 0)
+      ) {
+        const second = await requestPage(workflowSlice.page + 1);
+        content.push(
+          ...(second.data?.content ?? []).slice(
+            0,
+            workflowSlice.take - content.length
+          )
+        );
+      }
+
+      return {
+        content: content as WorkflowDto[],
+        totalElements: first.data?.totalElements ?? 0,
+      };
+    },
   });
 
   // Extract workflows array and pagination info from paginated response
-  const workflows = useMemo(
-    () => (response?.data?.content || []) as WorkflowDto[],
-    [response?.data?.content]
-  );
-  const totalElements = response?.data?.totalElements ?? 0;
-  const totalPages = response?.data?.totalPages ?? 1;
+  const workflows = useMemo(() => response?.content ?? [], [response?.content]);
+  const workflowTotal = response?.totalElements ?? 0;
+  const totalElements = folderCount + workflowTotal;
+  const totalPages = rowPageCount(folderCount, workflowTotal, pageSize);
   // Server handles both folder and search filtering via query parameters
   // Client-side: sort only
   const filteredWorkflows = useMemo(() => {
@@ -374,9 +425,19 @@ export function WorkflowsGrid({
     [moveTarget, moveMutation]
   );
 
-  const hasFolders = folders.length > 0;
-  const hasWorkflows = filteredWorkflows.length > 0;
-  const hasContent = hasFolders || hasWorkflows;
+  const visibleFolders = useMemo(
+    () =>
+      folders.slice(
+        rowWindow.folderStart,
+        rowWindow.folderStart + rowWindow.folderTake
+      ),
+    [folders, rowWindow.folderStart, rowWindow.folderTake]
+  );
+
+  const hasFolders = folderCount > 0;
+  // Emptiness is a property of the whole listing, not of the page being viewed:
+  // a page filled entirely with folders is not an empty workflow list.
+  const hasContent = hasFolders || workflowTotal > 0;
 
   // Pagination display values
   const startRow = totalElements === 0 ? 0 : page * pageSize + 1;
@@ -427,7 +488,7 @@ export function WorkflowsGrid({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {folders.map((folder) => {
+          {visibleFolders.map((folder) => {
             const count = folderWorkflowCounts[folder.path];
             return (
               <TableRow
@@ -494,7 +555,7 @@ export function WorkflowsGrid({
               pendingActionType={pendingAction?.type}
             />
           ))}
-          {!hasWorkflows && (
+          {workflowTotal === 0 && (
             <TableRow className="hover:bg-transparent">
               <TableCell
                 colSpan={4}
@@ -518,7 +579,7 @@ export function WorkflowsGrid({
             <TableStatusFooter
               left={`Rows ${startRow}–${endRow} of ${totalElements.toLocaleString()}${
                 hasFolders
-                  ? ` · ${folders.length} folder${folders.length === 1 ? '' : 's'}`
+                  ? ` · ${folderCount} folder${folderCount === 1 ? '' : 's'}`
                   : ''
               }`}
               right={

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/row-window.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/row-window.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  folderWorkflowWindow,
+  rowPageCount,
+  workflowServerSlice,
+} from './row-window';
+
+describe('folderWorkflowWindow', () => {
+  it('fills the page with workflows when there are no folders', () => {
+    expect(folderWorkflowWindow(0, 0, 10)).toEqual({
+      folderStart: 0,
+      folderTake: 0,
+      workflowOffset: 0,
+      workflowLimit: 10,
+    });
+    expect(folderWorkflowWindow(0, 3, 10)).toEqual({
+      folderStart: 0,
+      folderTake: 0,
+      workflowOffset: 30,
+      workflowLimit: 10,
+    });
+  });
+
+  it('puts folders first and fills the rest of the page with workflows', () => {
+    expect(folderWorkflowWindow(3, 0, 10)).toEqual({
+      folderStart: 0,
+      folderTake: 3,
+      workflowOffset: 0,
+      workflowLimit: 7,
+    });
+  });
+
+  it('never repeats folders on later pages', () => {
+    // The bug: page 2 used to render all 3 folders again above its workflows.
+    expect(folderWorkflowWindow(3, 1, 10)).toEqual({
+      folderStart: 3,
+      folderTake: 0,
+      workflowOffset: 7,
+      workflowLimit: 10,
+    });
+  });
+
+  it('spreads a folder list longer than a page across pages', () => {
+    expect(folderWorkflowWindow(12, 0, 10)).toEqual({
+      folderStart: 0,
+      folderTake: 10,
+      workflowOffset: 0,
+      workflowLimit: 0,
+    });
+    // Boundary page: the last folders, then workflows from the very beginning.
+    expect(folderWorkflowWindow(12, 1, 10)).toEqual({
+      folderStart: 10,
+      folderTake: 2,
+      workflowOffset: 0,
+      workflowLimit: 8,
+    });
+    expect(folderWorkflowWindow(12, 2, 10)).toEqual({
+      folderStart: 12,
+      folderTake: 0,
+      workflowOffset: 8,
+      workflowLimit: 10,
+    });
+  });
+
+  it('starts workflows on a clean page when folders fill an exact number of pages', () => {
+    expect(folderWorkflowWindow(20, 2, 10)).toEqual({
+      folderStart: 20,
+      folderTake: 0,
+      workflowOffset: 0,
+      workflowLimit: 10,
+    });
+  });
+});
+
+describe('workflowServerSlice', () => {
+  it('maps an aligned window straight onto a server page', () => {
+    expect(workflowServerSlice(0, 10, 10)).toEqual({
+      page: 0,
+      skip: 0,
+      take: 10,
+    });
+    expect(workflowServerSlice(30, 10, 10)).toEqual({
+      page: 3,
+      skip: 0,
+      take: 10,
+    });
+  });
+
+  it('reports a window that straddles two server pages', () => {
+    const slice = workflowServerSlice(7, 10, 10);
+
+    expect(slice).toEqual({ page: 0, skip: 7, take: 10 });
+    // skip + take past pageSize is the caller's cue to fetch the next page too.
+    expect(slice.skip + slice.take).toBeGreaterThan(10);
+  });
+
+  it('handles a partial window at the folder boundary', () => {
+    expect(workflowServerSlice(0, 8, 10)).toEqual({
+      page: 0,
+      skip: 0,
+      take: 8,
+    });
+  });
+
+  it('takes nothing for a page made entirely of folders', () => {
+    expect(workflowServerSlice(0, 0, 10)).toEqual({
+      page: 0,
+      skip: 0,
+      take: 0,
+    });
+  });
+});
+
+describe('rowPageCount', () => {
+  it('counts folders and workflows as one row set', () => {
+    expect(rowPageCount(12, 43, 10)).toBe(6);
+    expect(rowPageCount(0, 43, 10)).toBe(5);
+    expect(rowPageCount(3, 7, 10)).toBe(1);
+    expect(rowPageCount(3, 8, 10)).toBe(2);
+  });
+
+  it('always reports at least one page', () => {
+    expect(rowPageCount(0, 0, 10)).toBe(1);
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/row-window.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/row-window.ts
@@ -1,0 +1,74 @@
+/**
+ * Pagination math for a listing whose rows are folders first, then workflows.
+ *
+ * The two halves arrive differently: the folder endpoint returns the whole child
+ * list in one response, while workflows are paginated server-side. Paging them
+ * independently is what made the same folders reappear above every page, so the
+ * grid treats them as a single row set and slices both from one page index.
+ */
+
+export interface RowWindow {
+  /** Index of this page's first folder row within the folder list. */
+  folderStart: number;
+  /** How many folder rows this page holds. */
+  folderTake: number;
+  /** Index of this page's first workflow row within the workflow set. */
+  workflowOffset: number;
+  /** How many workflow rows this page holds, once folders have taken theirs. */
+  workflowLimit: number;
+}
+
+/** Split one page of the combined listing into its folder and workflow parts. */
+export function folderWorkflowWindow(
+  folderCount: number,
+  page: number,
+  pageSize: number
+): RowWindow {
+  const rowOffset = Math.max(0, page) * pageSize;
+  const folderStart = Math.min(rowOffset, folderCount);
+  const folderTake = Math.min(folderCount - folderStart, pageSize);
+
+  return {
+    folderStart,
+    folderTake,
+    workflowOffset: Math.max(0, rowOffset - folderCount),
+    workflowLimit: pageSize - folderTake,
+  };
+}
+
+export interface WorkflowServerSlice {
+  /** 0-based page to request from the workflow listing API. */
+  page: number;
+  /** Rows to drop from the front of that page. */
+  skip: number;
+  /** Rows to keep after dropping `skip` of them. */
+  take: number;
+}
+
+/**
+ * Translate an arbitrary `[offset, offset + limit)` workflow window into the
+ * page-based listing API.
+ *
+ * The API only offsets by whole pages, so a window that starts mid-page — which
+ * is every window once a folder block that is not a multiple of `pageSize` sits
+ * in front of it — spans two server pages. `skip + take > pageSize` is the caller's
+ * signal that it has to fetch the following page too.
+ */
+export function workflowServerSlice(
+  offset: number,
+  limit: number,
+  pageSize: number
+): WorkflowServerSlice {
+  const page = Math.floor(offset / pageSize);
+
+  return { page, skip: offset - page * pageSize, take: limit };
+}
+
+/** Pages needed for `folderCount` folder rows followed by `workflowCount` workflows. */
+export function rowPageCount(
+  folderCount: number,
+  workflowCount: number,
+  pageSize: number
+): number {
+  return Math.max(1, Math.ceil((folderCount + workflowCount) / pageSize));
+}


### PR DESCRIPTION
Folder rows were rendered from the full child-folder list on every page of the workflows table while only workflows were paginated, so the same folders reappeared above page 2, page 3, and so on, and a "10 rows per page" page actually held folders + 10 workflows.

Folders and workflows are now one row set, folders first: each page takes its folder slice from the folder list and fills the remaining rows with workflows continuing from where the folders end, so a folder list longer than a page spreads across pages instead of repeating. The listing API offsets by whole pages only, so a window shifted by a folder block that is not a multiple of the page size is stitched from two server pages.