### PR TITLE
Give SelectInput's Radix trigger the form item id

### DIFF
--- a/crates/runtara-server/frontend/e2e/fixtures/a11y.fixture.ts
+++ b/crates/runtara-server/frontend/e2e/fixtures/a11y.fixture.ts
@@ -26,8 +26,12 @@ const DEFAULT_BLOCKING_IMPACTS =
  * below should be tracked as tech debt in the backlog; do not add new entries
  * without a linked issue.
  *
+ * A page that has been cleaned up can opt back into a rule with `enabledRules`,
+ * which is how a fixed page stops regressing while the rest of the app catches
+ * up — see the trigger specs, which re-enable button-name.
+ *
  * Known debt:
- *   - button-name: icon-only buttons without aria-label (analytics, history, trigger forms)
+ *   - button-name: icon-only buttons without aria-label (analytics, history)
  *   - color-contrast: a handful of muted text colors below AA threshold
  *   - list / listitem: sidebar uses <ul><Component /></ul> which axe flags
  *   - aria-allowed-attr, aria-required-children, aria-required-parent: Radix UI primitives
@@ -50,6 +54,12 @@ export interface A11yFixtures {
       include?: string;
       exclude?: string[];
       disabledRules?: string[];
+      /**
+       * Opt a page back into a rule from DEFAULT_DISABLED_RULES, once that
+       * page no longer trips it. Keeps the fixed page from regressing without
+       * waiting on the rest of the app.
+       */
+      enabledRules?: string[];
       /** Lower the bar temporarily for a specific page. */
       blockingImpacts?: Array<'minor' | 'moderate' | 'serious' | 'critical'>;
     }
@@ -76,10 +86,11 @@ function makeRunner(testInfo: TestInfo) {
         builder = builder.exclude(sel);
       }
     }
+    const reEnabled = new Set(options.enabledRules ?? []);
     const disabled = [
       ...DEFAULT_DISABLED_RULES,
       ...(options.disabledRules ?? []),
-    ];
+    ].filter((rule) => !reEnabled.has(rule));
     if (disabled.length) {
       builder = builder.disableRules(disabled);
     }

--- a/crates/runtara-server/frontend/e2e/tests/mocked/triggers/create.mocked.spec.ts
+++ b/crates/runtara-server/frontend/e2e/tests/mocked/triggers/create.mocked.spec.ts
@@ -15,13 +15,20 @@ test.describe('Create trigger (mocked)', () => {
 
     await view.expectHeading(/create trigger/i);
 
-    // Nothing is selected yet, so the workflow picker has to say so rather
-    // than render an empty box and only explain itself on submit.
-    await expect(
-      page.getByRole('combobox').filter({ hasText: 'Select a workflow' })
-    ).toBeVisible();
+    // Querying by accessible name is the assertion: the picker's label has to
+    // reach the Radix trigger. Nothing is selected yet, so it also has to say
+    // so rather than render an empty box and only explain itself on submit.
+    await expect(page.getByRole('combobox', { name: 'Workflow' })).toHaveText(
+      /Select a workflow/
+    );
 
-    await runA11y(page, { exclude: ['[data-sonner-toaster]'] });
+    // The selects on this form used to render as unnamed comboboxes. They no
+    // longer do, so hold the page to button-name rather than leaving it under
+    // the app-wide waiver.
+    await runA11y(page, {
+      exclude: ['[data-sonner-toaster]'],
+      enabledRules: ['button-name'],
+    });
     await view.expectMatchesSnapshot('triggers-create');
   });
 });

--- a/crates/runtara-server/frontend/e2e/tests/mocked/triggers/edit.mocked.spec.ts
+++ b/crates/runtara-server/frontend/e2e/tests/mocked/triggers/edit.mocked.spec.ts
@@ -24,7 +24,13 @@ test.describe('Edit trigger (mocked)', () => {
     await view.goto();
 
     await view.expectHeading(/edit trigger/i);
-    await runA11y(page, { exclude: ['[data-sonner-toaster]'] });
+    // The selects on this form used to render as unnamed comboboxes. They no
+    // longer do, so hold the page to button-name rather than leaving it under
+    // the app-wide waiver.
+    await runA11y(page, {
+      exclude: ['[data-sonner-toaster]'],
+      enabledRules: ['button-name'],
+    });
     await view.expectMatchesSnapshot('triggers-edit');
   });
 });

--- a/crates/runtara-server/frontend/src/features/triggers/components/TriggerForm/TriggerForm.test.tsx
+++ b/crates/runtara-server/frontend/src/features/triggers/components/TriggerForm/TriggerForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
@@ -36,13 +36,8 @@ function renderForm(initValues?: TriggerSchemaType) {
   );
 }
 
