### PR TITLE
SYN-587: Offer chat only on workflows that can hold one

### DIFF
--- a/crates/runtara-server/frontend/e2e/fixtures/builders.ts
+++ b/crates/runtara-server/frontend/e2e/fixtures/builders.ts
@@ -77,6 +77,9 @@ export function buildWorkflow(
     created: nowIso(),
     updated: nowIso(),
     path: '/',
+    // Chat-capable by default so specs exercise the chat surface; pass
+    // `supportsChat: false` to get the "does not support chat" fallback.
+    supportsChat: true,
     ...overrides,
   } as WorkflowDto;
 }

--- a/crates/runtara-server/frontend/e2e/tests/mocked/workflows/chat-unsupported.mocked.spec.ts
+++ b/crates/runtara-server/frontend/e2e/tests/mocked/workflows/chat-unsupported.mocked.spec.ts
@@ -1,0 +1,79 @@
+import type { Route } from '@playwright/test';
+import { buildWorkflow, expect, test } from '../../../fixtures';
+import { WorkflowChatPage } from '../../../pages/WorkflowExtraPages';
+import { appPath } from '../../../utils/app-path';
+
+/** Same shape the mock fixture uses, so tenant-prefixed URLs still match. */
+function runtimeUrl(suffix: string): RegExp {
+  const escaped = suffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`/api/runtime(?:/[^/]+)?/${escaped}(?:\\?[^/]*)?$`);
+}
+
+test.describe('Workflow chat on an unsupported workflow (mocked)', () => {
+  test('withholds the Chat action from a workflow that never waits', async ({
+    page,
+    mockApi,
+  }) => {
+    const chattable = buildWorkflow({
+      id: 'scn_chat_yes',
+      name: 'Support agent',
+      supportsChat: true,
+    });
+    const plain = buildWorkflow({
+      id: 'scn_chat_no',
+      name: 'Nightly export',
+      supportsChat: false,
+    });
+
+    await mockApi.bootstrap(page);
+    await mockApi.workflows.list(page, [chattable, plain]);
+
+    await page.goto(appPath('/workflows'));
+
+    // Both rows render, so the single missing action below is the gate rather
+    // than a list that failed to load.
+    const chattableRow = page.getByRole('row', { name: /Support agent/ });
+    const plainRow = page.getByRole('row', { name: /Nightly export/ });
+    await expect(chattableRow).toBeVisible();
+    await expect(plainRow).toBeVisible();
+
+    await expect(chattableRow.getByTitle('Chat')).toHaveCount(1);
+    await expect(plainRow.getByTitle('Chat')).toHaveCount(0);
+    await expect(plainRow.getByTitle('Start')).toHaveCount(1);
+  });
+
+  test('explains the dead end and opens no session on a direct URL', async ({
+    page,
+    mockApi,
+  }) => {
+    const workflow = buildWorkflow({
+      id: 'scn_chat_none',
+      name: 'Nightly export',
+      supportsChat: false,
+    });
+
+    let sessionRequests = 0;
+
+    await mockApi.bootstrap(page);
+    await mockApi.workflows.get(page, workflow.id, workflow);
+    await mockApi.raw(
+      page,
+      runtimeUrl(`workflows/${workflow.id}/sessions`),
+      async (route: Route) => {
+        sessionRequests += 1;
+        await route.fulfill({ status: 200, body: '' });
+      }
+    );
+
+    // Bookmarks and hand-typed URLs still reach the page — hiding the row
+    // action removes the dead end, not the safety net.
+    const view = new WorkflowChatPage(page, workflow.id);
+    await view.goto();
+
+    await expect(
+      page.getByText('This workflow does not support chat')
+    ).toBeVisible();
+    await expect(page.getByPlaceholder('Type a message...')).toHaveCount(0);
+    expect(sessionRequests).toBe(0);
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowCard/index.test.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowCard/index.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowDto } from '@/generated/RuntaraRuntimeApi';
+import { Table, TableBody } from '@/shared/components/ui/table';
+import { WorkflowCard } from './index';
+
+function buildWorkflow(overrides: Partial<WorkflowDto> = {}): WorkflowDto {
+  return {
+    id: 'wf-1',
+    name: 'Probe workflow',
+    description: '',
+    created: '2026-07-27T10:00:00.000Z',
+    updated: '2026-07-27T10:00:00.000Z',
+    currentVersionNumber: 1,
+    lastVersionNumber: 1,
+    executionGraph: {},
+    inputSchema: {},
+    outputSchema: {},
+    path: '/',
+    ...overrides,
+  } as unknown as WorkflowDto;
+}
+
+function renderCard(workflow: WorkflowDto, onChat = vi.fn()) {
+  render(
+    <Table>
+      <TableBody>
+        <WorkflowCard
+          workflow={workflow}
+          onUpdate={vi.fn()}
+          onDelete={vi.fn()}
+          onSchedule={vi.fn()}
+          onClone={vi.fn()}
+          onChat={onChat}
+        />
+      </TableBody>
+    </Table>
+  );
+}
+
+describe('WorkflowCard chat action', () => {
+  it('offers Chat on a workflow that can hold a conversation', () => {
+    renderCard(buildWorkflow({ supportsChat: true }));
+
+    expect(screen.getByTitle('Chat')).toBeInTheDocument();
+  });
+
+  it('withholds Chat from a workflow with no step that waits for a reply', () => {
+    renderCard(buildWorkflow({ supportsChat: false }));
+
+    // The other row actions still render, so the absence below is the gate
+    // rather than a card that failed to render at all.
+    expect(screen.getByTitle('Start')).toBeInTheDocument();
+    expect(screen.getByTitle('Edit')).toBeInTheDocument();
+    expect(screen.queryByTitle('Chat')).not.toBeInTheDocument();
+  });
+
+  it('withholds Chat when the server did not report the capability', () => {
+    // A response predating `supportsChat` must not be read as "yes".
+    renderCard(buildWorkflow());
+
+    expect(screen.queryByTitle('Chat')).not.toBeInTheDocument();
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowCard/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowCard/index.tsx
@@ -55,6 +55,10 @@ export function WorkflowCard({
   const rawSchema =
     (workflow as any).inputSchema ?? (workflow as any).input_schema ?? {};
   const hasInputs = parseSchema(rawSchema).length > 0;
+  // The server answers whether this workflow has a step that waits for a reply.
+  // Without one the chat surface accepts messages nothing ever reads, so the
+  // row does not offer the action at all.
+  const supportsChat = workflow.supportsChat === true;
 
   return (
     <TableRow className={cn('group', className)}>
@@ -109,7 +113,7 @@ export function WorkflowCard({
               )}
             </Button>
           </Can>
-          {onChat && (
+          {onChat && supportsChat && (
             <Button
               variant="secondary"
               size="icon-sm"

--- a/crates/runtara-server/frontend/src/features/workflows/pages/Chat/index.test.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/pages/Chat/index.test.tsx
@@ -1,0 +1,174 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowDto } from '@/generated/RuntaraRuntimeApi';
+import { useChatStore } from '@/features/workflows/stores/chatStore';
+import { ChatPage } from './index';
+
+const mocks = vi.hoisted(() => ({
+  getWorkflow: vi.fn(),
+  getWorkflowInstance: vi.fn(),
+  createChatSession: vi.fn(),
+  fetchChatHistory: vi.fn(),
+}));
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { access_token: 'test-token' } }),
+}));
+
+vi.mock('@/features/workflows/queries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/features/workflows/queries')>()),
+  getWorkflow: mocks.getWorkflow,
+  getWorkflowInstance: mocks.getWorkflowInstance,
+}));
+
+vi.mock('@/features/workflows/queries/chat', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/features/workflows/queries/chat')
+  >()),
+  createChatSession: mocks.createChatSession,
+  fetchChatHistory: mocks.fetchChatHistory,
+}));
+
+const WORKFLOW_ID = 'wf-chat';
+const INSTANCE_ID = 'inst-chat';
+
+function buildWorkflow(supportsChat: boolean): WorkflowDto {
+  return {
+    id: WORKFLOW_ID,
+    name: 'Probe workflow',
+    description: '',
+    created: '2026-07-27T10:00:00.000Z',
+    updated: '2026-07-27T10:00:00.000Z',
+    currentVersionNumber: 1,
+    lastVersionNumber: 1,
+    executionGraph: {},
+    inputSchema: {},
+    outputSchema: {},
+    path: '/',
+    supportsChat,
+  } as unknown as WorkflowDto;
+}
+
+function renderChat(instanceId?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const entry = instanceId
+    ? `/workflows/${WORKFLOW_ID}/chat/${instanceId}`
+    : `/workflows/${WORKFLOW_ID}/chat`;
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/workflows/:workflowId/chat" element={<ChatPage />} />
+          <Route
+            path="/workflows/:workflowId/chat/:instanceId"
+            element={<ChatPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.getState().resetChat();
+  // An SSE response that closes immediately — enough to prove the session was
+  // opened without standing up a real stream.
+  mocks.createChatSession.mockResolvedValue({
+    body: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+  } as unknown as Response);
+  mocks.getWorkflowInstance.mockResolvedValue({ inputs: { data: {} } });
+  mocks.fetchChatHistory.mockResolvedValue([]);
+});
+
+describe('ChatPage on a workflow that cannot chat', () => {
+  it('explains the dead end instead of opening a session', async () => {
+    mocks.getWorkflow.mockResolvedValue({ data: buildWorkflow(false) });
+
+    renderChat();
+
+    expect(
+      await screen.findByText('This workflow does not support chat')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/needs a step that waits for your reply/i)
+    ).toBeInTheDocument();
+
+    // The composer is gone, so there is nothing to type into and lose.
+    expect(
+      screen.queryByPlaceholderText('Type a message...')
+    ).not.toBeInTheDocument();
+    expect(mocks.createChatSession).not.toHaveBeenCalled();
+  });
+
+  it('does not open a session while the workflow is still loading', async () => {
+    // Never resolves — the page must not start anything on an assumption.
+    mocks.getWorkflow.mockReturnValue(new Promise(() => {}));
+
+    renderChat();
+
+    await waitFor(() => {
+      expect(mocks.createChatSession).not.toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByText('This workflow does not support chat')
+    ).not.toBeInTheDocument();
+  });
+
+  it('still resumes an existing run, which may be holding a pending input', async () => {
+    // Invocation History links here for a run waiting on a reply. If the
+    // workflow lost its wait step since that run started, the transcript and
+    // the composer must survive — refusing here would strand the reply.
+    mocks.getWorkflow.mockResolvedValue({ data: buildWorkflow(false) });
+
+    renderChat(INSTANCE_ID);
+
+    await waitFor(() => {
+      expect(mocks.fetchChatHistory).toHaveBeenCalledWith(
+        'test-token',
+        WORKFLOW_ID,
+        INSTANCE_ID
+      );
+    });
+    expect(
+      screen.queryByText('This workflow does not support chat')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Type a message...')
+    ).toBeInTheDocument();
+    // Resuming attaches to the existing run rather than starting another.
+    expect(mocks.createChatSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatPage on a chat-capable workflow', () => {
+  it('opens a session and offers the composer', async () => {
+    mocks.getWorkflow.mockResolvedValue({ data: buildWorkflow(true) });
+
+    renderChat();
+
+    await waitFor(() => {
+      expect(mocks.createChatSession).toHaveBeenCalledWith(
+        'test-token',
+        WORKFLOW_ID,
+        expect.anything()
+      );
+    });
+    expect(
+      screen.queryByText('This workflow does not support chat')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Type a message...')
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/pages/Chat/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/pages/Chat/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, MessageSquareOff } from 'lucide-react';
+import { WorkflowDto } from '@/generated/RuntaraRuntimeApi';
 import { Button } from '@/shared/components/ui/button.tsx';
 import { usePageTitle } from '@/shared/hooks/usePageTitle';
 import { useCustomQuery } from '@/shared/hooks/api';
@@ -29,7 +30,21 @@ export function ChatPage() {
     enabled: !!workflowId,
   });
 
-  const workflowName = (workflowResponse as any)?.data?.name ?? 'Chat';
+  const workflow = (workflowResponse as { data?: WorkflowDto } | undefined)
+    ?.data;
+  const workflowName = workflow?.name ?? 'Chat';
+
+  // The server reports whether the graph contains a step that waits for a
+  // reply. Without one nothing ever reads what is typed here, so starting a
+  // session is a dead end and the page says so instead. Direct URLs still land
+  // here — this is the fallback for them, not a redirect.
+  //
+  // Resuming a run (`:instanceId`) is exempt: it already has a transcript, and
+  // Invocation History only links here for a run that is holding a pending
+  // input. Refusing that would block the one reply the user came to give.
+  const isWorkflowLoaded = !!workflow;
+  const supportsChat = workflow?.supportsChat === true;
+  const isDeadEnd = isWorkflowLoaded && !instanceId && !supportsChat;
 
   usePageTitle(`Chat - ${workflowName}`);
 
@@ -55,6 +70,10 @@ export function ChatPage() {
   // Initialize or resume chat on mount
   useEffect(() => {
     if (!workflowId) return;
+    // Nothing starts until the workflow has answered — a new session on a
+    // workflow that never waits allocated an instance for a chat that could
+    // never reply.
+    if (!isWorkflowLoaded || isDeadEnd) return;
     if (initRef.current) return;
     initRef.current = true;
 
@@ -113,7 +132,7 @@ export function ChatPage() {
       cancelStream();
       useChatStore.getState().resetChat();
     };
-  }, [workflowId, instanceId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workflowId, instanceId, isWorkflowLoaded, isDeadEnd]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleBack = useCallback(() => {
     navigate(`/workflows/${workflowId}`);
@@ -151,18 +170,37 @@ export function ChatPage() {
         </div>
       )}
 
-      {/* Message list */}
-      <ChatMessageList messages={messages} />
+      {isDeadEnd ? (
+        <div className="flex flex-1 flex-col items-center justify-center px-4 text-center">
+          <MessageSquareOff className="mb-3 size-10 text-muted-foreground/40" />
+          <p className="text-sm font-medium text-foreground">
+            This workflow does not support chat
+          </p>
+          <p className="mt-1 max-w-md text-xs text-muted-foreground">
+            A conversation needs a step that waits for your reply. Add a Wait
+            for signal step — on its own, or as an AI Agent tool — and this
+            workflow will start accepting messages.
+          </p>
+          <Button variant="secondary" className="mt-4" onClick={handleBack}>
+            Open workflow
+          </Button>
+        </div>
+      ) : (
+        <>
+          {/* Message list */}
+          <ChatMessageList messages={messages} />
 
-      {/* Input */}
-      <ChatInput
-        onSend={sendMessage}
-        onSignalResponse={sendMessage}
-        status={status}
-        waitingForInput={waitingForInput}
-        instanceId={storeInstanceId}
-        token={token}
-      />
+          {/* Input */}
+          <ChatInput
+            onSend={sendMessage}
+            onSignalResponse={sendMessage}
+            status={status}
+            waitingForInput={waitingForInput}
+            instanceId={storeInstanceId}
+            token={token}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -5845,6 +5845,13 @@ export interface WorkflowDto {
    */
   slug?: string | null;
   started?: string | null;
+  /**
+   * Whether this version can hold a conversation, i.e. whether it contains a
+   * step that waits for a reply. See `graph_supports_chat`. Consumers use it
+   * to decide whether to offer chat at all, rather than opening a surface
+   * that accepts messages nothing will ever read.
+   */
+  supportsChat?: boolean;
   /** Whether this version is compiled with step-event tracking instrumentation */
   trackEvents?: boolean;
   updated: string;

--- a/crates/runtara-server/src/api/dto/workflows.rs
+++ b/crates/runtara-server/src/api/dto/workflows.rs
@@ -710,6 +710,48 @@ impl Note {
     }
 }
 
+/// Whether a workflow's graph can hold a conversation.
+///
+/// A message typed into the chat surface only ever reaches a workflow through the
+/// session bridge, which pops it off the session queue and delivers it as a signal
+/// when the running instance asks for external input. Only a `WaitForSignal` step
+/// asks. A graph without one still starts an instance for every message sent, but
+/// nothing ever consumes what was typed — so chat there is a dead end.
+///
+/// The walk is a plain recursion over the stored JSON rather than a
+/// `runtara_dsl::ExecutionGraph` parse: the step structs are `deny_unknown_fields`,
+/// so a strict parse would turn any schema drift into "no chat" and hide a working
+/// feature. Walking the raw value also covers `Split`/`While` subgraphs, a
+/// `WaitForSignal`'s `onWait` branch, and AI Agent tool edges without naming them,
+/// since all of those are inlined in the same definition.
+///
+/// One case it cannot see: an `EmbedWorkflow` step names its child by id, so a
+/// child that waits is invisible here. The chat page stays reachable by direct URL
+/// for exactly that reason.
+pub fn graph_supports_chat(execution_graph: &Value) -> bool {
+    /// Depth ceiling, so a pathological definition cannot blow the stack. Real
+    /// graphs nest a handful of levels (subgraph within subgraph within onWait).
+    const MAX_DEPTH: u32 = 64;
+
+    fn walk(value: &Value, depth: u32) -> bool {
+        if depth > MAX_DEPTH {
+            return false;
+        }
+        match value {
+            Value::Object(map) => {
+                if map.get("stepType").and_then(|v| v.as_str()) == Some("WaitForSignal") {
+                    return true;
+                }
+                map.values().any(|child| walk(child, depth + 1))
+            }
+            Value::Array(items) => items.iter().any(|item| walk(item, depth + 1)),
+            _ => false,
+        }
+    }
+
+    walk(execution_graph, 0)
+}
+
 #[allow(dead_code)]
 #[derive(Serialize, Deserialize, ToSchema, Clone)]
 pub struct WorkflowDto {
@@ -764,6 +806,12 @@ pub struct WorkflowDto {
     /// on rename. `None` only for rows created before the slug backfill ran.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
+    /// Whether this version can hold a conversation, i.e. whether it contains a
+    /// step that waits for a reply. See `graph_supports_chat`. Consumers use it
+    /// to decide whether to offer chat at all, rather than opening a surface
+    /// that accepts messages nothing will ever read.
+    #[serde(default, rename = "supportsChat")]
+    pub supports_chat: bool,
 }
 
 fn default_path() -> String {
@@ -1620,5 +1668,100 @@ mod tests {
         let last = PageWorkflowDto::new(vec![], 100, 4, 20);
         assert!(last.last);
         assert!(!last.first);
+    }
+
+    #[test]
+    fn a_top_level_wait_makes_a_workflow_chattable() {
+        let graph = json!({
+            "entryPoint": "ask",
+            "steps": {
+                "ask": {
+                    "stepType": "WaitForSignal",
+                    "id": "ask",
+                    "responseSchema": {"message": {"type": "string"}}
+                },
+                "finish": {"stepType": "Finish", "id": "finish"}
+            }
+        });
+        assert!(graph_supports_chat(&graph));
+    }
+
+    #[test]
+    fn a_wait_nested_in_a_subgraph_still_counts() {
+        // Split/While bodies and onWait branches are inlined in the same
+        // definition, so the recursion reaches them without naming each shape.
+        let graph = json!({
+            "entryPoint": "loop",
+            "steps": {
+                "loop": {
+                    "stepType": "While",
+                    "id": "loop",
+                    "subgraph": {
+                        "entryPoint": "ask",
+                        "steps": {
+                            "ask": {"stepType": "WaitForSignal", "id": "ask"}
+                        }
+                    }
+                }
+            }
+        });
+        assert!(graph_supports_chat(&graph));
+    }
+
+    #[test]
+    fn a_wait_reached_as_an_ai_agent_tool_counts() {
+        // The agent's tools are labelled edges onto ordinary steps, so the wait
+        // is a peer of the agent rather than nested inside it.
+        let graph = json!({
+            "entryPoint": "agent",
+            "steps": {
+                "agent": {"stepType": "AiAgent", "id": "agent", "model": "claude"},
+                "ask_user": {"stepType": "WaitForSignal", "id": "ask_user"}
+            },
+            "executionPlan": [
+                {"fromStep": "agent", "toStep": "ask_user", "label": "tool:ask_user"}
+            ]
+        });
+        assert!(graph_supports_chat(&graph));
+    }
+
+    #[test]
+    fn a_workflow_that_never_waits_is_not_chattable() {
+        // The Log-only shape from the deep test: it runs, it finishes, and it
+        // never gives the session bridge a signal to hand the message to.
+        let graph = json!({
+            "entryPoint": "log",
+            "steps": {
+                "log": {"stepType": "Log", "id": "log", "message": "hello"},
+                "call": {
+                    "stepType": "Agent",
+                    "id": "call",
+                    "agentId": "http",
+                    "capabilityId": "request"
+                },
+                "finish": {"stepType": "Finish", "id": "finish"}
+            }
+        });
+        assert!(!graph_supports_chat(&graph));
+    }
+
+    #[test]
+    fn empty_and_malformed_graphs_are_not_chattable() {
+        assert!(!graph_supports_chat(&json!({})));
+        assert!(!graph_supports_chat(&json!({"steps": {}})));
+        assert!(!graph_supports_chat(&json!({"nonsense": true})));
+        assert!(!graph_supports_chat(&json!(null)));
+        assert!(!graph_supports_chat(&json!("WaitForSignal")));
+    }
+
+    #[test]
+    fn deep_nesting_terminates_instead_of_overflowing() {
+        // Build a graph nested past the depth ceiling; the answer degrades to
+        // "no chat", but the walk must return rather than blow the stack.
+        let mut graph = json!({"stepType": "WaitForSignal", "id": "deep"});
+        for _ in 0..200 {
+            graph = json!({"subgraph": graph});
+        }
+        assert!(!graph_supports_chat(&graph));
     }
 }

--- a/crates/runtara-server/src/api/repositories/workflows.rs
+++ b/crates/runtara-server/src/api/repositories/workflows.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use sha2::Digest;
 use sqlx::{PgPool, Row};
 
-use crate::api::dto::workflows::{Note, WorkflowDto, WorkflowVersionInfoDto};
+use crate::api::dto::workflows::{Note, WorkflowDto, WorkflowVersionInfoDto, graph_supports_chat};
 use crate::types::MemoryTier;
 
 type WorkflowVersionRow = (
@@ -564,6 +564,10 @@ impl WorkflowRepository {
                         notes: Vec::new(), // Empty for list view (no execution graph loaded)
                         path: row.8.clone(),
                         slug: row.9.clone(),
+                        // The graph is withheld from list rows, but it is already
+                        // in hand here — so the chat predicate costs nothing extra
+                        // and the list can gate its Chat action on the real answer.
+                        supports_chat: graph_supports_chat(&execution_graph),
                     }
                 })
                 .collect();
@@ -680,6 +684,7 @@ impl WorkflowRepository {
                 notes: Note::extract_from_execution_graph(&r.0),
                 path: r.7.clone(),
                 slug: r.8.clone(),
+                supports_chat: graph_supports_chat(execution_graph),
             }
         }))
     }

--- a/crates/runtara-server/src/api/services/workflows.rs
+++ b/crates/runtara-server/src/api/services/workflows.rs
@@ -252,6 +252,8 @@ impl WorkflowService {
             notes: Vec::new(), // Empty notes for new workflow
             path,
             slug: Some(slug),
+            // A new workflow's graph has no steps at all, so nothing waits yet.
+            supports_chat: false,
         })
     }
 


### PR DESCRIPTION
Every workflow row rendered a Chat action, and /workflows/:id/chat opened a working-looking chat for any workflow at all. On one with no step that waits for a reply, sending a message allocated an instance and then went nowhere — no reply, no error, no sign that chat was never going to work there.

A typed message reaches a workflow only through the session bridge, which pops it off the session queue and delivers it as a signal when the run asks for external input. Only a WaitForSignal step asks. Without one the message is genuinely lost, so the graph is the thing that decides.

The workflow DTO now carries that answer, walked off the stored definition the list query already loads. The row withholds Chat when it is false, and the page says what is missing and how to fix it rather than opening a session. Direct URLs still reach the page — it is the fallback, not a redirect — and resuming a run stays exempt: Invocation History links there for runs holding a pending input, and refusing would strand the reply.