### PR TITLE
Replace oracle-less unit tests with ones that can fail

### DIFF
--- a/crates/runtara-component-host/src/host_state.rs
+++ b/crates/runtara-component-host/src/host_state.rs
@@ -276,7 +276,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn host_state_builds_with_full_context() {
+    fn host_state_shares_one_call_context_with_its_hooks() {
         let ctx = Arc::new(CallContext::for_test(
             "tenant-1",
             "http://proxy.local:7001",
@@ -284,7 +284,34 @@ mod tests {
             "http://obj.local:7003",
             "http://core.local:7004",
         ));
-        let _state = HostState::new(ctx);
+        let state = HostState::new(Arc::clone(&ctx));
+
+        // The hooks must see the same context the state was built from — a
+        // divergence here would let host calls run against another tenant.
+        assert!(Arc::ptr_eq(&state.ctx, &ctx));
+        assert!(Arc::ptr_eq(&state.hooks.ctx, &ctx));
+    }
+
+    #[test]
+    fn host_state_starts_unterminated_with_default_table_cap() {
+        let ctx = Arc::new(CallContext::for_test(
+            "tenant-1",
+            "http://proxy.local:7001",
+            "http://agent.local:7002",
+            "http://obj.local:7003",
+            "http://core.local:7004",
+        ));
+        let state = HostState::new(ctx);
+
+        // A fresh state has not been interrupted; the epoch callback is the
+        // only thing allowed to set this.
+        assert!(state.termination.is_none());
+        assert_eq!(
+            state.limiter.max_table_elements,
+            DEFAULT_GUEST_TABLE_MAX_ELEMENTS
+        );
+        assert_eq!(state.limiter.memory_peak_bytes, 0);
+        assert!(!state.limiter.denied_memory_grow);
     }
 
     #[test]

--- a/crates/runtara-core/src/instance_handlers/state.rs
+++ b/crates/runtara-core/src/instance_handlers/state.rs
@@ -61,10 +61,35 @@ mod tests {
     use crate::instance_handlers::mock_persistence::MockPersistence;
 
     #[test]
-    fn test_instance_handler_state_new() {
-        let persistence = Arc::new(MockPersistence::new());
-        let state = InstanceHandlerState::new(persistence);
-        // Just verify it compiles and persistence is accessible
-        let _ = &state.persistence;
+    fn new_disables_the_concurrency_cap_and_starts_undrained() {
+        let state = InstanceHandlerState::new(Arc::new(MockPersistence::new()));
+
+        // 0 is the documented "no cap" value — a nonzero default here would
+        // silently start refusing registrations.
+        assert_eq!(state.max_concurrent_instances, 0);
+        assert!(!state.is_draining());
+    }
+
+    #[test]
+    fn with_limits_carries_the_concurrency_cap() {
+        let state = InstanceHandlerState::with_limits(Arc::new(MockPersistence::new()), 12);
+
+        assert_eq!(state.max_concurrent_instances, 12);
+        assert!(!state.is_draining());
+    }
+
+    #[test]
+    fn draining_handle_aliases_the_flag_the_state_reads() {
+        let state = InstanceHandlerState::new(Arc::new(MockPersistence::new()));
+        let handle = state.draining_handle();
+
+        // The handle exists so an external coordinator can request drain; if it
+        // were a copy rather than an alias, drain would be silently ignored.
+        assert!(!state.is_draining());
+        handle.store(true, Ordering::SeqCst);
+        assert!(state.is_draining());
+
+        handle.store(false, Ordering::SeqCst);
+        assert!(!state.is_draining());
     }
 }

--- a/crates/runtara-dsl/src/spec/compatibility.rs
+++ b/crates/runtara-dsl/src/spec/compatibility.rs
@@ -476,8 +476,15 @@ mod tests {
             BreakingChangeType::RemovedStepType
         ));
         assert_eq!(report.breaking_changes[0].component, "GroupBy");
-        // GroupBy has a migration guide
-        assert!(report.breaking_changes[0].migration_guide.is_some());
+        // GroupBy has a migration guide, and it must name the replacement.
+        assert!(
+            report.breaking_changes[0]
+                .migration_guide
+                .as_deref()
+                .is_some_and(|g| g.contains("transform.group-by")),
+            "got {:?}",
+            report.breaking_changes[0].migration_guide
+        );
     }
 
     #[test]
@@ -898,42 +905,40 @@ mod tests {
     }
 
     // ============================================================================
-    // BreakingChangeType Tests
+    // Migration guidance on removals
     // ============================================================================
 
+    /// A removed step type only carries a migration guide when a replacement
+    /// actually exists. `test_dsl_compatibility_step_removed` pins the GroupBy
+    /// case; this pins the other side of that branch, so a guide can't start
+    /// leaking onto every removal.
     #[test]
-    fn test_breaking_change_type_variants() {
-        let variants = vec![
-            BreakingChangeType::RemovedStepType,
-            BreakingChangeType::RemovedAgent,
-            BreakingChangeType::RemovedCapability,
-            BreakingChangeType::RequiredFieldAdded,
-            BreakingChangeType::TypeChanged,
-            BreakingChangeType::EnumValueRemoved,
-        ];
-        // Just verify all variants can be created and debugged
-        for variant in variants {
-            let _ = format!("{:?}", variant);
-        }
-    }
+    fn removed_step_type_without_a_replacement_has_no_migration_guide() {
+        let old_spec = json!({
+            "definitions": {
+                "Step": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/AgentStep" },
+                        { "$ref": "#/definitions/LogStep" }
+                    ]
+                }
+            }
+        });
+        let new_spec = json!({
+            "definitions": {
+                "Step": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/AgentStep" }
+                    ]
+                }
+            }
+        });
 