-// SelectInput leaves its Radix trigger without an id, so the label is not
-// programmatically associated with it and the combobox has no accessible
-// name. Scope the lookup to the field that holds the "Workflow" label.
-function workflowCombobox() {
-  const field = screen.getByText('Workflow').closest('div');
-  return within(field as HTMLElement).getByRole('combobox');
-}
+const workflowCombobox = () =>
+  screen.getByRole('combobox', { name: 'Workflow' });
 
 describe('TriggerForm workflow field', () => {
   beforeAll(() => {

--- a/crates/runtara-server/frontend/src/shared/components/select-input.test.tsx
+++ b/crates/runtara-server/frontend/src/shared/components/select-input.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { SelectInput } from './select-input.tsx';
+import { Form } from './ui/form.tsx';
+
+const OPTIONS = [
+  { value: 'wf-1', label: 'Orders sync' },
+  { value: 'wf-2', label: 'Inventory reconcile' },
+];
+
+function Harness({ description }: { description?: string }) {
+  const form = useForm({ defaultValues: { workflowId: '' } });
+
+  return (
+    <Form {...form}>
+      <SelectInput
+        name="workflowId"
+        label="Workflow"
+        placeholder="Select a workflow"
+        description={description}
+        options={OPTIONS}
+      />
+    </Form>
+  );
+}
+
+afterEach(cleanup);
+
+describe('SelectInput', () => {
+  beforeAll(() => {
+    // Radix's Select trigger measures itself; jsdom has no ResizeObserver.
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      writable: true,
+      value: class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    });
+  });
+
+  // FormControl has to wrap the trigger rather than the Radix root, or the
+  // form item id lands on a component that renders no DOM and the label
+  // associates with nothing.
+  it('gives the trigger the form item id so the label names it', () => {
+    render(<Harness />);
+
+    const trigger = screen.getByRole('combobox', { name: 'Workflow' });
+    const label = screen.getByText('Workflow');
+
+    expect(trigger.id).not.toBe('');
+    expect(label).toHaveAttribute('for', trigger.id);
+  });
+
+  it('describes the trigger with the field description', () => {
+    render(<Harness description="Runs whenever the trigger fires." />);
+
+    expect(
+      screen.getByRole('combobox', { name: 'Workflow' })
+    ).toHaveAccessibleDescription('Runs whenever the trigger fires.');
+  });
+});

--- a/crates/runtara-server/frontend/src/shared/components/select-input.tsx
+++ b/crates/runtara-server/frontend/src/shared/components/select-input.tsx
@@ -43,32 +43,37 @@ export function SelectInput(props: SelectInputProps) {
         return (
           <FormItem>
             {label && <FormLabel>{label}</FormLabel>}
-            <FormControl>
-              <Select
-                onValueChange={onChange}
-                value={field.value}
-                disabled={disabled}
-              >
+            <Select
+              onValueChange={onChange}
+              value={field.value}
+              disabled={disabled}
+            >
+              {/* FormControl is a Slot: it forwards the form item id and the
+                  aria attributes to its immediate child. That child has to be
+                  the trigger, not the Radix root, or they land on a component
+                  that renders no DOM and the label above associates with
+                  nothing. */}
+              <FormControl>
                 {/* The muted class lives here rather than on the shared
                     SelectTrigger so only this component's selects restyle. */}
                 <SelectTrigger className="data-[placeholder]:text-muted-foreground">
                   <SelectValue placeholder={placeholder} />
                 </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {options.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </FormControl>
+              </FormControl>
+              <SelectContent>
+                <SelectGroup>
+                  {options.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
             {description && <FormDescription>{description}</FormDescription>}
             <FormMessage />
           </FormItem>


### PR DESCRIPTION
SelectInput wrapped the Radix Select root in FormControl. FormControl is a Slot: it forwards id, aria-describedby and aria-invalid to its immediate child, and SelectPrimitive.Root renders no DOM, so all three were dropped. The rendered <button role="combobox"> had no id, the sibling <label for> associated with nothing, and the control had no accessible name — on Workflow, Trigger Type, Session Mode and every NextForm type: 'select'.

Move FormControl inside Select so it wraps SelectTrigger, the arrangement WorkflowForm already uses. A <label for> names a button role="combobox" correctly, so no explicit aria-labelledby is needed and ui/form.tsx is untouched.

axe was catching this all along: button-name reports it at critical severity, above the e2e gate. The suite stayed green only because 'button-name' sits in the a11y fixture's DEFAULT_DISABLED_RULES. Add an enabledRules option so a cleaned-up page can opt back into a waived rule, and use it on the two trigger specs — verified to fail on the unfixed markup.