### PR TITLE
SYN-600: Add a read-only scope to API keys

### DIFF
--- a/crates/runtara-server/frontend/e2e/tests/mocked/settings/api-keys.mocked.spec.ts
+++ b/crates/runtara-server/frontend/e2e/tests/mocked/settings/api-keys.mocked.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test, buildApiKey } from '../../../fixtures';
 import { SettingsPage } from '../../../pages/SettingsPage';
 
@@ -10,6 +11,9 @@ test.describe('Settings / API keys (mocked)', () => {
     await mockApi.bootstrap(page);
     await mockApi.apiKeys.list(page, [
       buildApiKey({ name: 'CI deploy key' }),
+      // A null scope is what every key created before scopes existed carries, so both
+      // renderings of the Scope column are covered by the snapshot.
+      buildApiKey({ name: 'Read-only MCP key', scope: 'read_only' }),
       buildApiKey({ name: 'Backup key' }),
     ]);
 
@@ -31,5 +35,69 @@ test.describe('Settings / API keys (mocked)', () => {
     await view.expectHeading(/api keys/i);
     await runA11y(page, { exclude: ['[data-sonner-toaster]'] });
     await view.expectMatchesSnapshot('settings-api-keys-empty');
+  });
+
+  // The scope is write-once at creation — there is no edit path — so what this dialog POSTs
+  // is the whole contract between it and the credential the server issues.
+
+  test('creates an unscoped key by default', async ({ page, mockApi }) => {
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, []);
+
+    const bodies: unknown[] = [];
+    await page.route(/\/api\/runtime(?:\/[^/]+)?\/api-keys$/, async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      bodies.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...buildApiKey({ name: 'CI key' }),
+          key: 'rt_org_mocked_e2e_deadbeef',
+        }),
+      });
+    });
+
+    const view = new SettingsPage(page);
+    await view.goto();
+    await page.getByRole('button', { name: /new api key/i }).click();
+    await page.getByLabel('Name').fill('CI key');
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    await expect.poll(() => bodies.length).toBe(1);
+    // No `scope` key at all — an unscoped key is stored exactly like a pre-scope one.
+    expect(bodies[0]).toEqual({ name: 'CI key' });
+  });
+
+  test('creates a read-only key when the checkbox is ticked', async ({
+    page,
+    mockApi,
+  }) => {
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, []);
+
+    const bodies: unknown[] = [];
+    await page.route(/\/api\/runtime(?:\/[^/]+)?\/api-keys$/, async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback();
+      bodies.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...buildApiKey({ name: 'MCP reader', scope: 'read_only' }),
+          key: 'rt_org_mocked_e2e_deadbeef',
+        }),
+      });
+    });
+
+    const view = new SettingsPage(page);
+    await view.goto();
+    await page.getByRole('button', { name: /new api key/i }).click();
+    await page.getByLabel('Name').fill('MCP reader');
+    await page.getByLabel('Read-only').check();
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    await expect.poll(() => bodies.length).toBe(1);
+    expect(bodies[0]).toEqual({ name: 'MCP reader', scope: 'read_only' });
   });
 });

--- a/crates/runtara-server/frontend/e2e/tests/mocked/settings/api-keys.mocked.spec.ts
+++ b/crates/runtara-server/frontend/e2e/tests/mocked/settings/api-keys.mocked.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { test, buildApiKey } from '../../../fixtures';
 import { SettingsPage } from '../../../pages/SettingsPage';
 
@@ -25,6 +25,34 @@ test.describe('Settings / API keys (mocked)', () => {
     await view.expectMatchesSnapshot('settings-api-keys');
   });
 
