### PR TITLE
SYN-592: Persist workflow list search, page and page size in the URL

### DIFF
--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.test.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.test.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useLocation } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WorkflowDto } from '@/generated/RuntaraRuntimeApi';
@@ -94,23 +94,37 @@ function serveWorkflowPage(_token: string, params: Record<string, any>) {
   });
 }
 
-function renderGrid(props: Partial<ComponentProps<typeof WorkflowsGrid>> = {}) {
+/** Reports the live query string so tests can assert on the URL the grid writes. */
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location-search">{location.search}</output>;
+}
+
+function renderGrid(
+  props: Partial<ComponentProps<typeof WorkflowsGrid>> = {},
+  initialEntry = '/workflows'
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/workflows']}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <WorkflowsGrid
           searchTerm=""
           folderPath="/"
           folders={allFolders}
           {...props}
         />
+        <LocationProbe />
       </MemoryRouter>
     </QueryClientProvider>
   );
+}
+
+function locationSearch(): string {
+  return screen.getByTestId('location-search').textContent ?? '';
 }
 
 function folderRowNames(): string[] {
@@ -315,5 +329,66 @@ describe('WorkflowsGrid empty-workflow row', () => {
     renderGrid({ folderPath: '/folder-01/' });
 
     await screen.findByText('No workflows in this folder yet.');
+  });
+});
+
+describe('WorkflowsGrid URL state', () => {
+  beforeEach(() => {
+    mocks.getWorkflowsInFolder.mockReset();
+    mocks.getWorkflowsInFolder.mockImplementation(serveWorkflowPage);
+  });
+
+  it('opens on the page and size the URL asks for', async () => {
+    // Page 2 of 20 rows: the 12 folders and workflows 1–8 are behind us.
+    renderGrid({}, '/workflows?page=2&pageSize=20');
+
+    await screen.findByText('Workflow 09');
+    expect(folderRowNames()).toEqual([]);
+    expect(screen.getByText('Workflow 28')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow 29')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Rows 21–40 of 55 · 12 folders')
+    ).toBeInTheDocument();
+  });
+
+  it('puts the page it turns to in the URL', async () => {
+    renderGrid();
+
+    await screen.findByText('folder-01');
+    expect(locationSearch()).toBe('');
+
+    await goToNextPage();
+    await screen.findByText('Workflow 01');
+    expect(locationSearch()).toBe('?page=2');
+  });
+
+  it('records a new page size and returns to the first page', async () => {
+    renderGrid({}, '/workflows?page=3');
+
+    await screen.findByText('Workflow 09');
+    await userEvent.selectOptions(screen.getByLabelText('Rows per page'), '20');
+
+    await screen.findByText('folder-01');
+    expect(locationSearch()).toBe('?pageSize=20');
+  });
+
+  it('lands on the last page when the URL asks for one past the end', async () => {
+    // What a shared link turns into once the listing it pointed at shrinks.
+    renderGrid({}, '/workflows?page=99');
+
+    await screen.findByText('Workflow 43');
+    expect(locationSearch()).toBe('?page=6');
+    expect(
+      screen.getByText('Rows 51–55 of 55 · 12 folders')
+    ).toBeInTheDocument();
+  });
+
+  it('drops a size it had to ignore instead of leaving the URL claiming it', async () => {
+    renderGrid({}, '/workflows?pageSize=7&q=keep-me');
+
+    await screen.findByText('folder-01');
+    expect(screen.getByLabelText('Rows per page')).toHaveValue('10');
+    // The listing's own parameters are corrected; the rest is left alone.
+    expect(locationSearch()).toBe('?q=keep-me');
   });
 });

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import {
   ArrowDown,
@@ -25,6 +25,7 @@ import {
   rowPageCount,
   workflowServerSlice,
 } from './row-window';
+import { readListUrlState, writeListUrlState } from './list-url-state';
 import {
   cloneWorkflow,
   getWorkflowsInFolder,
@@ -59,8 +60,6 @@ import { MoveToFolderDialog } from '../FolderDialogs';
 import { ConfirmationDialog } from '@/shared/components/confirmation-dialog';
 import { parseSchema } from '@/features/workflows/utils/schema';
 import { useFolders } from '../../hooks/useFolders';
-
-const DEFAULT_PAGE_SIZE = 10;
 
 interface WorkflowFolderItem {
   name: string;
@@ -159,14 +158,39 @@ export function WorkflowsGrid({
     );
   }, []);
 
-  // Pagination state (API uses 0-based pages)
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  // Pagination lives in the URL so the view survives a reload and can be shared
+  // (API and control are both 0-based; the URL is 1-based).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { page, pageSize } = readListUrlState(searchParams);
 
-  // Reset to first page when folder or search changes
+  // Turning a page is a navigation of its own, so it pushes: Back returns to the
+  // page you came from. Resizing keeps the same listing, so it replaces — and
+  // drops the page index, whose rows the new size no longer lines up with.
+  const goToPage = useCallback(
+    (next: number) => {
+      setSearchParams((current) => writeListUrlState(current, { page: next }));
+    },
+    [setSearchParams]
+  );
+  const changePageSize = useCallback(
+    (next: number) => {
+      setSearchParams(
+        (current) => writeListUrlState(current, { pageSize: next }),
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  // A parameter the listing had to ignore — a hand-edited `pageSize=7`, a
+  // default spelled out — shouldn't sit in the URL describing a view that isn't
+  // the one on screen. Write back what was actually read.
   useEffect(() => {
-    setPage(0);
-  }, [folderPath, searchTerm]);
+    const canonical = writeListUrlState(searchParams, { page, pageSize });
+    if (canonical.toString() !== searchParams.toString()) {
+      setSearchParams(canonical, { replace: true });
+    }
+  }, [searchParams, page, pageSize, setSearchParams]);
 
   // Fetch folders for move dialog
   const { data: foldersData } = useFolders();
@@ -255,6 +279,20 @@ export function WorkflowsGrid({
   const workflowTotal = response?.totalElements ?? 0;
   const totalElements = folderCount + workflowTotal;
   const totalPages = rowPageCount(folderCount, workflowTotal, pageSize);
+
+  // A link can outlive the rows it pointed at — a shared `?page=9` for a listing
+  // that has since shrunk. Land on the last page that exists rather than on an
+  // empty table, and replace so Back doesn't return to the dead page.
+  useEffect(() => {
+    if (isFetching || isError || !response) return;
+    if (page > 0 && page >= totalPages) {
+      setSearchParams(
+        (current) => writeListUrlState(current, { page: totalPages - 1 }),
+        { replace: true }
+      );
+    }
+  }, [isFetching, isError, response, page, totalPages, setSearchParams]);
+
   // Server handles both folder and search filtering via query parameters
   // Client-side: sort only
   const filteredWorkflows = useMemo(() => {
@@ -627,11 +665,8 @@ export function WorkflowsGrid({
                   pageIndex={page}
                   pageSize={pageSize}
                   pageCount={totalPages}
-                  onPageChange={setPage}
-                  onPageSizeChange={(size) => {
-                    setPageSize(size);
-                    setPage(0);
-                  }}
+                  onPageChange={goToPage}
+                  onPageSizeChange={changePageSize}
                 />
               }
             />

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/list-url-state.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/list-url-state.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PAGE_SIZE,
+  readListUrlState,
+  writeListUrlState,
+} from './list-url-state.ts';
+
+function read(query: string) {
+  return readListUrlState(new URLSearchParams(query));
+}
+
+function write(query: string, patch: Parameters<typeof writeListUrlState>[1]) {
+  return writeListUrlState(new URLSearchParams(query), patch).toString();
+}
+
+describe('readListUrlState', () => {
+  it('falls back to the first page, the default size and no query', () => {
+    expect(read('')).toEqual({
+      page: 0,
+      pageSize: DEFAULT_PAGE_SIZE,
+      search: '',
+    });
+  });
+
+  it('reads a 1-based page as a 0-based index', () => {
+    expect(read('page=3').page).toBe(2);
+    expect(read('page=1').page).toBe(0);
+  });
+
+  it('ignores page values the listing cannot use', () => {
+    // Hand-edited URLs are input, not a promise.
+    for (const query of [
+      'page=0',
+      'page=-4',
+      'page=abc',
+      'page=2.5',
+      'page=',
+    ]) {
+      expect(read(query).page).toBe(0);
+    }
+  });
+
+  it('accepts only the sizes the pagination control offers', () => {
+    expect(read('pageSize=50').pageSize).toBe(50);
+    for (const query of ['pageSize=7', 'pageSize=0', 'pageSize=nope']) {
+      expect(read(query).pageSize).toBe(DEFAULT_PAGE_SIZE);
+    }
+  });
+
+  it('reads the query verbatim, spaces and all', () => {
+    expect(read('q=order+sync').search).toBe('order sync');
+  });
+});
+
+describe('writeListUrlState', () => {
+  it('leaves the default view without any listing parameters', () => {
+    expect(write('page=4&pageSize=50&q=sync', { page: 0 })).toBe(
+      'pageSize=50&q=sync'
+    );
+    expect(write('pageSize=50', { pageSize: DEFAULT_PAGE_SIZE })).toBe('');
+    expect(write('q=sync', { search: '' })).toBe('');
+    expect(write('q=sync', { search: '   ' })).toBe('');
+  });
+
+  it('writes the page 1-based', () => {
+    expect(write('', { page: 2 })).toBe('page=3');
+  });
+
+  it('drops the page when the search changes', () => {
+    // Page 4 of the old result set says nothing about the new one.
+    expect(write('page=4&q=old', { search: 'new' })).toBe('q=new');
+  });
+
+  it('drops the page when the page size changes', () => {
+    expect(write('page=4', { pageSize: 20 })).toBe('pageSize=20');
+  });
+
+  it('leaves parameters it was not asked about alone', () => {
+    expect(write('folder=%2FDemo%2F&q=sync', { page: 1 })).toBe(
+      'folder=%2FDemo%2F&q=sync&page=2'
+    );
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/list-url-state.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowsGrid/list-url-state.ts
@@ -1,0 +1,79 @@
+/**
+ * The workflow listing's view state, carried in the URL query string.
+ *
+ * The folder was already a query parameter, so reloading a folder kept it while
+ * the search, the page and the page size — plain component state — were thrown
+ * away. Putting all of them in the URL makes the whole view reloadable,
+ * navigable with back/forward, and shareable as a link.
+ *
+ * Defaults are elided rather than written, so the default view has one
+ * canonical URL instead of `?page=1&pageSize=10`. The values are user-editable
+ * text, so reading them validates rather than trusts.
+ */
+
+import { PAGE_SIZE_OPTIONS } from '@/shared/components/console';
+
+export const DEFAULT_PAGE_SIZE = 10;
+
+export const PAGE_PARAM = 'page';
+export const PAGE_SIZE_PARAM = 'pageSize';
+export const SEARCH_PARAM = 'q';
+
+export interface ListUrlState {
+  /** 0-based, as the listing API and the pagination control expect. */
+  page: number;
+  pageSize: number;
+  search: string;
+}
+
+/**
+ * Read the listing state out of the query string.
+ *
+ * `page` is 1-based in the URL — it should match the "Page 2 of 11" the footer
+ * shows — and 0-based everywhere else.
+ */
+export function readListUrlState(params: URLSearchParams): ListUrlState {
+  const rawPage = Number(params.get(PAGE_PARAM));
+  const page = Number.isInteger(rawPage) && rawPage > 1 ? rawPage - 1 : 0;
+
+  const rawPageSize = Number(params.get(PAGE_SIZE_PARAM));
+  const pageSize = PAGE_SIZE_OPTIONS.includes(rawPageSize)
+    ? rawPageSize
+    : DEFAULT_PAGE_SIZE;
+
+  return { page, pageSize, search: params.get(SEARCH_PARAM) ?? '' };
+}
+
+/**
+ * Apply a change to the listing state, returning the new query string.
+ *
+ * Changing the search or the page size resizes or refills the listing, so the
+ * page it was showing no longer means anything: both drop it. Doing that here
+ * rather than in an effect afterwards keeps one URL update — and so one history
+ * entry — per user action.
+ */
+export function writeListUrlState(
+  params: URLSearchParams,
+  patch: Partial<ListUrlState>
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+
+  if (patch.search !== undefined) {
+    if (patch.search.trim()) next.set(SEARCH_PARAM, patch.search);
+    else next.delete(SEARCH_PARAM);
+    next.delete(PAGE_PARAM);
+  }
+
+  if (patch.pageSize !== undefined) {
+    if (patch.pageSize === DEFAULT_PAGE_SIZE) next.delete(PAGE_SIZE_PARAM);
+    else next.set(PAGE_SIZE_PARAM, String(patch.pageSize));
+    next.delete(PAGE_PARAM);
+  }
+
+  if (patch.page !== undefined) {
+    if (patch.page > 0) next.set(PAGE_PARAM, String(patch.page + 1));
+    else next.delete(PAGE_PARAM);
+  }
+
+  return next;
+}

--- a/crates/runtara-server/frontend/src/features/workflows/pages/Workflows/index.test.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/pages/Workflows/index.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Workflows } from './index';
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { access_token: 'test-token' } }),
+}));
+
+vi.mock('../../hooks/useFolders', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useFolders')>()),
+  useFolders: () => ({ data: undefined, isError: false }),
+  useFolderWorkflowCounts: () => ({}),
+  useRenameFolder: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteFolder: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+/** Stands in for the listing so the page's own URL handling is what is under test. */
+vi.mock('../../components/WorkflowsGrid', () => ({
+  WorkflowsGrid: ({
+    toolbar,
+    searchTerm,
+  }: {
+    toolbar: React.ReactNode;
+    searchTerm: string;
+  }) => (
+    <>
+      {toolbar}
+      <output data-testid="grid-search-term">{searchTerm}</output>
+    </>
+  ),
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <output data-testid="location-search">{location.search}</output>
+      <button onClick={() => navigate('/workflows?q=beta')}>go beta</button>
+      <button onClick={() => navigate(-1)}>go back</button>
+    </>
+  );
+}
+
+function renderPage(initialEntry = '/workflows') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Workflows />
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function searchBox(): HTMLInputElement {
+  return screen.getByPlaceholderText('Search workflows…') as HTMLInputElement;
+}
+
+function locationSearch(): string {
+  return screen.getByTestId('location-search').textContent ?? '';
+}
+
+describe('Workflows search URL state', () => {
+  it('opens with the query the URL carries, in the box and in the listing', () => {
+    renderPage('/workflows?q=alpha');
+
+    expect(searchBox()).toHaveValue('alpha');
+    expect(screen.getByTestId('grid-search-term')).toHaveTextContent('alpha');
+  });
+
+  it('writes what was typed once it settles, and forgets the page', async () => {
+    renderPage('/workflows?page=3');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Search (⌘F)' }));
+    await userEvent.type(searchBox(), 'demo');
+
+    // Page 3 of the unfiltered listing means nothing to the filtered one.
+    await waitFor(() => expect(locationSearch()).toBe('?q=demo'));
+    expect(screen.getByTestId('grid-search-term')).toHaveTextContent('demo');
+  });
+
+  it('leaves the URL clean when the box is emptied again', async () => {
+    renderPage('/workflows?q=alpha');
+
+    await userEvent.clear(searchBox());
+
+    await waitFor(() => expect(locationSearch()).toBe(''));
+  });
+
+  it('follows the URL when navigation changes it', async () => {
+    renderPage('/workflows?q=alpha');
+
+    await userEvent.click(screen.getByRole('button', { name: 'go beta' }));
+    await waitFor(() => expect(searchBox()).toHaveValue('beta'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'go back' }));
+    await waitFor(() => expect(searchBox()).toHaveValue('alpha'));
+    expect(screen.getByTestId('grid-search-term')).toHaveTextContent('alpha');
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/pages/Workflows/index.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/pages/Workflows/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { PlusIcon } from 'lucide-react';
 import { toast } from 'sonner';
@@ -25,15 +25,53 @@ import {
   getChildFolders,
 } from '../../hooks/useFolders';
 import { createWorkflowHref } from '../../folder-nav';
+import {
+  readListUrlState,
+  writeListUrlState,
+} from '../../components/WorkflowsGrid/list-url-state';
 
 export function Workflows() {
   usePageTitle('Workflows');
   const [searchParams, setSearchParams] = useSearchParams();
-  const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // Folder navigation state - derived from URL search params for proper browser history support
   const currentFolderPath = searchParams.get('folder') || '/';
+
+  // The URL owns the query and the listing reads it from there. The box keeps
+  // its own copy so typing stays responsive, and only the settled value is
+  // written — a history entry per keystroke would make Back useless.
+  const urlSearchTerm = readListUrlState(searchParams).search;
+  const [searchInput, setSearchInput] = useState(urlSearchTerm);
+  const debouncedInput = useDebounce(searchInput, 300);
+  // Whitespace is no query at all, and the URL says so by holding nothing.
+  const settledSearchTerm = debouncedInput.trim() ? debouncedInput : '';
+  // The last value the two sides agreed on, so each sync below can tell its own
+  // write from a change that came from elsewhere — a back/forward, or a link
+  // opened with a query already on it — instead of the two overwriting in a loop.
+  const syncedSearchTerm = useRef(urlSearchTerm);
+
+  // Box → URL.
+  useEffect(() => {
+    // The debounce still trailing the box means this fired for some other
+    // reason — `setSearchParams` is a new function after every navigation — and
+    // the settled value is the one from before that navigation. Writing it back
+    // is how a Back taken mid-debounce used to bounce straight forward again.
+    if (debouncedInput !== searchInput) return;
+    if (settledSearchTerm === syncedSearchTerm.current) return;
+    syncedSearchTerm.current = settledSearchTerm;
+    setSearchParams(
+      (prev) => writeListUrlState(prev, { search: settledSearchTerm }),
+      { replace: true }
+    );
+  }, [debouncedInput, searchInput, settledSearchTerm, setSearchParams]);
+
+  // URL → box, for the queries this page didn't type: a back/forward, or a link
+  // opened with one already on it.
+  useEffect(() => {
+    if (urlSearchTerm === syncedSearchTerm.current) return;
+    syncedSearchTerm.current = urlSearchTerm;
+    setSearchInput(urlSearchTerm);
+  }, [urlSearchTerm]);
 
   // Dialog state
   const [renameFolderTarget, setRenameFolderTarget] = useState<string | null>(
@@ -71,19 +109,13 @@ export function Workflows() {
   // Folder navigation - updates URL to enable browser back/forward navigation
   const handleFolderNavigate = useCallback(
     (path: string) => {
-      if (path === '/') {
-        setSearchParams((prev) => {
-          const next = new URLSearchParams(prev);
-          next.delete('folder');
-          return next;
-        });
-      } else {
-        setSearchParams((prev) => {
-          const next = new URLSearchParams(prev);
-          next.set('folder', path);
-          return next;
-        });
-      }
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (path === '/') next.delete('folder');
+        else next.set('folder', path);
+        // Another folder is another listing, so the page index goes with it.
+        return writeListUrlState(next, { page: 0 });
+      });
     },
     [setSearchParams]
   );
@@ -128,7 +160,7 @@ export function Workflows() {
             (prev) => {
               const next = new URLSearchParams(prev);
               next.delete('folder');
-              return next;
+              return writeListUrlState(next, { page: 0 });
             },
             { replace: true }
           );
@@ -168,8 +200,8 @@ export function Workflows() {
       left={<Breadcrumb items={breadcrumbItems} />}
       search={
         <ToolbarSearch
-          value={searchTerm}
-          onChange={setSearchTerm}
+          value={searchInput}
+          onChange={setSearchInput}
           placeholder="Search workflows…"
           className="w-56"
         />
@@ -191,12 +223,12 @@ export function Workflows() {
     <>
       <WorkflowsGrid
         toolbar={toolbar}
-        searchTerm={debouncedSearchTerm}
+        searchTerm={urlSearchTerm}
         folderPath={currentFolderPath}
         showMoveAction={true}
         folders={childFolders}
         folderWorkflowCounts={folderWorkflowCounts}
-        onClearSearch={() => setSearchTerm('')}
+        onClearSearch={() => setSearchInput('')}
         onFolderNavigate={handleFolderNavigate}
         onFolderRename={setRenameFolderTarget}
         onFolderDelete={setDeleteFolderTarget}

--- a/crates/runtara-server/frontend/src/shared/components/console/TablePagination.tsx
+++ b/crates/runtara-server/frontend/src/shared/components/console/TablePagination.tsx
@@ -5,8 +5,7 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+import { PAGE_SIZE_OPTIONS } from './page-size-options';
 
 export interface TablePaginationProps {
   pageIndex: number;

--- a/crates/runtara-server/frontend/src/shared/components/console/index.tsx
+++ b/crates/runtara-server/frontend/src/shared/components/console/index.tsx
@@ -24,6 +24,7 @@ export {
   type TableStatusFooterProps,
 } from './TableStatusFooter';
 export { TablePagination, type TablePaginationProps } from './TablePagination';
+export { PAGE_SIZE_OPTIONS } from './page-size-options';
 export {
   ConsoleTableShell,
   type ConsoleTableShellProps,

--- a/crates/runtara-server/frontend/src/shared/components/console/page-size-options.ts
+++ b/crates/runtara-server/frontend/src/shared/components/console/page-size-options.ts
@@ -1,0 +1,7 @@
+/**
+ * Row counts a console table offers in its pagination control.
+ *
+ * Its own module so callers that only need the values — validating a `pageSize`
+ * read out of a URL, say — don't import a component to get them.
+ */
+export const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];


### PR DESCRIPTION
Closes [SYN-592](https://linear.app/syncmyordershq/issue/SYN-592/f8-workflow-list-state-is-not-persisted-in-the-url-except-for-folder) — finding **F8** of the [SYN-569](https://linear.app/syncmyordershq/issue/SYN-569/runtara-ui-deep-test-findings) UI deep-test.

## The problem

The workflow list already kept its folder in the URL, so that survived a reload. The search text, the page and the page size were plain component state — a reload cleared the query and dropped you back on page 1, and a list view could not be shared as a link.

## The change

All three now live in the URL as `q`, `page` and `pageSize`, alongside the existing `folder`.

- **`list-url-state.ts`** (new) — pure read/write of the listing parameters, with a co-located test. Defaults are elided, so the default view keeps one canonical URL rather than `?page=1&pageSize=10`. `page` is 1-based in the URL to match the "Page 2 of 3" the footer shows, and 0-based everywhere else. `pageSize` is validated against the sizes the pagination control actually offers — which is why `PAGE_SIZE_OPTIONS` moved out of `TablePagination.tsx` into its own module, so both sides read the same list.
- **`WorkflowsGrid`** — page and page size come from the URL instead of `useState`. Turning a page pushes, so Back returns to the page you came from; resizing replaces and drops the page index, whose rows the new size no longer lines up with. Two corrections keep the URL honest: a `page` past the end of a listing that has since shrunk snaps to the last page that exists, and a parameter the listing had to ignore (a hand-edited `pageSize=7`) is rewritten rather than left describing a view that isn't on screen.
- **`Workflows` page** — `q` owns the search. The box keeps a local copy so typing stays responsive, and only the settled value is written, so a keystroke never costs a history entry.

Changing the folder, the search or the page size drops the page in the same URL update, so each user action is one history entry rather than a reset effect firing after the fact.

### A bug found while verifying

`setSearchParams` gets a new identity on every navigation, so the write effect re-ran with a stale debounced value: a Back taken within the 300 ms debounce window wrote the old query straight back and bounced you forward again. The write now waits for the debounce to catch up with the box. The back/forward test covers it.

## Verification

- **1418 unit tests pass** (15 new across three files), lint at 0 errors and back to the baseline warning count, prettier clean, `tsc -b && vite build` green. The existing `WorkflowsGrid` pagination and search tests pass untouched.
- **Run against a local runtara** with 26 workflows and 2 folders seeded (deleted afterwards; the dev DB is back to its baseline):
  - default view `/workflows` carries no `q`/`page`/`pageSize`;
  - Next page → `?page=2`, matching "Page 2 of 3"; page size → `?pageSize=20` with the page dropped; search → `?q=probe-1`;
  - a cold reload of `?pageSize=20&q=probe-1` restored the view — confirmed against the server's own request log, which shows `page=0&pageSize=20&search=probe-1`, not just the UI text;
  - `?page=99&pageSize=7` landed on page 3 of 3 at 10/page, with the URL corrected to `?page=3`;
  - Back returned to the previous page; entering a folder dropped the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)