-    // ============================================================================
-    // CompatibleChangeType Tests
-    // ============================================================================
+        let report = check_dsl_compatibility(&old_spec, &new_spec);
 
-    #[test]
-    fn test_compatible_change_type_variants() {
-        let variants = vec![
-            CompatibleChangeType::AddedStepType,
-            CompatibleChangeType::AddedAgent,
-            CompatibleChangeType::AddedCapability,
-            CompatibleChangeType::OptionalFieldAdded,
-            CompatibleChangeType::EnumValueAdded,
-            CompatibleChangeType::DescriptionUpdated,
-        ];
-        for variant in variants {
-            let _ = format!("{:?}", variant);
-        }
+        assert_eq!(report.breaking_changes.len(), 1);
+        assert_eq!(report.breaking_changes[0].component, "Log");
+        assert!(report.breaking_changes[0].migration_guide.is_none());
     }
 
     // ============================================================================

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -516,21 +516,8 @@ fn test_heartbeat_monitor_config_debug() {
 }
 
 // ============================================================================
-// HeartbeatMonitor Creation Tests
+// HeartbeatMonitor Lifecycle Tests
 // ============================================================================
-
-#[tokio::test]
-async fn test_heartbeat_monitor_creation() {
-    skip_if_no_db!();
-    let pool = get_test_pool().await;
-
-    let persistence = Arc::new(MockPersistence::new());
-    let config = HeartbeatMonitorConfig::default();
-
-    let monitor = HeartbeatMonitor::new(pool, persistence, Arc::new(MockRunner), config);
-    let _shutdown = monitor.shutdown_handle();
-    // Monitor created successfully
-}
 
 #[tokio::test]
 async fn test_heartbeat_monitor_shutdown() {
@@ -551,15 +538,20 @@ async fn test_heartbeat_monitor_shutdown() {
         monitor.run().await;
     });
 
-    // Give it a moment to start
+    // Give it a moment to start, so shutdown races against a running poll loop
+    // rather than arriving before `run` has begun.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Signal shutdown
     shutdown.notify_one();
 
-    // Wait for it to stop (with timeout)
-    let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
-    assert!(result.is_ok(), "Monitor should shutdown promptly");
+    // Wait for it to stop (with timeout). Both layers matter: the outer one is
+    // "did it stop in time", the inner one is "did it stop cleanly" — a panic
+    // inside `run` also joins promptly and would otherwise pass unnoticed.
+    tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("monitor should shut down within 2s of being notified")
+        .expect("monitor task should exit cleanly, not panic");
 }
 
 // ============================================================================