+  test('tells an expired key apart from an active one', async ({
+    page,
+    mockApi,
+  }) => {
+    // An expired key is never revoked — the server just stops validating it — so without an
+    // expiry-aware status it would sit here labelled "Active" while refusing every request.
+    const inDays = (days: number) =>
+      new Date(Date.now() + days * 86_400_000).toISOString();
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, [
+      buildApiKey({ name: 'Long lived key', expires_at: inDays(90) }),
+      buildApiKey({ name: 'Nearly done key', expires_at: inDays(3) }),
+      buildApiKey({ name: 'Lapsed key', expires_at: inDays(-1) }),
+      buildApiKey({ name: 'Permanent key' }),
+    ]);
+
+    const view = new SettingsPage(page);
+    await view.goto();
+    await view.expectHeading(/api keys/i);
+
+    const rowFor = (name: string) =>
+      page.getByRole('row').filter({ hasText: name });
+    await expect(rowFor('Long lived key')).toContainText('Active');
+    await expect(rowFor('Nearly done key')).toContainText('Expiring');
+    await expect(rowFor('Lapsed key')).toContainText('Expired');
+    await expect(rowFor('Permanent key')).toContainText('No expiration');
+  });
+
   test('empty state', async ({ page, mockApi, runA11y }) => {
     await mockApi.bootstrap(page);
     await mockApi.apiKeys.list(page, []);
@@ -37,13 +65,14 @@ test.describe('Settings / API keys (mocked)', () => {
     await view.expectMatchesSnapshot('settings-api-keys-empty');
   });
 
-  // The scope is write-once at creation — there is no edit path — so what this dialog POSTs
-  // is the whole contract between it and the credential the server issues.
+  // Scope and expiry are both write-once at creation — there is no edit path — so what this
+  // dialog POSTs is the whole contract between it and the credential the server issues.
 
-  test('creates an unscoped key by default', async ({ page, mockApi }) => {
-    await mockApi.bootstrap(page);
-    await mockApi.apiKeys.list(page, []);
-
+  /** Capture the create-key POST bodies and answer with a plausible created key. */
+  async function captureCreates(
+    page: Page,
+    created: Parameters<typeof buildApiKey>[0] = {}
+  ): Promise<unknown[]> {
     const bodies: unknown[] = [];
     await page.route(/\/api\/runtime(?:\/[^/]+)?\/api-keys$/, async (route) => {
       if (route.request().method() !== 'POST') return route.fallback();
@@ -52,11 +81,22 @@ test.describe('Settings / API keys (mocked)', () => {
         status: 201,
         contentType: 'application/json',
         body: JSON.stringify({
-          ...buildApiKey({ name: 'CI key' }),
+          ...buildApiKey(created),
           key: 'rt_org_mocked_e2e_deadbeef',
         }),
       });
     });
+    return bodies;
+  }
+
+  /** Days between now and an ISO timestamp, rounded — the presets are day-granular. */
+  const daysUntil = (iso: string) =>
+    Math.round((new Date(iso).getTime() - Date.now()) / 86_400_000);
+
+  test('defaults to a 90-day key with no scope', async ({ page, mockApi }) => {
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, []);
+    const bodies = await captureCreates(page, { name: 'CI key' });
 
     const view = new SettingsPage(page);
     await view.goto();
@@ -65,8 +105,16 @@ test.describe('Settings / API keys (mocked)', () => {
     await page.getByRole('button', { name: /^create$/i }).click();
 
     await expect.poll(() => bodies.length).toBe(1);
-    // No `scope` key at all — an unscoped key is stored exactly like a pre-scope one.
-    expect(bodies[0]).toEqual({ name: 'CI key' });
+    const body = bodies[0] as {
+      name: string;
+      expires_at: string;
+      scope?: string;
+    };
+    expect(body.name).toBe('CI key');
+    // Untouched, the dialog produces a bounded key — the default is deliberately not
+    // "no expiration", which is what every key created before this control carried.
+    expect(daysUntil(body.expires_at)).toBe(90);
+    expect(body.scope).toBeUndefined();
   });
 
   test('creates a read-only key when the checkbox is ticked', async ({
@@ -75,19 +123,9 @@ test.describe('Settings / API keys (mocked)', () => {
   }) => {
     await mockApi.bootstrap(page);
     await mockApi.apiKeys.list(page, []);
-
-    const bodies: unknown[] = [];
-    await page.route(/\/api\/runtime(?:\/[^/]+)?\/api-keys$/, async (route) => {
-      if (route.request().method() !== 'POST') return route.fallback();
-      bodies.push(route.request().postDataJSON());
-      await route.fulfill({
-        status: 201,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          ...buildApiKey({ name: 'MCP reader', scope: 'read_only' }),
-          key: 'rt_org_mocked_e2e_deadbeef',
-        }),
-      });
+    const bodies = await captureCreates(page, {
+      name: 'MCP reader',
+      scope: 'read_only',
     });
 
     const view = new SettingsPage(page);
@@ -98,6 +136,48 @@ test.describe('Settings / API keys (mocked)', () => {
     await page.getByRole('button', { name: /^create$/i }).click();
 
     await expect.poll(() => bodies.length).toBe(1);
-    expect(bodies[0]).toEqual({ name: 'MCP reader', scope: 'read_only' });
+    const body = bodies[0] as { name: string; scope: string };
+    expect(body.name).toBe('MCP reader');
+    expect(body.scope).toBe('read_only');
+  });
+
+  test('omits expires_at entirely when No expiration is chosen', async ({
+    page,
+    mockApi,
+  }) => {
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, []);
+    const bodies = await captureCreates(page, { name: 'Permanent key' });
+
+    const view = new SettingsPage(page);
+    await view.goto();
+    await page.getByRole('button', { name: /new api key/i }).click();
+    await page.getByLabel('Name').fill('Permanent key');
+    await page.getByLabel('Expiration').click();
+    await page.getByRole('option', { name: 'No expiration' }).click();
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    await expect.poll(() => bodies.length).toBe(1);
+    // Absent, not null: a permanent key is stored exactly like a pre-expiry one.
+    expect(bodies[0]).toEqual({ name: 'Permanent key' });
+  });
+
+  test('sends the chosen preset', async ({ page, mockApi }) => {
+    await mockApi.bootstrap(page);
+    await mockApi.apiKeys.list(page, []);
+    const bodies = await captureCreates(page, { name: 'Short key' });
+
+    const view = new SettingsPage(page);
+    await view.goto();
+    await page.getByRole('button', { name: /new api key/i }).click();
+    await page.getByLabel('Name').fill('Short key');
+    await page.getByLabel('Expiration').click();
+    await page.getByRole('option', { name: '30 days' }).click();
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    await expect.poll(() => bodies.length).toBe(1);
+    expect(daysUntil((bodies[0] as { expires_at: string }).expires_at)).toBe(
+      30
+    );
   });
 });

--- a/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
+++ b/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { toast } from 'sonner';
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/shared/components/ui/dialog';
 import { Button } from '@/shared/components/ui/button';
+import { Checkbox } from '@/shared/components/ui/checkbox';
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import { FieldError } from '@/shared/components/ui/form';
@@ -21,6 +22,8 @@ import { Alert, AlertDescription } from '@/shared/components/ui/alert';
 
 const schema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
+  /** Maps to the `read_only` scope on submit; unchecked sends no scope at all. */
+  readOnly: z.boolean(),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -37,16 +40,21 @@ export function CreateApiKeyDialog({ open, onClose }: CreateApiKeyDialogProps) {
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { name: '' },
+    defaultValues: { name: '', readOnly: false },
   });
 
-  const handleSubmit = (values: FormValues) => {
-    createKey(values, {
-      onSuccess: (data) => {
-        setCreatedKey(data.key);
-        toast.success('API key created');
-      },
-    });
+  const handleSubmit = ({ name, readOnly }: FormValues) => {
+    // An unscoped key sends no `scope` at all, so it is stored exactly like every key
+    // created before scopes existed.
+    createKey(
+      { name, ...(readOnly ? { scope: 'read_only' as const } : {}) },
+      {
+        onSuccess: (data) => {
+          setCreatedKey(data.key);
+          toast.success('API key created');
+        },
+      }
+    );
   };
 
   const handleCopy = async () => {
@@ -114,19 +122,45 @@ export function CreateApiKeyDialog({ open, onClose }: CreateApiKeyDialogProps) {
                 Create an API key for MCP or external integrations.
               </DialogDescription>
             </DialogHeader>
-            <div className="py-4">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                placeholder="e.g. MCP Server, CI/CD Pipeline"
-                {...form.register('name')}
-                className="mt-1.5"
-              />
-              {form.formState.errors.name && (
-                <FieldError className="mt-1">
-                  {form.formState.errors.name.message}
-                </FieldError>
-              )}
+            <div className="space-y-4 py-4">
+              <div>
+                <Label htmlFor="name">Name</Label>
+                <Input
+                  id="name"
+                  placeholder="e.g. MCP Server, CI/CD Pipeline"
+                  {...form.register('name')}
+                  className="mt-1.5"
+                />
+                {form.formState.errors.name && (
+                  <FieldError className="mt-1">
+                    {form.formState.errors.name.message}
+                  </FieldError>
+                )}
+              </div>
+              <div className="flex items-start gap-2.5">
+                <Controller
+                  control={form.control}
+                  name="readOnly"
+                  render={({ field }) => (
+                    <Checkbox
+                      id="read-only"
+                      checked={field.value}
+                      onCheckedChange={(state) => field.onChange(state === true)}
+                      className="mt-0.5"
+                    />
+                  )}
+                />
+                <div className="space-y-1">
+                  <Label htmlFor="read-only" className="font-normal">
+                    Read-only
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    The key acts as you, limited to read operations — it can't
+                    create, edit, delete, run workflows, or manage API keys.
+                    Scope can't be changed later.
+                  </p>
+                </div>
+              </div>
             </div>
             <DialogFooter>
               <Button

--- a/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
+++ b/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
@@ -145,7 +145,9 @@ export function CreateApiKeyDialog({ open, onClose }: CreateApiKeyDialogProps) {
                     <Checkbox
                       id="read-only"
                       checked={field.value}
-                      onCheckedChange={(state) => field.onChange(state === true)}
+                      onCheckedChange={(state) =>
+                        field.onChange(state === true)
+                      }
                       className="mt-0.5"
                     />
                   )}

--- a/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
+++ b/crates/runtara-server/frontend/src/features/settings/components/CreateApiKeyDialog/index.tsx
@@ -3,6 +3,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { toast } from 'sonner';
+import { addDays } from 'date-fns';
 import { Copy, Check, AlertTriangle } from 'lucide-react';
 import {
   Dialog,
@@ -16,14 +17,50 @@ import { Button } from '@/shared/components/ui/button';
 import { Checkbox } from '@/shared/components/ui/checkbox';
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
 import { FieldError } from '@/shared/components/ui/form';
 import { useCreateApiKey } from '../../hooks/useApiKeys';
 import { Alert, AlertDescription } from '@/shared/components/ui/alert';
+
+/**
+ * Expiry presets, shortest first. `null` days is "no expiration" — kept as an option in the
+ * same select rather than a separate checkbox, so choosing a permanent key is one decision in
+ * one control instead of two that can disagree.
+ *
+ * The default is a bounded lifetime, not "never": before this existed every key created through
+ * this dialog was permanent, and a default that quietly reproduces that is the thing worth
+ * changing. A permanent key is still one click away, it just has to be asked for.
+ */
+const EXPIRY_OPTIONS = [
+  { value: '30d', label: '30 days', days: 30 },
+  { value: '90d', label: '90 days', days: 90 },
+  { value: '180d', label: '180 days', days: 180 },
+  { value: '1y', label: '1 year', days: 365 },
+  { value: 'never', label: 'No expiration', days: null },
+] as const;
+
+const DEFAULT_EXPIRY = '90d';
+
+type ExpiryValue = (typeof EXPIRY_OPTIONS)[number]['value'];
+
+/** The `expires_at` a preset resolves to, or `undefined` for "no expiration". */
+function expiresAtFor(value: ExpiryValue): string | undefined {
+  const option = EXPIRY_OPTIONS.find((o) => o.value === value);
+  if (!option?.days) return undefined;
+  return addDays(new Date(), option.days).toISOString();
+}
 
 const schema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
   /** Maps to the `read_only` scope on submit; unchecked sends no scope at all. */
   readOnly: z.boolean(),
+  expiry: z.enum(EXPIRY_OPTIONS.map((o) => o.value) as [string, ...string[]]),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -40,14 +77,20 @@ export function CreateApiKeyDialog({ open, onClose }: CreateApiKeyDialogProps) {
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { name: '', readOnly: false },
+    defaultValues: { name: '', readOnly: false, expiry: DEFAULT_EXPIRY },
   });
 
-  const handleSubmit = ({ name, readOnly }: FormValues) => {
-    // An unscoped key sends no `scope` at all, so it is stored exactly like every key
-    // created before scopes existed.
+  const handleSubmit = ({ name, readOnly, expiry }: FormValues) => {
+    // Both narrowings are omitted rather than sent as an explicit "none": an unscoped,
+    // non-expiring key is then stored exactly like every key created before either control
+    // existed, so there is one representation of each default.
+    const expiresAt = expiresAtFor(expiry as ExpiryValue);
     createKey(
-      { name, ...(readOnly ? { scope: 'read_only' as const } : {}) },
+      {
+        name,
+        ...(readOnly ? { scope: 'read_only' as const } : {}),
+        ...(expiresAt ? { expires_at: expiresAt } : {}),
+      },
       {
         onSuccess: (data) => {
           setCreatedKey(data.key);
@@ -136,6 +179,27 @@ export function CreateApiKeyDialog({ open, onClose }: CreateApiKeyDialogProps) {
                     {form.formState.errors.name.message}
                   </FieldError>
                 )}
+              </div>
+              <div>
+                <Label htmlFor="expiry">Expiration</Label>
+                <Controller
+                  control={form.control}
+                  name="expiry"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger id="expiry" className="mt-1.5">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {EXPIRY_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
               </div>
               <div className="flex items-start gap-2.5">
                 <Controller

--- a/crates/runtara-server/frontend/src/features/settings/pages/Settings/index.tsx
+++ b/crates/runtara-server/frontend/src/features/settings/pages/Settings/index.tsx
@@ -28,6 +28,19 @@ import { CreateApiKeyDialog } from '../../components/CreateApiKeyDialog';
 import { RevokeApiKeyDialog } from '../../components/RevokeApiKeyDialog';
 import type { ApiKey } from '@/generated/RuntaraRuntimeApi';
 
+/**
+ * A key's scope, as stored: `null` means no narrowing — the key exercises its owner's role in
+ * full, which is what every key created before scopes existed carries.
+ */
+function ApiKeyScopeLabel({ scope }: { scope: ApiKey['scope'] }) {
+  if (!scope) return <>Full access</>;
+  if (scope === 'read_only')
+    return <StatusPill tone="neutral" dot={false} label="Read-only" />;
+  // A scope this build doesn't know about: the server denies everything for it, so show the
+  // raw value rather than implying it grants anything.
+  return <StatusPill tone="neutral" dot={false} label={scope} />;
+}
+
 export function Settings() {
   const { data: apiKeys, isFetching, isError, error } = useApiKeys();
   const [createOpen, setCreateOpen] = useState(false);
@@ -89,6 +102,7 @@ export function Settings() {
             <TableHead>Name</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>Key</TableHead>
+            <TableHead>Scope</TableHead>
             <TableHead>Created</TableHead>
             <TableHead>Last used</TableHead>
             <TableHead>Expires</TableHead>
@@ -106,6 +120,9 @@ export function Settings() {
               </TableCell>
               <TableCell className="font-mono text-xs text-muted-foreground">
                 {key.key_prefix}...
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <ApiKeyScopeLabel scope={key.scope} />
               </TableCell>
               <TableCell className="text-muted-foreground">
                 {formatDate(key.created_at)}
@@ -144,6 +161,9 @@ export function Settings() {
               </TableCell>
               <TableCell className="font-mono text-xs text-muted-foreground">
                 {key.key_prefix}...
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <ApiKeyScopeLabel scope={key.scope} />
               </TableCell>
               <TableCell className="text-muted-foreground">
                 {formatDate(key.created_at)}

--- a/crates/runtara-server/frontend/src/features/settings/pages/Settings/index.tsx
+++ b/crates/runtara-server/frontend/src/features/settings/pages/Settings/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { PlusIcon, Key, Ban } from 'lucide-react';
+import { addDays, formatDistanceToNowStrict } from 'date-fns';
 import { formatDate } from '@/lib/utils';
 import { Button } from '@/shared/components/ui/button';
 import { WithTooltip } from '@/shared/components/ui/tooltip';
@@ -27,6 +28,51 @@ import { useApiKeys } from '../../hooks/useApiKeys';
 import { CreateApiKeyDialog } from '../../components/CreateApiKeyDialog';
 import { RevokeApiKeyDialog } from '../../components/RevokeApiKeyDialog';
 import type { ApiKey } from '@/generated/RuntaraRuntimeApi';
+
+/** A key is called out as expiring this many days ahead of `expires_at`. */
+const EXPIRY_WARNING_DAYS = 7;
+
+/**
+ * Where a key sits relative to its own expiry. The server stops validating a key the moment
+ * `expires_at` passes (`validate_api_key_by_hash` filters on it), but nothing revokes the row —
+ * so an expired key is still `is_revoked: false` and would otherwise render as "Active" while
+ * refusing every request. `expired` exists to keep this table honest about that.
+ */
+function expiryState(
+  expiresAt: ApiKey['expires_at']
+): 'none' | 'expired' | 'soon' | 'ok' {
+  if (!expiresAt) return 'none';
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) return 'none';
+  if (expiry <= new Date()) return 'expired';
+  return expiry <= addDays(new Date(), EXPIRY_WARNING_DAYS) ? 'soon' : 'ok';
+}
+
+/** The status pill for a key that has not been revoked. */
+function ApiKeyStatusPill({ apiKey }: { apiKey: ApiKey }) {
+  switch (expiryState(apiKey.expires_at)) {
+    case 'expired':
+      return <StatusPill tone="neutral" label="Expired" />;
+    case 'soon':
+      return <StatusPill tone="warning" label="Expiring" />;
+    default:
+      return <StatusPill tone="success" label="Active" />;
+  }
+}
+
+/** The Expires cell: the date, plus how long is left while that is still worth saying. */
+function ApiKeyExpiry({ apiKey }: { apiKey: ApiKey }) {
+  const state = expiryState(apiKey.expires_at);
+  if (state === 'none' || !apiKey.expires_at) return <>No expiration</>;
+  return (
+    <span className={state === 'soon' ? 'text-warning' : undefined}>
+      {formatDate(apiKey.expires_at)}
+      {state === 'soon' && (
+        <> · in {formatDistanceToNowStrict(new Date(apiKey.expires_at))}</>
+      )}
+    </span>
+  );
+}
 
 /**
  * A key's scope, as stored: `null` means no narrowing — the key exercises its owner's role in
@@ -116,7 +162,7 @@ export function Settings() {
                 {key.name}
               </TableCell>
               <TableCell className="text-muted-foreground">
-                <StatusPill tone="success" label="Active" />
+                <ApiKeyStatusPill apiKey={key} />
               </TableCell>
               <TableCell className="font-mono text-xs text-muted-foreground">
                 {key.key_prefix}...
@@ -131,7 +177,7 @@ export function Settings() {
                 {key.last_used_at ? formatDate(key.last_used_at) : 'Never'}
               </TableCell>
               <TableCell className="text-muted-foreground">
-                {key.expires_at ? formatDate(key.expires_at) : 'No expiration'}
+                <ApiKeyExpiry apiKey={key} />
               </TableCell>
               <TableCell className="text-right">
                 <div className="flex items-center justify-end gap-1">
@@ -172,7 +218,7 @@ export function Settings() {
                 {key.last_used_at ? formatDate(key.last_used_at) : 'Never'}
               </TableCell>
               <TableCell className="text-muted-foreground">
-                {key.expires_at ? formatDate(key.expires_at) : 'No expiration'}
+                <ApiKeyExpiry apiKey={key} />
               </TableCell>
               <TableCell className="text-right" />
             </TableRow>

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -368,6 +368,9 @@ export type BulkValidationMode = "stop" | "skip";
 /** Behavior on unique-key conflict for bulk-create. */
 export type BulkConflictMode = "error" | "skip" | "upsert";
 
+/** How much of the issuing user's role the key may exercise. Omitted or `full` means no narrowing. */
+export type ApiKeyScope = "full" | "read_only";
+
 /** Aggregate function. JSON encoding is SCREAMING_SNAKE_CASE. */
 export type AggregateFn =
   | "COUNT"
@@ -758,6 +761,12 @@ export interface ApiKey {
   last_used_at?: string | null;
   name: string;
   org_id: string;
+  /**
+   * Optional narrowing of the inherited role (`read_only`). `None` — the value every key
+   * created before scopes existed carries — means no narrowing. Never widens: the role gate
+   * still runs on top. See [`ApiKeyScope`].
+   */
+  scope?: string | null;
 }
 
 /** Generic API response wrapper */
@@ -1022,6 +1031,13 @@ export interface ApiResponseWorkflowDto {
      */
     slug?: string | null;
     started?: string | null;
+    /**
+     * Whether this version can hold a conversation, i.e. whether it contains a
+     * step that waits for a reply. See `graph_supports_chat`. Consumers use it
+     * to decide whether to offer chat at all, rather than opening a surface
+     * that accepts messages nothing will ever read.
+     */
+    supportsChat?: boolean;
     /** Whether this version is compiled with step-event tracking instrumentation */
     trackEvents?: boolean;
     updated: string;
@@ -1680,6 +1696,12 @@ export interface CreateApiKeyRequest {
   expires_at?: string | null;
   /** Human-readable name for the key */
   name: string;
+  /**
+   * How much of the issuing user's role this key may exercise. Omitted (or `full`) means no
+   * narrowing — today's behavior. An unrecognized value is rejected rather than ignored, so
+   * a client asking for a scope this build doesn't know never silently gets a full key.
+   */
+  scope?: null | ApiKeyScope;
 }
 
 export type CreateApiKeyResponse = ApiKey & {
@@ -8049,7 +8071,7 @@ export class Api<
     listWorkflowsHandler: (
       query: {
         /**
-         * Page number (1-based, default: 1)
+         * Page number (0-based, default: 0)
          * @format int32
          */
         page?: number;

--- a/crates/runtara-server/migrations/20260813000000_api_keys_scope.sql
+++ b/crates/runtara-server/migrations/20260813000000_api_keys_scope.sql
@@ -1,0 +1,14 @@
+-- Per-key permission scope for `rt_*` API keys.
+--
+-- A key acts as its issuing user and inherits that user's live role on every request. `scope`
+-- is an additional filter applied on top of that role: it can only narrow what the key may do,
+-- never widen it.
+--
+-- The column holds a scope *name* (`read_only`), not a permission list, so a future scope is a
+-- new value rather than a new migration. NULL means "no narrowing" — the inherit-everything
+-- behavior every key had before this column existed, which is what every existing row keeps.
+
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS scope TEXT;
+
+COMMENT ON COLUMN api_keys.scope IS
+    'Optional narrowing of the key''s inherited role (e.g. read_only). NULL = no narrowing.';

--- a/crates/runtara-server/src/api/handlers/api_keys.rs
+++ b/crates/runtara-server/src/api/handlers/api_keys.rs
@@ -12,6 +12,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::auth::AuthContext;
+use crate::authz::ApiKeyScope;
 use crate::middleware::tenant_auth::{CallerId, OrgId, Source};
 use crate::product_events::{EventType, ProductEvent, ProductEventSink};
 
@@ -35,6 +36,10 @@ pub struct ApiKey {
     /// Token identity — the `token:revoked:{jti}` revocation-denylist key. `None` for
     /// legacy rows.
     pub jti: Option<String>,
+    /// Optional narrowing of the inherited role (`read_only`). `None` — the value every key
+    /// created before scopes existed carries — means no narrowing. Never widens: the role gate
+    /// still runs on top. See [`ApiKeyScope`].
+    pub scope: Option<String>,
     #[schema(value_type = String)]
     pub created_at: DateTime<Utc>,
     #[schema(value_type = Option<String>)]
@@ -51,6 +56,11 @@ pub struct CreateApiKeyRequest {
     /// Optional expiration time
     #[schema(value_type = Option<String>)]
     pub expires_at: Option<DateTime<Utc>>,
+    /// How much of the issuing user's role this key may exercise. Omitted (or `full`) means no
+    /// narrowing — today's behavior. An unrecognized value is rejected rather than ignored, so
+    /// a client asking for a scope this build doesn't know never silently gets a full key.
+    #[serde(default)]
+    pub scope: Option<ApiKeyScope>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -185,12 +195,15 @@ pub async fn create_api_key(
         plaintext_key[..12].to_string()
     };
     let key_hash = sha256_hex(&plaintext_key);
+    // `Full` persists as NULL, so an unscoped key created today is indistinguishable from one
+    // created before scopes existed — there is exactly one representation of "no narrowing".
+    let scope = request.scope.unwrap_or_default().to_column();
 
     match sqlx::query_as::<_, ApiKey>(
         r#"
-        INSERT INTO public.api_keys (org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, expires_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-        RETURNING id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, created_at, expires_at, last_used_at, is_revoked
+        INSERT INTO public.api_keys (org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, expires_at, scope)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        RETURNING id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, scope, created_at, expires_at, last_used_at, is_revoked
         "#,
     )
     .bind(&tenant_id)
@@ -201,6 +214,7 @@ pub async fn create_api_key(
     .bind(&issuing_user_id)
     .bind(&jti)
     .bind(request.expires_at)
+    .bind(scope)
     .fetch_one(&pool)
     .await
     {
@@ -253,7 +267,7 @@ pub async fn list_api_keys(
     // of role. Ownership — not a role permission — is the gate, so this scoping is unconditional.
     match sqlx::query_as::<_, ApiKey>(
         r#"
-        SELECT id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, created_at, expires_at, last_used_at, is_revoked
+        SELECT id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, scope, created_at, expires_at, last_used_at, is_revoked
         FROM public.api_keys
         WHERE org_id = $1 AND issuing_user_id = $2
         ORDER BY created_at DESC
@@ -362,7 +376,7 @@ pub async fn validate_api_key_by_hash(pool: &PgPool, key_hash: &str) -> Result<A
         WHERE key_hash = $1
           AND is_revoked = FALSE
           AND (expires_at IS NULL OR expires_at > NOW())
-        RETURNING id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, created_at, expires_at, last_used_at, is_revoked
+        RETURNING id, org_id, name, key_prefix, key_hash, created_by, issuing_user_id, jti, scope, created_at, expires_at, last_used_at, is_revoked
         "#,
     )
     .bind(key_hash)

--- a/crates/runtara-server/src/auth/mod.rs
+++ b/crates/runtara-server/src/auth/mod.rs
@@ -9,7 +9,7 @@ use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
-use crate::authz::Role;
+use crate::authz::{ApiKeyScope, Role};
 
 pub use provider::{AuthError, AuthProvider, AuthProviderKind, AuthProviders};
 
@@ -43,6 +43,13 @@ pub struct AuthContext {
     /// lookup populates it. JWTs never carry the role; it is read from the
     /// per-tenant Valkey `member:{sub}` entry.
     pub role: Option<Role>,
+    /// How much of `role` this credential may actually exercise. [`ApiKeyScope::Full`] for JWTs
+    /// and for every unscoped API key — the scope narrows an API key's inherited role and can
+    /// never widen it. Enforced in [`crate::middleware::authorization`] ahead of the role gate,
+    /// and inherited by MCP tool calls, which run their in-process API calls under a clone of
+    /// this context.
+    #[serde(default)]
+    pub api_key_scope: ApiKeyScope,
     /// Token identity (`jti` claim / API-key token id). Key for the revocation denylist.
     pub jti: Option<String>,
     /// Identity claims passed through from the JWT, for logging and the `/me` response.
@@ -62,6 +69,7 @@ impl AuthContext {
             user_id,
             auth_method,
             role: None,
+            api_key_scope: ApiKeyScope::Full,
             jti: None,
             email: None,
             name: None,

--- a/crates/runtara-server/src/auth/providers/oidc.rs
+++ b/crates/runtara-server/src/auth/providers/oidc.rs
@@ -72,6 +72,8 @@ impl AuthProvider for OidcProvider {
             // Role is read from the tenant's Valkey, not the JWT — populated by the auth
             // middleware's membership lookup.
             role: None,
+            // A JWT is the user themselves, not a narrowable credential: no scope to apply.
+            api_key_scope: crate::authz::ApiKeyScope::Full,
             jti: claims.jti,
             email: claims.email,
             name: claims.name,

--- a/crates/runtara-server/src/authz/mod.rs
+++ b/crates/runtara-server/src/authz/mod.rs
@@ -10,10 +10,16 @@
 //! The map is expressed per role: each [`Role`] owns a constant list of the permissions it
 //! grants and the scope of each (see [`Role::grants`]). A permission absent from a role's
 //! list is denied.
+//!
+//! A credential may narrow what it exercises of its role — see [`ApiKeyScope`] in [`scope`].
+
+pub mod scope;
 
 use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+pub use scope::ApiKeyScope;
 
 /// Built-in tenant roles, most- to least-privileged.
 ///
@@ -191,6 +197,21 @@ impl Permission {
     /// Parse a colon-style wire identifier back into a `Permission`.
     pub fn from_wire(s: &str) -> Option<Permission> {
         Permission::ALL.into_iter().find(|p| p.as_str() == s)
+    }
+
+    /// Whether this permission is a read — the `<resource>:read` half of the vocabulary.
+    ///
+    /// Derived from the wire form rather than a hand-kept list, so a permission added to the
+    /// enum joins or stays out of the read set by its own name instead of by remembering to
+    /// edit a second place. This is what [`ApiKeyScope::ReadOnly`] narrows to; the exact
+    /// membership is pinned by `is_read_matches_the_read_permissions`.
+    ///
+    /// Note this is a property of the *permission*, not of the HTTP method: routes that read
+    /// via `POST` (SQL queries, report renders, graph validation) map to a read permission and
+    /// are reads here, while `GET /connections/{id}/oauth/authorize` maps to
+    /// `connection:update` and is not.
+    pub fn is_read(self) -> bool {
+        self.as_str().ends_with(":read")
     }
 }
 
@@ -422,6 +443,34 @@ mod tests {
     #[test]
     fn role_rejects_unknown_value() {
         assert!(serde_json::from_value::<Role>(serde_json::json!("superuser")).is_err());
+    }
+
+    #[test]
+    fn is_read_matches_the_read_permissions() {
+        // `is_read` derives from the wire form, so this pins the resulting membership: it is
+        // what `ApiKeyScope::ReadOnly` lets through, and a permission joining or leaving the
+        // set is a change to what every read-only key can do.
+        let read: Vec<&str> = Permission::ALL
+            .into_iter()
+            .filter(|p| p.is_read())
+            .map(|p| p.as_str())
+            .collect();
+        assert_eq!(
+            read,
+            [
+                "workflow:read",
+                "invocation_history:read",
+                "database:read",
+                "report:read",
+                "trigger:read",
+                "connection:read",
+                "analytics:read",
+            ]
+        );
+        // The two non-`*:read` permissions that could plausibly be mistaken for reads: a
+        // capability grant, and a GET-shaped route that starts a credential change.
+        assert!(!Permission::UserManagementAccess.is_read());
+        assert!(!Permission::ConnectionUpdate.is_read());
     }
 
     #[test]

--- a/crates/runtara-server/src/authz/scope.rs
+++ b/crates/runtara-server/src/authz/scope.rs
@@ -1,0 +1,259 @@
+//! Per-credential scope: an optional narrowing applied on top of an API key's inherited role.
+//!
+//! An `rt_*` API key acts as its issuing user — it resolves that user's *current* role from the
+//! tenant Valkey on every request, so demoting the user degrades the key. What it could not do
+//! before was act as *less* than that user: a key minted by an Owner for a read-only
+//! integration could also delete workflows, run arbitrary SQL, and mint further keys.
+//!
+//! [`ApiKeyScope`] is that missing narrowing. It is stored per key (`api_keys.scope`), carried
+//! on [`crate::auth::AuthContext`], and enforced in [`crate::middleware::authorization`] *before*
+//! the role gate. Two properties are load-bearing:
+//!
+//! - **It only ever narrows.** The role gate still runs afterwards, unchanged, so a scope can
+//!   never grant what the issuing user's role denies.
+//! - **It does not depend on the membership rollout.** Unlike the role gate — dormant unless
+//!   [`crate::auth::MembershipPolicy`] is `Required` — the scope is a property of the credential
+//!   itself, so it is enforced in every mode. That is what makes it meaningful in the
+//!   non-OIDC self-hosted modes, where an API key acts as `Role::Owner` outright.
+//!
+//! Adding a scope later (`execute`, `data_read`, …) is a variant, an arm in [`ApiKeyScope::permits`],
+//! and a choice in the create dialog — the column stores a name, so no migration is involved.
+
+use axum::http::Method;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+use super::Permission;
+
+/// How much of its issuing user's role a key may actually exercise.
+///
+/// The wire and column form is the snake_case name ([`ApiKeyScope::as_str`]), matching the
+/// colon-free half of the [`Permission`] wire convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ApiKeyScope {
+    /// No narrowing: the key exercises its issuing user's role in full. This is what a `NULL`
+    /// column means, so every key issued before scopes existed keeps its behavior.
+    #[default]
+    Full,
+    /// Read-only: the key may perform read operations and nothing else. See
+    /// [`ApiKeyScope::permits`] for what "read" means at a route level.
+    ReadOnly,
+    /// A scope name this build does not recognize — a row written by a newer server, seen after
+    /// a rollback. Never selectable and never parsed from the wire; it denies everything, so an
+    /// unknown narrowing fails closed rather than silently degrading to `Full`.
+    Unrecognized,
+}
+
+impl ApiKeyScope {
+    /// The scopes a caller may choose when creating a key, in narrowing order. `Unrecognized` is
+    /// deliberately absent — it is a read-path artifact, not a choice.
+    pub const SELECTABLE: [ApiKeyScope; 2] = [ApiKeyScope::Full, ApiKeyScope::ReadOnly];
+
+    /// The wire/column identifier. `Unrecognized` renders as `unknown` for logs and metrics; it
+    /// is never persisted or accepted as input under that name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ApiKeyScope::Full => "full",
+            ApiKeyScope::ReadOnly => "read_only",
+            ApiKeyScope::Unrecognized => "unknown",
+        }
+    }
+
+    /// Parse a selectable scope name; `None` for anything else (including `unknown`).
+    pub fn from_wire(s: &str) -> Option<ApiKeyScope> {
+        Self::SELECTABLE.into_iter().find(|s2| s2.as_str() == s)
+    }
+
+    /// Read the scope off an `api_keys.scope` column value.
+    ///
+    /// `NULL` is [`ApiKeyScope::Full`] — the pre-scope behavior every existing key keeps. A
+    /// value this build cannot parse becomes [`ApiKeyScope::Unrecognized`] (denies everything)
+    /// rather than falling back to `Full`, so a downgrade cannot widen a key that was created
+    /// narrow.
+    pub fn from_column(value: Option<&str>) -> ApiKeyScope {
+        match value {
+            None => ApiKeyScope::Full,
+            Some(s) => ApiKeyScope::from_wire(s).unwrap_or(ApiKeyScope::Unrecognized),
+        }
+    }
+
+    /// The column value to persist: `None` for [`ApiKeyScope::Full`], so "no narrowing" is a
+    /// `NULL` and every unscoped key — old or new — is represented identically.
+    pub const fn to_column(self) -> Option<&'static str> {
+        match self {
+            ApiKeyScope::Full => None,
+            other => Some(other.as_str()),
+        }
+    }
+
+    /// Whether this scope permits a request, given the [`Permission`] the route maps to (`None`
+    /// for an ungated route) and the request method.
+    ///
+    /// [`ApiKeyScope::ReadOnly`] answers the two cases differently, and both halves matter:
+    ///
+    /// - **Mapped route** → the permission must be a read ([`Permission::is_read`]). Keying on
+    ///   the permission rather than the method is what keeps POST-shaped reads working — SQL
+    ///   `query`, report `preview`/`render`, graph `validate`, CSV export are all `POST` and all
+    ///   map to a `*:read` permission.
+    /// - **Ungated route** (`permission == None`) → the method must be safe. The ungated set is
+    ///   mostly metadata, but it also includes the API-key management routes, which are gated by
+    ///   ownership in their handlers rather than by role. Without this arm a read-only key could
+    ///   `POST /api/runtime/api-keys` and mint itself an unscoped one.
+    pub fn permits(self, permission: Option<Permission>, method: &Method) -> bool {
+        match self {
+            ApiKeyScope::Full => true,
+            ApiKeyScope::ReadOnly => match permission {
+                Some(permission) => permission.is_read(),
+                None => method.is_safe(),
+            },
+            ApiKeyScope::Unrecognized => false,
+        }
+    }
+
+    /// Whether this scope narrows anything at all. `false` for [`ApiKeyScope::Full`], which lets
+    /// callers skip scope bookkeeping entirely on the overwhelmingly common path.
+    pub const fn is_narrowing(self) -> bool {
+        !matches!(self, ApiKeyScope::Full)
+    }
+}
+
+// Custom serde so the wire form is the snake_case name and unknown values are a hard error
+// rather than a silent `Full`. `Unrecognized` can be serialized (it appears in denial bodies)
+// but never deserialized.
+impl Serialize for ApiKeyScope {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ApiKeyScope {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ApiKeyScope::from_wire(&s)
+            .ok_or_else(|| D::Error::custom(format!("unknown api key scope: {s}")))
+    }
+}
+
+// utoipa sees the scope as a string enum of the selectable names, so the generated OpenAPI (and
+// the TypeScript client generated from it) offers exactly what the API accepts.
+impl utoipa::PartialSchema for ApiKeyScope {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .enum_values(Some(
+                ApiKeyScope::SELECTABLE.into_iter().map(|s| s.as_str()),
+            ))
+            .description(Some(
+                "How much of the issuing user's role the key may exercise. \
+                 Omitted or `full` means no narrowing.",
+            ))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for ApiKeyScope {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ApiKeyScope")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_form_round_trips_for_selectable_scopes() {
+        for scope in ApiKeyScope::SELECTABLE {
+            assert_eq!(ApiKeyScope::from_wire(scope.as_str()), Some(scope));
+            assert_eq!(
+                serde_json::to_value(scope).unwrap(),
+                serde_json::json!(scope.as_str())
+            );
+            assert_eq!(
+                serde_json::from_value::<ApiKeyScope>(serde_json::json!(scope.as_str())).unwrap(),
+                scope
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_wire_value_is_rejected_not_defaulted() {
+        // A typo or a scope from a newer build must be a 400 at the API boundary, never a
+        // silent `Full`.
+        assert!(ApiKeyScope::from_wire("readonly").is_none());
+        assert!(serde_json::from_value::<ApiKeyScope>(serde_json::json!("readonly")).is_err());
+        assert!(serde_json::from_value::<ApiKeyScope>(serde_json::json!("unknown")).is_err());
+    }
+
+    #[test]
+    fn null_column_is_full_and_full_persists_as_null() {
+        assert_eq!(ApiKeyScope::from_column(None), ApiKeyScope::Full);
+        assert_eq!(ApiKeyScope::Full.to_column(), None);
+        assert_eq!(ApiKeyScope::default(), ApiKeyScope::Full);
+        assert!(!ApiKeyScope::Full.is_narrowing());
+    }
+
+    #[test]
+    fn read_only_column_round_trips() {
+        assert_eq!(
+            ApiKeyScope::from_column(Some("read_only")),
+            ApiKeyScope::ReadOnly
+        );
+        assert_eq!(ApiKeyScope::ReadOnly.to_column(), Some("read_only"));
+        assert!(ApiKeyScope::ReadOnly.is_narrowing());
+    }
+
+    #[test]
+    fn unparseable_column_denies_everything() {
+        // Rollback safety: a row written by a newer server must not widen to `Full`.
+        let scope = ApiKeyScope::from_column(Some("execute"));
+        assert_eq!(scope, ApiKeyScope::Unrecognized);
+        assert!(scope.is_narrowing());
+        for permission in Permission::ALL {
+            assert!(!scope.permits(Some(permission), &Method::GET));
+        }
+        assert!(!scope.permits(None, &Method::GET));
+    }
+
+    #[test]
+    fn full_permits_everything() {
+        for permission in Permission::ALL {
+            for method in [Method::GET, Method::POST, Method::PUT, Method::DELETE] {
+                assert!(ApiKeyScope::Full.permits(Some(permission), &method));
+                assert!(ApiKeyScope::Full.permits(None, &method));
+            }
+        }
+    }
+
+    #[test]
+    fn read_only_permits_exactly_the_read_permissions() {
+        // Method is irrelevant on a mapped route: a POST-shaped read (SQL query, report render)
+        // passes, and a GET-shaped write (the OAuth authorize redirect, gated at
+        // `connection:update`) does not.
+        for permission in Permission::ALL {
+            let want = permission.is_read();
+            for method in [Method::GET, Method::POST, Method::DELETE] {
+                assert_eq!(
+                    ApiKeyScope::ReadOnly.permits(Some(permission), &method),
+                    want,
+                    "{permission} via {method}"
+                );
+            }
+        }
+        assert!(ApiKeyScope::ReadOnly.permits(Some(Permission::DatabaseRead), &Method::POST));
+        assert!(!ApiKeyScope::ReadOnly.permits(Some(Permission::ConnectionUpdate), &Method::GET));
+    }
+
+    #[test]
+    fn read_only_permits_ungated_reads_but_not_ungated_writes() {
+        // The escalation case: API-key management is ungated (ownership-gated in the handler),
+        // so only the safe-method rule stops a read-only key minting an unscoped one.
+        assert!(ApiKeyScope::ReadOnly.permits(None, &Method::GET));
+        assert!(ApiKeyScope::ReadOnly.permits(None, &Method::HEAD));
+        assert!(!ApiKeyScope::ReadOnly.permits(None, &Method::POST));
+        assert!(!ApiKeyScope::ReadOnly.permits(None, &Method::DELETE));
+        assert!(!ApiKeyScope::ReadOnly.permits(None, &Method::PUT));
+        assert!(!ApiKeyScope::ReadOnly.permits(None, &Method::PATCH));
+    }
+}

--- a/crates/runtara-server/src/middleware/auth.rs
+++ b/crates/runtara-server/src/middleware/auth.rs
@@ -9,7 +9,7 @@ use tracing::Instrument;
 
 use crate::api::handlers::api_keys::ApiKey;
 use crate::auth::{AuthContext, AuthMethod, AuthProviderKind, AuthState, MembershipPolicy};
-use crate::authz::Role;
+use crate::authz::{ApiKeyScope, Role};
 use crate::valkey::auth::{AuthzValkeyError, get_member_role, token_is_revoked};
 
 /// Authentication middleware. Defers to the configured `AuthProvider` for everything
@@ -119,6 +119,11 @@ async fn validate_api_key(token: &str, auth_state: &AuthState) -> Result<ApiKey,
 
 /// Build the `AuthContext` for an API-key request. The key acts as its issuing user — role
 /// and resource ownership inherit from them — so `user_id` is the issuing user's `sub`.
+///
+/// The key's `scope` rides along as the ceiling on that inherited role. Unlike the role, it
+/// comes off the key row rather than the tenant Valkey, so it applies in every auth mode and
+/// on every request — including the in-process calls MCP tools make under a clone of this
+/// context.
 fn api_key_context(key: &ApiKey) -> AuthContext {
     let mut ctx = AuthContext::new(
         key.org_id.clone(),
@@ -126,6 +131,7 @@ fn api_key_context(key: &ApiKey) -> AuthContext {
         AuthMethod::ApiKey,
     );
     ctx.jti = key.jti.clone();
+    ctx.api_key_scope = ApiKeyScope::from_column(key.scope.as_deref());
     ctx
 }
 
@@ -478,10 +484,18 @@ mod tests {
             created_by: Some(issuing_user_id.to_string()),
             issuing_user_id: issuing_user_id.to_string(),
             jti: jti.map(|s| s.to_string()),
+            scope: None,
             created_at: chrono::Utc::now(),
             expires_at: None,
             last_used_at: None,
             is_revoked: false,
+        }
+    }
+
+    fn api_key_row_scoped(issuing_user_id: &str, scope: Option<&str>) -> ApiKey {
+        ApiKey {
+            scope: scope.map(|s| s.to_string()),
+            ..api_key_row(issuing_user_id, Some("jti-scoped"))
         }
     }
 
@@ -587,6 +601,40 @@ mod tests {
         assert_eq!(ctx.user_id, "auth0|owner");
         assert_eq!(ctx.jti.as_deref(), Some("jti-9"));
         assert_eq!(ctx.auth_method, AuthMethod::ApiKey);
+        // A key with no stored scope exercises its issuing user's role in full — the behavior
+        // every key had before scopes existed.
+        assert_eq!(ctx.api_key_scope, ApiKeyScope::Full);
+    }
+
+    #[tokio::test]
+    async fn api_key_context_carries_the_stored_scope() {
+        let ctx = api_key_context(&api_key_row_scoped("auth0|owner", Some("read_only")));
+        assert_eq!(ctx.api_key_scope, ApiKeyScope::ReadOnly);
+        // The scope is independent of the role: it rides on the context even before the
+        // membership lookup runs, and the role gate still applies on top of it.
+        assert_eq!(ctx.role, None);
+    }
+
+    #[tokio::test]
+    async fn api_key_context_fails_closed_on_an_unknown_scope() {
+        // A row written by a newer server, read after a rollback: deny rather than widen.
+        let ctx = api_key_context(&api_key_row_scoped("auth0|owner", Some("execute")));
+        assert_eq!(ctx.api_key_scope, ApiKeyScope::Unrecognized);
+    }
+
+    #[tokio::test]
+    async fn self_hosted_owner_role_does_not_clear_the_scope() {
+        // `local`/`trust_proxy` hand every key `Role::Owner`, so the scope is the only thing
+        // narrowing it there — the membership shortcut must leave it intact.
+        let key = api_key_row_scoped("operator", Some("read_only"));
+        let mut ctx = api_key_context(&key);
+        let local = Arc::new(LocalProvider::new("tenant".to_string())) as Arc<dyn AuthProvider>;
+        let st = state_with_provider(local, MembershipPolicy::Required, None);
+        enforce_api_key_membership(&st, &key, &mut ctx)
+            .await
+            .expect("self-hosted keys authenticate");
+        assert_eq!(ctx.role, Some(Role::Owner));
+        assert_eq!(ctx.api_key_scope, ApiKeyScope::ReadOnly);
     }
 
     #[tokio::test]

--- a/crates/runtara-server/src/middleware/authorization.rs
+++ b/crates/runtara-server/src/middleware/authorization.rs
@@ -32,7 +32,7 @@ use futures::{FutureExt, future::BoxFuture};
 use serde_json::{Value, json};
 
 use crate::auth::{AuthContext, MembershipPolicy};
-use crate::authz::{Access, Permission, Role, access_for};
+use crate::authz::{Access, ApiKeyScope, Permission, Role, access_for};
 
 /// A route-level authorization denial: the caller's role does not grant `permission`.
 ///
@@ -78,6 +78,94 @@ impl AuthzDenial {
 impl IntoResponse for AuthzDenial {
     fn into_response(self) -> Response {
         (StatusCode::FORBIDDEN, Json(self.json_body())).into_response()
+    }
+}
+
+/// A credential-scope denial: the caller's API key is narrowed to a scope that does not cover
+/// this request.
+///
+/// Separate from [`AuthzDenial`] on purpose. That one answers "your *role* can't do this" and is
+/// tied to the membership rollout; this one answers "your *key* can't do this", holds whether or
+/// not a role resolved, and names a different remedy — mint a key with a wider scope, rather
+/// than ask for a role change. Keeping the codes distinct is what lets denial logs and metrics
+/// tell a scope rejection from a role rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeDenial {
+    scope: ApiKeyScope,
+    /// The permission the route maps to, or `None` for an ungated route (metadata, API-key
+    /// management) that the scope blocked on method alone.
+    permission: Option<Permission>,
+}
+
+impl ScopeDenial {
+    /// Stable error code surfaced to clients and logs, distinct from [`AuthzDenial::CODE`].
+    pub const CODE: &'static str = "API_KEY_SCOPE_DENIED";
+
+    pub fn forbidden(scope: ApiKeyScope, permission: Option<Permission>) -> Self {
+        Self { scope, permission }
+    }
+
+    pub fn scope(&self) -> ApiKeyScope {
+        self.scope
+    }
+
+    pub fn permission(&self) -> Option<Permission> {
+        self.permission
+    }
+
+    pub fn code(&self) -> &'static str {
+        Self::CODE
+    }
+
+    /// The 403 JSON body. Mirrors [`AuthzDenial::json_body`]'s shape — stable `code` plus
+    /// context fields — so MCP's error translation surfaces it structurally to MCP clients the
+    /// same way, and `permission` is present whenever the route has one.
+    pub fn json_body(&self) -> Value {
+        json!({
+            "code": Self::CODE,
+            "scope": self.scope.as_str(),
+            "permission": self.permission.map(|p| p.as_str()),
+            "message": match self.permission {
+                Some(permission) => format!(
+                    "This API key is limited to {} access and cannot perform {}",
+                    self.scope.as_str(),
+                    permission.as_str()
+                ),
+                None => format!(
+                    "This API key is limited to {} access and cannot perform this operation",
+                    self.scope.as_str()
+                ),
+            },
+        })
+    }
+}
+
+impl IntoResponse for ScopeDenial {
+    fn into_response(self) -> Response {
+        (StatusCode::FORBIDDEN, Json(self.json_body())).into_response()
+    }
+}
+
+/// The credential-scope gate: may a key scoped to `scope` make this request?
+///
+/// Deliberately independent of [`MembershipPolicy`] and of whether a role resolved, unlike
+/// [`decision_for`]. A scope is a property of the credential rather than of the SaaS membership
+/// rollout, so it holds in every auth mode — including the non-OIDC self-hosted modes where an
+/// API key acts as `Role::Owner` outright and this gate is the only thing narrowing it. There is
+/// no shadow-logging stage for the same reason: only keys created with a scope can be caught by
+/// it, so there is no existing traffic to preview against.
+///
+/// This gate only ever narrows. It runs *before* the role gate and never substitutes for it: a
+/// request that clears the scope still has to clear [`decision_for`].
+pub fn scope_decision_for(
+    scope: ApiKeyScope,
+    permission: Option<Permission>,
+    method: &Method,
+) -> Result<(), ScopeDenial> {
+    if scope.permits(permission, method) {
+        Ok(())
+    } else {
+        Err(ScopeDenial::forbidden(scope, permission))
     }
 }
 
@@ -416,6 +504,15 @@ pub fn permission_for(method: &Method, path: &str) -> Option<Permission> {
         | ("GET", "/connections/{id}/rate-limit-history") => ConnectionRead,
         ("GET", "/api/runtime/connections/{id}/rate-limit-timeline")
         | ("GET", "/connections/{id}/rate-limit-timeline") => ConnectionRead,
+        // ── Event ingest ─────────────────────────────────────────────────
+        // Both routes run a workflow, so they map to `workflow:execute`. On the public app they
+        // are mounted with no auth layer at all — webhook ingest is authenticated by the
+        // unguessable trigger/workflow id in the URL, not by a caller identity — so this mapping
+        // has no effect there. It exists for the *internal* copy of these routes, the one MCP
+        // tools call in-process (`execute_workflow_sync` targets `events/http-sync`), where the
+        // caller is a real identity with a role and a credential scope that must apply.
+        (_, "/api/runtime/events/http-sync/{workflow_id}") => WorkflowExecute,
+        (_, "/api/runtime/events/http/{trigger_id}/{action}") => WorkflowExecute,
         // API-key routes (legacy rt_* keys) are intentionally NOT role-gated here. An API key is
         // a personal credential scoped to its issuing user: any role may manage its own keys, and
         // the handlers enforce that ownership directly (list/revoke filter on `issuing_user_id`).
@@ -432,19 +529,25 @@ pub fn permission_for(method: &Method, path: &str) -> Option<Permission> {
 /// time (process-global, `Copy`).
 ///
 /// Reads the matched route template ([`MatchedPath`], populated by routing) and the caller's
-/// role ([`AuthContext`], populated by `authenticate`), both of which are present by the time a
-/// `route_layer` runs. A request whose route has no permission, or whose role [`decision_for`]
-/// permits, passes through untouched. A denied role short-circuits with `403 PERMISSION_DENIED`
-/// under `Required`; under `Logging` the same denial is logged and counted with
-/// `enforced = false` while the request passes through, so the shadow stage previews exactly
-/// what promotion to `required` will reject.
+/// role and credential scope ([`AuthContext`], populated by `authenticate`), all present by the
+/// time a `route_layer` runs. Two gates run in order:
+///
+/// 1. **Credential scope** ([`scope_decision_for`]) — enforced for every request, regardless of
+///    `policy` and of whether a role resolved, and enforced on *ungated* routes too (on method
+///    alone). That last part is what stops a read-only key from `POST`ing to the deliberately
+///    ungated API-key routes and minting itself an unscoped key.
+/// 2. **Role** ([`decision_for`]) — unchanged: a request whose route has no permission, or whose
+///    role permits it, passes through. A denied role short-circuits with `403 PERMISSION_DENIED`
+///    under `Required`; under `Logging` the same denial is logged and counted with
+///    `enforced = false` while the request passes through, so the shadow stage previews exactly
+///    what promotion to `required` will reject.
 pub fn authorize(
     policy: MembershipPolicy,
 ) -> impl Clone + Send + Sync + 'static + Fn(Request, Next) -> BoxFuture<'static, Response> {
     move |req: Request, next: Next| {
         // Snapshot the caller identity so denial logs are self-contained rather than relying on
-        // parent-span field flattening. `role` also drives the gate decision.
-        let (tenant_id, user_id, auth_method, role) = req
+        // parent-span field flattening. `role` and `scope` also drive the gate decisions.
+        let (tenant_id, user_id, auth_method, role, scope) = req
             .extensions()
             .get::<AuthContext>()
             .map(|c| {
@@ -453,18 +556,45 @@ pub fn authorize(
                     Some(c.user_id.clone()),
                     Some(c.auth_method.as_str()),
                     c.role,
+                    c.api_key_scope,
                 )
             })
-            .unwrap_or((None, None, None, None));
+            .unwrap_or((None, None, None, None, ApiKeyScope::Full));
         let matched = req
             .extensions()
             .get::<MatchedPath>()
             .map(|m| m.as_str().to_owned());
         let method = req.method().clone();
         async move {
-            if let Some(path) = matched.as_deref()
-                && let Some(permission) = permission_for(&method, path)
-            {
+            let permission = matched
+                .as_deref()
+                .and_then(|path| permission_for(&method, path));
+
+            // Gate 1 — credential scope. Runs even when the route maps to no permission, and
+            // even when no role resolved: the key's own ceiling does not depend on either.
+            if let Err(denial) = scope_decision_for(scope, permission, &method) {
+                tracing::warn!(
+                    tenant_id = tenant_id.as_deref(),
+                    user_id = user_id.as_deref(),
+                    auth_method,
+                    role = role.map(|r| r.as_str()),
+                    scope = scope.as_str(),
+                    permission = permission.map(|p| p.as_str()),
+                    code = ScopeDenial::CODE,
+                    method = method.as_str(),
+                    matched_path = matched.as_deref(),
+                    enforced = true,
+                    "api key scope denied"
+                );
+                crate::observability::record_scope_denial(
+                    permission.map(|p| p.as_str()).unwrap_or("<ungated>"),
+                    scope.as_str(),
+                );
+                return denial.into_response();
+            }
+
+            // Gate 2 — role.
+            if let (Some(path), Some(permission)) = (matched.as_deref(), permission) {
                 let decision = decision_for(policy, role, permission);
                 if let GateDecision::ShadowDeny(denial) | GateDecision::Deny(denial) = decision {
                     let enforced = matches!(decision, GateDecision::Deny(_));
@@ -1173,6 +1303,41 @@ mod tests {
     }
 
     #[test]
+    fn permission_for_gates_event_ingest_as_execution() {
+        // These routes run a workflow. On the public app they are mounted without an auth layer
+        // (webhook ingest), so this mapping only bites on the internal copy MCP calls — which is
+        // exactly where `execute_workflow_sync` would otherwise slip a scoped or read-only
+        // caller past the gate. Every method the routes accept must map, not just POST.
+        for method in [
+            Method::POST,
+            Method::GET,
+            Method::PUT,
+            Method::DELETE,
+            Method::PATCH,
+        ] {
+            assert_eq!(
+                permission_for(&method, "/api/runtime/events/http-sync/{workflow_id}"),
+                Some(Permission::WorkflowExecute),
+                "{method} http-sync"
+            );
+            assert_eq!(
+                permission_for(&method, "/api/runtime/events/http/{trigger_id}/{action}"),
+                Some(Permission::WorkflowExecute),
+                "{method} http trigger"
+            );
+        }
+        // And a read-only key is refused it, on the same footing as `workflows/{id}/execute`.
+        assert!(
+            scope_decision_for(
+                ApiKeyScope::ReadOnly,
+                Some(Permission::WorkflowExecute),
+                &Method::POST
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn permission_for_gates_agent_execution() {
         // Host-mediated agent capability I/O is gated like running a workflow.
         let cases: &[(Method, &str, Permission)] = &[
@@ -1267,6 +1432,278 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── credential scope: the pure decision ─────────────────────────────────
+
+    #[test]
+    fn scope_full_permits_every_route() {
+        // The overwhelmingly common case — every JWT caller and every unscoped key.
+        for permission in Permission::ALL {
+            assert!(
+                scope_decision_for(ApiKeyScope::Full, Some(permission), &Method::DELETE).is_ok()
+            );
+        }
+        assert!(scope_decision_for(ApiKeyScope::Full, None, &Method::POST).is_ok());
+    }
+
+    #[test]
+    fn scope_read_only_permits_reads_and_denies_writes() {
+        assert!(
+            scope_decision_for(
+                ApiKeyScope::ReadOnly,
+                Some(Permission::WorkflowRead),
+                &Method::GET
+            )
+            .is_ok()
+        );
+        // A POST-shaped read (the SQL query tools, report render) still passes: the decision is
+        // keyed on the permission, not the verb.
+        assert!(
+            scope_decision_for(
+                ApiKeyScope::ReadOnly,
+                Some(Permission::DatabaseRead),
+                &Method::POST
+            )
+            .is_ok()
+        );
+        let denial = scope_decision_for(
+            ApiKeyScope::ReadOnly,
+            Some(Permission::WorkflowDelete),
+            &Method::POST,
+        )
+        .expect_err("a write permission is out of a read-only scope");
+        assert_eq!(denial.scope(), ApiKeyScope::ReadOnly);
+        assert_eq!(denial.permission(), Some(Permission::WorkflowDelete));
+    }
+
+    #[test]
+    fn scope_read_only_denies_writes_on_ungated_routes() {
+        // The escalation path: `POST /api/runtime/api-keys` maps to no permission (it is gated
+        // by ownership in the handler), so only the ungated-route arm stops a read-only key
+        // minting itself an unscoped one.
+        assert_eq!(
+            permission_for(&Method::POST, "/api/runtime/api-keys"),
+            None,
+            "precondition: API-key creation is ungated by the permission map"
+        );
+        let denial = scope_decision_for(ApiKeyScope::ReadOnly, None, &Method::POST)
+            .expect_err("an ungated write is out of a read-only scope");
+        assert_eq!(denial.permission(), None);
+        assert!(scope_decision_for(ApiKeyScope::ReadOnly, None, &Method::GET).is_ok());
+    }
+
+    #[test]
+    fn scope_denial_body_carries_a_distinct_code() {
+        // A distinct code from the role gate: the remedy is a wider key, not a role change.
+        // MCP's error translation keys on `code`, so it must be present and stable.
+        let body = ScopeDenial::forbidden(ApiKeyScope::ReadOnly, Some(Permission::WorkflowCreate))
+            .json_body();
+        assert_eq!(body["code"], ScopeDenial::CODE);
+        assert_ne!(ScopeDenial::CODE, AuthzDenial::CODE);
+        assert_eq!(body["scope"], "read_only");
+        assert_eq!(body["permission"], "workflow:create");
+
+        let ungated = ScopeDenial::forbidden(ApiKeyScope::ReadOnly, None).json_body();
+        assert_eq!(ungated["permission"], Value::Null);
+    }
+
+    // ── credential scope: through the real layer ────────────────────────────
+
+    /// Inject an `AuthContext` carrying both a role and a credential scope.
+    fn inject_scoped(
+        role: Option<Role>,
+        scope: ApiKeyScope,
+    ) -> impl Clone + Send + Sync + 'static + Fn(Request, Next) -> BoxFuture<'static, Response>
+    {
+        move |mut req: Request, next: Next| {
+            let mut ctx = AuthContext::new("tenant".into(), "auth0|u".into(), AuthMethod::ApiKey);
+            ctx.role = role;
+            ctx.api_key_scope = scope;
+            async move {
+                req.extensions_mut().insert(ctx);
+                next.run(req).await
+            }
+            .boxed()
+        }
+    }
+
+    /// The two gated workflow routes plus the ungated API-key creation route, so one app covers
+    /// both arms of the scope decision.
+    fn scoped_app(role: Option<Role>, scope: ApiKeyScope, policy: MembershipPolicy) -> Router {
+        Router::new()
+            .route("/api/runtime/workflows", get(|| async { "ok" }))
+            .route(
+                "/api/runtime/workflows/{id}/delete",
+                post(|| async { "ok" }),
+            )
+            .route("/api/runtime/api-keys", post(|| async { "ok" }))
+            .route_layer(from_fn(authorize(policy)))
+            .route_layer(from_fn(inject_scoped(role, scope)))
+    }
+
+    async fn status_and_body(resp: Response) -> (StatusCode, Value) {
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn read_only_key_reads_but_cannot_write_even_as_owner() {
+        // The headline case: an Owner's key, narrowed at creation. The role would allow the
+        // delete; the scope does not.
+        let app = scoped_app(
+            Some(Role::Owner),
+            ApiKeyScope::ReadOnly,
+            MembershipPolicy::Required,
+        );
+        let (status, _) = status_and_body(
+            app.clone()
+                .oneshot(
+                    HttpRequest::get("/api/runtime/workflows")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, body) = status_and_body(
+            app.oneshot(
+                HttpRequest::post("/api/runtime/workflows/wf-1/delete")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], ScopeDenial::CODE);
+        assert_eq!(body["scope"], "read_only");
+    }
+
+    #[tokio::test]
+    async fn read_only_key_cannot_mint_another_key() {
+        // API-key creation is ungated by the permission map, so this passes the role gate for
+        // every role — the scope gate is the only thing standing between a read-only key and an
+        // unscoped one.
+        let app = scoped_app(
+            Some(Role::Owner),
+            ApiKeyScope::ReadOnly,
+            MembershipPolicy::Required,
+        );
+        let (status, body) = status_and_body(
+            app.oneshot(
+                HttpRequest::post("/api/runtime/api-keys")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], ScopeDenial::CODE);
+    }
+
+    #[tokio::test]
+    async fn scope_is_enforced_under_every_membership_policy() {
+        // Unlike the role gate, the scope does not wait for the membership rollout: it is a
+        // property of the credential. `role = None` stands in for the modes where no membership
+        // lookup happens at all.
+        for policy in [
+            MembershipPolicy::Disabled,
+            MembershipPolicy::Logging,
+            MembershipPolicy::Required,
+        ] {
+            let app = scoped_app(None, ApiKeyScope::ReadOnly, policy);
+            let (status, body) = status_and_body(
+                app.oneshot(
+                    HttpRequest::post("/api/runtime/workflows/wf-1/delete")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "policy {policy:?}");
+            assert_eq!(body["code"], ScopeDenial::CODE, "policy {policy:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn scope_never_widens_a_denied_role() {
+        // A Viewer with a `Full` key is still a Viewer: the role gate runs after the scope gate
+        // and rejects with its own code.
+        let app = scoped_app(
+            Some(Role::Viewer),
+            ApiKeyScope::Full,
+            MembershipPolicy::Required,
+        );
+        let (status, body) = status_and_body(
+            app.oneshot(
+                HttpRequest::post("/api/runtime/workflows/wf-1/delete")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], AuthzDenial::CODE);
+    }
+
+    #[tokio::test]
+    async fn unscoped_key_behaves_exactly_as_before() {
+        // Regression guard for existing keys: a NULL scope reads as `Full` and changes nothing.
+        let app = scoped_app(
+            Some(Role::Owner),
+            ApiKeyScope::Full,
+            MembershipPolicy::Required,
+        );
+        for request in [
+            HttpRequest::get("/api/runtime/workflows"),
+            HttpRequest::post("/api/runtime/workflows/wf-1/delete"),
+            HttpRequest::post("/api/runtime/api-keys"),
+        ] {
+            let (status, _) = status_and_body(
+                app.clone()
+                    .oneshot(request.body(Body::empty()).unwrap())
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn unrecognized_scope_denies_everything() {
+        // Rollback safety, end to end: a scope name this build cannot parse blocks reads too.
+        let app = scoped_app(
+            Some(Role::Owner),
+            ApiKeyScope::Unrecognized,
+            MembershipPolicy::Required,
+        );
+        let (status, body) = status_and_body(
+            app.oneshot(
+                HttpRequest::get("/api/runtime/workflows")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], ScopeDenial::CODE);
+        assert_eq!(body["scope"], "unknown");
     }
 
     /// Build an app exposing the real folder-rename route under the `authorize` layer.

--- a/crates/runtara-server/src/observability/mod.rs
+++ b/crates/runtara-server/src/observability/mod.rs
@@ -416,6 +416,27 @@ pub fn record_permission_denial(permission: &'static str, gate: &'static str, en
     }
 }
 
+/// Count a credential-scope denial on the same counter, tagged `gate="api_key_scope"` plus the
+/// `scope` that refused it. `permission` is `"<ungated>"` for a route the permission map does not
+/// cover (metadata, API-key management), which the scope blocks on method alone.
+///
+/// Separate from [`record_permission_denial`] only so the extra `scope` attribute does not have
+/// to be threaded through the role-gate call sites, where it is always absent. Scope denials are
+/// always enforced — there is no shadow stage — so `enforced` is fixed at `true`.
+pub fn record_scope_denial(permission: &'static str, scope: &'static str) {
+    if let Some(m) = metrics() {
+        m.auth_permission_denials_total.add(
+            1,
+            &[
+                KeyValue::new("permission", permission),
+                KeyValue::new("gate", "api_key_scope"),
+                KeyValue::new("scope", scope),
+                KeyValue::new("enforced", true),
+            ],
+        );
+    }
+}
+
 /// Initialize OpenTelemetry with OTLP exporter
 ///
 /// Uses environment variables:

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -175,6 +175,7 @@ use runtime_client::RuntimeClient;
             api::handlers::api_keys::ApiKey,
             api::handlers::api_keys::CreateApiKeyRequest,
             api::handlers::api_keys::CreateApiKeyResponse,
+            crate::authz::ApiKeyScope,
             // Entitlement DTOs
             api::dto::entitlements::EntitlementsDto,
             crate::entitlements::FeatureKey,
@@ -675,6 +676,10 @@ async fn permissions_handler() -> Json<serde_json::Value> {
 /// access level (`allow`/`own`) so the SPA can show/hide controls. In `local`/`trust_proxy`
 /// modes the caller acts as Owner, minus `user_management:access`: that UI-only capability
 /// links to the managed control plane, which self-hosted deployments don't have.
+///
+/// A scoped API key reports the *intersection* of its role's grants and its scope, so what
+/// `/me` advertises is what the credential can actually do rather than what its issuing user
+/// could. `scope` is echoed alongside so a client can tell a narrowed key from a demoted user.
 /// See `docs/security/user-management-contracts.md`.
 async fn me_handler(
     axum::Extension(auth): axum::Extension<crate::auth::AuthContext>,
@@ -688,6 +693,15 @@ async fn me_handler(
             let mut m = serde_json::Map::new();
             for (perm, access) in role.grants() {
                 if self_hosted && *perm == crate::authz::Permission::UserManagementAccess {
+                    continue;
+                }
+                // The gate would refuse these anyway; hiding them keeps the SPA's controls and
+                // the enforcement in agreement for a scoped key. The method argument is inert
+                // here — it only decides ungated routes, and every permission is `Some`.
+                if !auth
+                    .api_key_scope
+                    .permits(Some(*perm), &axum::http::Method::POST)
+                {
                     continue;
                 }
                 if !matches!(access, crate::authz::Access::Deny) {
@@ -709,6 +723,7 @@ async fn me_handler(
         "email": auth.email,
         "name": auth.name,
         "role": auth.role.map(|r| r.as_str()),
+        "scope": auth.api_key_scope.as_str(),
         "permissions": permissions,
     }))
 }
@@ -2346,12 +2361,24 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     // in-process instead of hitting the router fallback and returning a bare 404
     // in every deployment. `event_routes` is moved into `public_app` below, so
     // clone it here.
+    // `event_routes` is the one group that carries no authorization layer on the public app —
+    // webhook ingest is authenticated by the unguessable id in the URL, not by a caller. In
+    // process, though, `execute_workflow_sync` reaches it as a real identity, so the internal
+    // copy gets the same gate every other MCP-reachable route has. Without it that single tool
+    // would run a workflow for a caller whose role or credential scope forbids executing one.
+    let internal_event_routes =
+        event_routes
+            .clone()
+            .route_layer(from_fn(crate::middleware::authorization::authorize(
+                membership_policy,
+            )));
+
     let internal_router = Router::new()
         .merge(tenant_routes.clone())
         .merge(object_model_routes.clone())
         .nest("/api/runtime", connections_tenant_routes.clone())
         .merge(public_routes.clone())
-        .merge(event_routes.clone());
+        .merge(internal_event_routes);
 
     // Build MCP (Model Context Protocol) router with JWT authentication.
     // Uses .layer() (not .route_layer()) because the MCP transport is a


### PR DESCRIPTION
An rt_* key acts as its issuing user and inherits that user's live role in full, so a key minted for a read-only integration could also delete workflows, run arbitrary SQL, rewrite connection credentials, and mint further keys.

Give a key an optional scope that narrows what it may exercise of that role. `read_only` allows a request whose route maps to a `*:read` permission, and — for routes the permission map does not cover — only safe methods. That second arm matters: API-key management is ungated by design (the handlers enforce ownership), so without it a read-only key could POST /api/runtime/api-keys and mint itself an unscoped one.

The scope is enforced ahead of the role gate and can only narrow; the role gate still runs on top. Unlike the role gate it does not depend on the membership policy, because a scope is a property of the credential rather than of the SaaS rollout — which is what makes it bite in the self-hosted modes where a key acts as Owner outright. MCP is covered by the same gate: every tool re-enters the REST router in-process under a clone of the caller's context.

One route needed closing to make that true. MCP's execute_workflow_sync targets the webhook-ingest router, which carries no authorization layer on the public app (ingest is authenticated by the unguessable id in the URL). The internal copy MCP calls now gets the same gate as every other in-process route, which also stops a Viewer executing a workflow through that tool.

The column stores a scope name, so a further scope is a variant plus an arm in `permits` rather than a migration. NULL means no narrowing, so every existing key is untouched, and an unparseable value denies everything so a rollback cannot widen a key that was created narrow.

## Description

<!-- Describe your changes and the problem they solve -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [ ] My changes don't introduce new warnings

## Testing

<!-- Describe how you tested your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