--- a/crates/runtara-http/src/lib.rs
+++ b/crates/runtara-http/src/lib.rs
@@ -468,48 +468,133 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_client() {
-        let _client = HttpClient::new();
-    }
-
-    #[test]
-    fn test_create_client_with_timeout() {
-        let _client = HttpClient::with_timeout(Duration::from_secs(5));
+    fn test_request_starts_empty_from_either_constructor() {
+        // The client-level timeout lives inside the backend agent and isn't
+        // observable from here; what both constructors must guarantee is that
+        // `request` seeds a builder with the verb and URL and nothing else.
+        for client in [
+            HttpClient::new(),
+            HttpClient::with_timeout(Duration::from_secs(5)),
+        ] {
+            let req = client.request("GET", "http://example.com/path");
+            assert_eq!(req.method, "GET");
+            assert_eq!(req.url, "http://example.com/path");
+            assert!(req.headers.is_empty());
+            assert!(req.query_params.is_empty());
+            assert!(req.body.is_none());
+            assert!(req.timeout.is_none());
+        }
     }
 
     #[test]
     fn test_request_builder_headers() {
         let client = HttpClient::new();
-        let _req = client
+        let req = client
             .request("GET", "http://example.com")
             .header("Authorization", "Bearer token")
             .header("Accept", "application/json");
+
+        // Order is preserved: some servers are sensitive to header ordering,
+        // and repeated keys must accumulate rather than overwrite.
+        assert_eq!(
+            req.headers,
+            vec![
+                ("Authorization".to_string(), "Bearer token".to_string()),
+                ("Accept".to_string(), "application/json".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_request_builder_repeated_header_key_accumulates() {
+        let client = HttpClient::new();
+        let req = client
+            .request("GET", "http://example.com")
+            .header("Set-Cookie", "a=1")
+            .header("Set-Cookie", "b=2");
+
+        assert_eq!(
+            req.headers,
+            vec![
+                ("Set-Cookie".to_string(), "a=1".to_string()),
+                ("Set-Cookie".to_string(), "b=2".to_string()),
+            ]
+        );
     }
 
     #[test]
     fn test_request_builder_query_params() {
         let client = HttpClient::new();
-        let _req = client
+        let req = client
             .request("GET", "http://example.com")
             .query("page", "1")
             .query("limit", "10");
+
+        assert_eq!(
+            req.query_params,
+            vec![
+                ("page".to_string(), "1".to_string()),
+                ("limit".to_string(), "10".to_string()),
+            ]
+        );
+        // Query params must not leak into the URL until the request executes.
+        assert_eq!(req.url, "http://example.com");
     }
 
     #[test]
     fn test_request_builder_json_body() {
         let client = HttpClient::new();
         let body = serde_json::json!({"key": "value"});
-        let _req = client
+        let req = client
             .request("POST", "http://example.com")
             .body_json(&body);
+
+        match req.body {
+            Some(Body::Json(ref value)) => assert_eq!(*value, body),
+            Some(Body::Bytes(_)) => panic!("body_json stored a byte body"),
+            None => panic!("body_json stored no body"),
+        }
     }
 
     #[test]
     fn test_request_builder_bytes_body() {
         let client = HttpClient::new();
-        let _req = client
+        let req = client
             .request("PUT", "http://example.com")
             .body_bytes(b"raw data");
+
+        match req.body {
+            Some(Body::Bytes(ref bytes)) => assert_eq!(bytes.as_slice(), b"raw data"),
+            Some(Body::Json(_)) => panic!("body_bytes stored a JSON body"),
+            None => panic!("body_bytes stored no body"),
+        }
+    }
+
+    #[test]
+    fn test_request_builder_last_body_wins() {
+        let client = HttpClient::new();
+        let req = client
+            .request("POST", "http://example.com")
+            .body_json(&serde_json::json!({"key": "value"}))
+            .body_bytes(b"raw data");
+
+        // A single request carries a single body; the later call replaces the
+        // earlier one rather than sending both or silently keeping the first.
+        match req.body {
+            Some(Body::Bytes(ref bytes)) => assert_eq!(bytes.as_slice(), b"raw data"),
+            Some(Body::Json(_)) => panic!("the earlier JSON body survived body_bytes"),
+            None => panic!("no body was stored"),
+        }
+    }
+
+    #[test]
+    fn test_request_builder_timeout_is_recorded() {
+        let client = HttpClient::new();
+        let req = client
+            .request("GET", "http://example.com")
+            .timeout(Duration::from_secs(7));
+
+        assert_eq!(req.timeout, Some(Duration::from_secs(7)));
     }
 
     #[test]

--- a/crates/runtara-sdk/src/types.rs
+++ b/crates/runtara-sdk/src/types.rs
@@ -612,12 +612,43 @@ mod tests {
     }
 
     #[test]
-    fn test_retry_config_delay_overflow_protection() {
-        // Test that we don't overflow with very large values
+    fn test_retry_config_delay_saturates_on_multiply_overflow() {
+        // `delay_ms * 2^63` overflows u64. Saturating to the maximum delay is
+        // what keeps a failing call backing off; wrapping would hand back a
+        // tiny duration and turn the backoff into a retry storm.
         let config = RetryConfig::new(100, u64::MAX, RetryStrategy::ExponentialBackoff);
-        // This should use saturating_mul and not panic
-        let _delay = config.delay_for_attempt(64); // 2^63 would overflow
-        // Just verify it doesn't panic
+        assert_eq!(
+            config.delay_for_attempt(64),
+            std::time::Duration::from_millis(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn test_retry_config_delay_saturates_on_exponent_overflow() {
+        // Attempt 65 asks for 2^64, which does not fit in u64. The multiplier
+        // itself must saturate before it ever reaches the multiply.
+        let config = RetryConfig::new(100, 1, RetryStrategy::ExponentialBackoff);
+        assert_eq!(
+            config.delay_for_attempt(65),
+            std::time::Duration::from_millis(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn test_retry_config_delay_never_decreases_with_attempt() {
+        // The property that actually matters: no attempt may back off less than
+        // the attempt before it, including across both saturation points.
+        let config = RetryConfig::new(100, 1000, RetryStrategy::ExponentialBackoff);
+        let mut previous = config.delay_for_attempt(0);
+        for attempt in 1..=70 {
+            let current = config.delay_for_attempt(attempt);
+            assert!(
+                current >= previous,
+                "attempt {attempt} backs off {current:?}, less than the previous {previous:?}"
+            );
+            previous = current;
+        }
+        assert_eq!(previous, std::time::Duration::from_millis(u64::MAX));
     }
 
     #[test]

--- a/crates/runtara-server/src/observability/trace_context.rs
+++ b/crates/runtara-server/src/observability/trace_context.rs
@@ -87,14 +87,100 @@ mod tests {
     // each other and produce flaky results.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Run `f` under a thread-local subscriber carrying a real OpenTelemetry
+    /// tracer, so span contexts are valid regardless of what the rest of the
+    /// test binary has installed globally. `with_default` scopes the
+    /// subscriber to this thread, so parallel tests are unaffected.
+    fn with_otel_subscriber<T>(f: impl FnOnce() -> T) -> T {
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::SdkTracerProvider;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        // No exporter: spans are still sampled and assigned real ids, they
+        // just go nowhere, which is all these assertions need.
+        let provider = SdkTracerProvider::builder().build();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer().with_tracer(provider.tracer("trace-context-test")),
+        );
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
     #[test]
     fn test_format_traceparent_no_active_span() {
-        // Without an active span, should return None.
-        // This test does not touch env vars, so no lock is needed.
-        let result = format_traceparent();
-        // May or may not be None depending on whether OTel is initialised in
-        // the test process — just ensure it doesn't panic.
-        let _ = result;
+        // A subscriber with no OpenTelemetry layer yields no span context, so
+        // there is nothing to propagate. Pinning the subscriber makes the
+        // answer deterministic instead of depending on whether some other test
+        // in this binary happened to initialise OTel first.
+        let result = tracing::subscriber::with_default(tracing_subscriber::registry(), || {
+            let span = tracing::info_span!("no_otel_layer");
+            let _entered = span.enter();
+            format_traceparent()
+        });
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_format_traceparent_with_active_span() {
+        let (traceparent, context) = with_otel_subscriber(|| {
+            let span = tracing::info_span!("outbound");
+            let _entered = span.enter();
+            (format_traceparent(), get_current_trace_context())
+        });
+
+        let traceparent = traceparent.expect("an active sampled span must produce a traceparent");
+
+        // W3C traceparent: version "00", 32-hex trace id, 16-hex span id, and
+        // the sampled flag. A child process parses this verbatim, so the field
+        // widths matter as much as the values.
+        let fields: Vec<&str> = traceparent.split('-').collect();
+        assert_eq!(fields.len(), 4, "malformed traceparent {traceparent:?}");
+        assert_eq!(fields[0], "00");
+        assert_eq!(fields[1].len(), 32, "trace id must be 32 hex chars");
+        assert_eq!(fields[2].len(), 16, "span id must be 16 hex chars");
+        assert_eq!(fields[3], "01");
+        assert!(
+            fields[1]
+                .chars()
+                .chain(fields[2].chars())
+                .all(|c| c.is_ascii_hexdigit()),
+            "trace and span ids must be lower-hex, got {traceparent:?}"
+        );
+
+        // Neither id may be the all-zero "invalid" sentinel.
+        assert_ne!(fields[1], "0".repeat(32));
+        assert_ne!(fields[2], "0".repeat(16));
+
+        // The header is exactly the pair `get_current_trace_context` reports.
+        let (trace_id, span_id) = context.expect("context must be present alongside traceparent");
+        assert_eq!(fields[1], trace_id);
+        assert_eq!(fields[2], span_id);
+    }
+
+    #[test]
+    fn test_sibling_spans_share_a_trace_but_not_a_span_id() {
+        // Propagation is only useful if the span id actually tracks the span
+        // being propagated from; a stale or constant span id would still pass
+        // every shape check above.
+        let (outer, inner) = with_otel_subscriber(|| {
+            let outer_span = tracing::info_span!("outer");
+            let _outer = outer_span.enter();
+            let outer_ctx = get_current_trace_context();
+
+            let inner_span = tracing::info_span!("inner");
+            let _inner = inner_span.enter();
+            let inner_ctx = get_current_trace_context();
+
+            (outer_ctx, inner_ctx)
+        });
+
+        let (outer_trace, outer_span) = outer.expect("outer span context");
+        let (inner_trace, inner_span) = inner.expect("inner span context");
+
+        assert_eq!(
+            outer_trace, inner_trace,
+            "a child span joins its parent trace"
+        );
+        assert_ne!(outer_span, inner_span, "each span needs its own span id");
     }
 
     #[test]


### PR DESCRIPTION
Six tests constructed values and dropped them without asserting anything, so the code paths they named were unverified. Each is replaced with assertions on the behaviour the test claims to cover.

- runtara-sdk: the sole guard on RetryConfig's saturating arithmetic just called delay_for_attempt and discarded it. Swapping saturating_mul or saturating_pow for the wrapping variants now fails; before, both passed and a wrapped multiplier would silently turn backoff into a retry storm.
- runtara-http: six builder tests bound their result to `_`, so header, query, body_json and body_bytes could each be a no-op returning self. They now assert the stored fields, plus coverage for repeated header keys, last-body-wins and the per-request timeout.
- runtara-dsl: the two *_variants tests only Debug-formatted each enum variant. Dropped, since check_dsl_compatibility's classification is already covered; kept one genuinely new case, a removal with no replacement carrying no migration guide, and tightened the GroupBy assertion from is_some() to naming the replacement.
- runtara-server: test_format_traceparent_no_active_span read whatever ambient tracing state the binary happened to have and accepted either answer. It now pins a thread-local subscriber, and two new tests cover the W3C traceparent field widths and that sibling spans share a trace but not a span id.
- runtara-core / runtara-component-host: the "verify it compiles" tests now assert the defaults that matter — the disabled concurrency cap, the draining flag aliasing through draining_handle, and HostState sharing one CallContext with its hooks.
- runtara-environment: test_heartbeat_monitor_creation needed a live database to verify nothing; dropped. test_heartbeat_monitor_shutdown only checked the join did not time out, so a panic inside run() also passed — it now unwraps both layers.