### PR TITLE
SYN-602: Apply every status in a multi-status executions filter

### DIFF
--- a/crates/runtara-environment/src/db.rs
+++ b/crates/runtara-environment/src/db.rs
@@ -168,8 +168,9 @@ pub async fn get_instance_full(
 pub struct ListInstancesOptions {
     /// Filter by tenant ID.
     pub tenant_id: Option<String>,
-    /// Filter by status.
-    pub status: Option<String>,
+    /// Filter by status — a row matches if it holds any one of these. `None`
+    /// (or an empty list) leaves the status unfiltered.
+    pub statuses: Option<Vec<String>>,
     /// Filter by image ID (exact match).
     pub image_id: Option<String>,
     /// Filter by image name prefix (e.g., "workflow_id:" matches "workflow_id:1", "workflow_id:2").
@@ -188,6 +189,16 @@ pub struct ListInstancesOptions {
     pub limit: i64,
     /// Pagination offset.
     pub offset: i64,
+}
+
+/// Status filter as a bindable array. An empty list means "no status filter"
+/// rather than "match nothing", so callers can pass a filtered/deduped vector
+/// straight through without special-casing the empty case.
+fn status_filter(options: &ListInstancesOptions) -> Option<&[String]> {
+    options
+        .statuses
+        .as_deref()
+        .filter(|statuses| !statuses.is_empty())
 }
 
 /// List instances with optional filters.
@@ -218,7 +229,7 @@ pub async fn list_instances(
         LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
         LEFT JOIN images img ON ii.image_id = img.image_id
         WHERE ($1::TEXT IS NULL OR i.tenant_id = $1)
-          AND ($2::TEXT IS NULL OR i.status::TEXT = $2)
+          AND ($2::TEXT[] IS NULL OR i.status::TEXT = ANY($2::TEXT[]))
           AND ($3::TEXT IS NULL OR ii.image_id = $3)
           AND ($4::TEXT IS NULL OR img.name LIKE $4)
           AND ($5::TIMESTAMPTZ IS NULL OR i.created_at >= $5)
@@ -233,7 +244,7 @@ pub async fn list_instances(
 
     sqlx::query_as::<_, InstanceWithImage>(&query)
         .bind(options.tenant_id.as_deref())
-        .bind(options.status.as_deref())
+        .bind(status_filter(options))
         .bind(options.image_id.as_deref())
         .bind(image_name_pattern.as_deref())
         .bind(options.created_after)
@@ -264,7 +275,7 @@ pub async fn count_instances(
         LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
         LEFT JOIN images img ON ii.image_id = img.image_id
         WHERE ($1::TEXT IS NULL OR i.tenant_id = $1)
-          AND ($2::TEXT IS NULL OR i.status::TEXT = $2)
+          AND ($2::TEXT[] IS NULL OR i.status::TEXT = ANY($2::TEXT[]))
           AND ($3::TEXT IS NULL OR ii.image_id = $3)
           AND ($4::TEXT IS NULL OR img.name LIKE $4)
           AND ($5::TIMESTAMPTZ IS NULL OR i.created_at >= $5)
@@ -274,7 +285,7 @@ pub async fn count_instances(
         "#,
     )
     .bind(options.tenant_id.as_deref())
-    .bind(options.status.as_deref())
+    .bind(status_filter(options))
     .bind(options.image_id.as_deref())
     .bind(image_name_pattern.as_deref())
     .bind(options.created_after)
@@ -552,7 +563,7 @@ mod tests {
         let options = ListInstancesOptions::default();
 
         assert!(options.tenant_id.is_none());
-        assert!(options.status.is_none());
+        assert!(options.statuses.is_none());
         assert!(options.image_id.is_none());
         assert!(options.image_name_prefix.is_none());
         assert!(options.created_after.is_none());
@@ -577,11 +588,38 @@ mod tests {
     #[test]
     fn test_list_instances_options_with_status() {
         let options = ListInstancesOptions {
-            status: Some("running".to_string()),
+            statuses: Some(vec!["running".to_string()]),
             ..Default::default()
         };
 
-        assert_eq!(options.status, Some("running".to_string()));
+        assert_eq!(options.statuses, Some(vec!["running".to_string()]));
+        assert_eq!(status_filter(&options), Some(&["running".to_string()][..]));
+    }
+
+    #[test]
+    fn test_list_instances_options_with_multiple_statuses() {
+        let options = ListInstancesOptions {
+            statuses: Some(vec!["failed".to_string(), "cancelled".to_string()]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            status_filter(&options),
+            Some(&["failed".to_string(), "cancelled".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn test_status_filter_treats_empty_list_as_unfiltered() {
+        // An empty array bound into `= ANY(...)` would match no rows at all,
+        // which is not what "no status filter" means.
+        let options = ListInstancesOptions {
+            statuses: Some(Vec::new()),
+            ..Default::default()
+        };
+
+        assert_eq!(status_filter(&options), None);
+        assert_eq!(status_filter(&ListInstancesOptions::default()), None);
     }
 
     #[test]
@@ -643,7 +681,7 @@ mod tests {
 
         let options = ListInstancesOptions {
             tenant_id: Some("tenant-1".to_string()),
-            status: Some("completed".to_string()),
+            statuses: Some(vec!["completed".to_string()]),
             image_id: Some("img-456".to_string()),
             image_name_prefix: Some("workflow:".to_string()),
             created_after: Some(now - chrono::Duration::days(7)),
@@ -656,7 +694,7 @@ mod tests {
         };
 
         assert_eq!(options.tenant_id, Some("tenant-1".to_string()));
-        assert_eq!(options.status, Some("completed".to_string()));
+        assert_eq!(options.statuses, Some(vec!["completed".to_string()]));
         assert_eq!(options.image_id, Some("img-456".to_string()));
         assert_eq!(options.image_name_prefix, Some("workflow:".to_string()));
         assert!(options.created_after.is_some());
@@ -685,7 +723,7 @@ mod tests {
     fn test_list_instances_options_clone() {
         let options = ListInstancesOptions {
             tenant_id: Some("tenant-1".to_string()),
-            status: Some("running".to_string()),
+            statuses: Some(vec!["running".to_string()]),
             limit: 10,
             ..Default::default()
         };
@@ -693,7 +731,7 @@ mod tests {
         let cloned = options.clone();
 
         assert_eq!(options.tenant_id, cloned.tenant_id);
-        assert_eq!(options.status, cloned.status);
+        assert_eq!(options.statuses, cloned.statuses);
         assert_eq!(options.limit, cloned.limit);
     }
 

--- a/crates/runtara-environment/src/http_server.rs
+++ b/crates/runtara-environment/src/http_server.rs
@@ -190,8 +190,14 @@ struct InstanceStatusJsonResponse {
 struct ListInstancesQuery {
     #[serde(default)]
     tenant_id: Option<String>,
+    /// Single status filter. Superseded by `statuses`; kept so clients that
+    /// predate the multi-status filter keep working.
     #[serde(default)]
     status: Option<String>,
+    /// Comma-separated status filter — a row matches if it holds any one of
+    /// them. Takes precedence over `status` when both are present.
+    #[serde(default)]
+    statuses: Option<String>,
     #[serde(default)]
     image_id: Option<String>,
     #[serde(default)]
@@ -210,6 +216,25 @@ struct ListInstancesQuery {
     limit: Option<u32>,
     #[serde(default)]
     offset: Option<u32>,
+}
+
+/// Resolve the status filter from the two query forms.
+///
+/// `statuses` (comma-separated) wins when present; `status` is the older
+/// single-value form. Blank entries are dropped and repeats collapsed, so a
+/// list that normalizes to nothing leaves the status unfiltered rather than
+/// matching no rows.
+fn resolve_status_filter(statuses: Option<&str>, status: Option<&str>) -> Option<Vec<String>> {
+    let raw = statuses.or(status)?;
+
+    let mut resolved: Vec<String> = Vec::new();
+    for entry in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if !resolved.iter().any(|kept| kept == entry) {
+            resolved.push(entry.to_string());
+        }
+    }
+
+    (!resolved.is_empty()).then_some(resolved)
 }
 
 /// Instance summary for list responses.
@@ -1201,8 +1226,7 @@ async fn handle_list_instances(
     let limit = query.limit.unwrap_or(100) as i64;
     let offset = query.offset.unwrap_or(0) as i64;
 
-    // Convert status string to match DB format
-    let status = query.status;
+    let statuses = resolve_status_filter(query.statuses.as_deref(), query.status.as_deref());
 
     // Convert milliseconds to DateTime
     let created_after = query
@@ -1220,7 +1244,7 @@ async fn handle_list_instances(
 
     let options = db::ListInstancesOptions {
         tenant_id: query.tenant_id,
-        status,
+        statuses,
         image_id: query.image_id,
         image_name_prefix: query.image_name_prefix,
         created_after,
@@ -2185,6 +2209,51 @@ mod tests {
 
     use runtara_core::persistence::{CompleteInstanceParams, Persistence, SqlitePersistence};
     use std::sync::Arc;
+
+    fn owned(values: &[&str]) -> Option<Vec<String>> {
+        Some(values.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn resolve_status_filter_splits_the_multi_status_form() {
+        assert_eq!(
+            resolve_status_filter(Some("failed,cancelled"), None),
+            owned(&["failed", "cancelled"])
+        );
+    }
+
+    #[test]
+    fn resolve_status_filter_prefers_statuses_over_status() {
+        // A client that sends both means the list; `status` is only there for
+        // servers that do not understand `statuses`.
+        assert_eq!(
+            resolve_status_filter(Some("failed,cancelled"), Some("failed")),
+            owned(&["failed", "cancelled"])
+        );
+    }
+
+    #[test]
+    fn resolve_status_filter_falls_back_to_the_single_form() {
+        assert_eq!(
+            resolve_status_filter(None, Some("running")),
+            owned(&["running"])
+        );
+    }
+
+    #[test]
+    fn resolve_status_filter_normalizes_whitespace_and_repeats() {
+        assert_eq!(
+            resolve_status_filter(Some(" failed , cancelled ,failed"), None),
+            owned(&["failed", "cancelled"])
+        );
+    }
+
+    #[test]
+    fn resolve_status_filter_treats_an_empty_list_as_no_filter() {
+        assert_eq!(resolve_status_filter(Some(" , "), None), None);
+        assert_eq!(resolve_status_filter(Some(""), None), None);
+        assert_eq!(resolve_status_filter(None, None), None);
+    }
 
     /// A suspended instance with the given `termination_reason` marker.
     async fn suspended_instance(

--- a/crates/runtara-environment/tests/db_test.rs
+++ b/crates/runtara-environment/tests/db_test.rs
@@ -392,7 +392,7 @@ async fn test_list_instances() {
     // List by status
     let options = db::ListInstancesOptions {
         tenant_id: Some(tenant_id.to_string()),
-        status: Some("completed".to_string()),
+        statuses: Some(vec!["completed".to_string()]),
         limit: 100,
         ..Default::default()
     };
@@ -402,6 +402,83 @@ async fn test_list_instances() {
 
     assert_eq!(completed.len(), 1);
     assert_eq!(completed[0].instance_id, ids[0]);
+
+    // Cleanup
+    for id in &ids {
+        sqlx::query("DELETE FROM instances WHERE instance_id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+    sqlx::query("DELETE FROM images WHERE image_id = $1")
+        .bind(&image_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn test_list_instances_by_multiple_statuses() {
+    skip_if_no_db!();
+    let pool = get_pool().await.expect("Failed to connect to database");
+
+    // Unique per run: the assertions count rows for this tenant, so a previous
+    // run that died before its cleanup must not be able to skew them.
+    let tenant_id = format!("test-tenant-list-multi-status-{}", Uuid::new_v4());
+    let tenant_id = tenant_id.as_str();
+    let image_id = Uuid::new_v4().to_string();
+
+    create_test_image(&pool, &image_id, tenant_id)
+        .await
+        .expect("Failed to create test image");
+
+    // One instance per status, so a filter that only honours its first entry
+    // comes back short.
+    let ids: Vec<_> = (0..3).map(|_| Uuid::new_v4().to_string()).collect();
+    for id in &ids {
+        create_test_instance(&pool, id, tenant_id, &image_id).await;
+    }
+    update_test_instance_status(&pool, &ids[0], "failed", None).await;
+    update_test_instance_status(&pool, &ids[1], "cancelled", None).await;
+    update_test_instance_status(&pool, &ids[2], "completed", None).await;
+
+    let options = db::ListInstancesOptions {
+        tenant_id: Some(tenant_id.to_string()),
+        statuses: Some(vec!["failed".to_string(), "cancelled".to_string()]),
+        limit: 100,
+        ..Default::default()
+    };
+
+    let matched = db::list_instances(&pool, &options)
+        .await
+        .expect("Failed to list instances");
+    let mut matched_ids: Vec<_> = matched.iter().map(|i| i.instance_id.clone()).collect();
+    matched_ids.sort();
+    let mut expected_ids = vec![ids[0].clone(), ids[1].clone()];
+    expected_ids.sort();
+
+    assert_eq!(matched_ids, expected_ids, "both statuses must be applied");
+
+    // The count drives totalElements, so it has to agree with the page.
+    let count = db::count_instances(&pool, &options)
+        .await
+        .expect("Failed to count instances");
+    assert_eq!(count, 2);
+
+    // An empty list means "no status filter", not "match nothing".
+    let unfiltered = db::ListInstancesOptions {
+        tenant_id: Some(tenant_id.to_string()),
+        statuses: Some(Vec::new()),
+        limit: 100,
+        ..Default::default()
+    };
+    assert_eq!(
+        db::count_instances(&pool, &unfiltered)
+            .await
+            .expect("Failed to count instances"),
+        3
+    );
 
     // Cleanup
     for id in &ids {

--- a/crates/runtara-environment/tests/wake_scheduler_test.rs
+++ b/crates/runtara-environment/tests/wake_scheduler_test.rs
@@ -387,7 +387,7 @@ async fn test_list_instances() {
     // List running for tenant-a
     let options = db::ListInstancesOptions {
         tenant_id: Some("list-test-tenant-a".to_string()),
-        status: Some("running".to_string()),
+        statuses: Some(vec!["running".to_string()]),
         limit: 100,
         ..Default::default()
     };

--- a/crates/runtara-management-sdk/src/client.rs
+++ b/crates/runtara-management-sdk/src/client.rs
@@ -353,6 +353,70 @@ fn instance_status_from_string(s: &str) -> InstanceStatus {
     }
 }
 
+/// Build the query parameters for `GET /api/v1/instances`.
+///
+/// The status filter goes out twice on purpose. `statuses` is the real filter —
+/// an instance matches any one of them — while `status` repeats the first entry
+/// for environments that predate the multi-status filter: those ignore the
+/// unknown `statuses` parameter, and without `status` they would return every
+/// instance rather than a narrower set.
+fn list_instances_query(options: &ListInstancesOptions) -> Vec<(String, String)> {
+    let mut query: Vec<(String, String)> = Vec::new();
+
+    if let Some(ref tenant_id) = options.tenant_id {
+        query.push(("tenant_id".to_string(), tenant_id.clone()));
+    }
+    if let Some(first) = options.statuses.first() {
+        query.push(("status".to_string(), first.as_str().to_string()));
+        query.push((
+            "statuses".to_string(),
+            options
+                .statuses
+                .iter()
+                .map(|status| status.as_str())
+                .collect::<Vec<_>>()
+                .join(","),
+        ));
+    }
+    if let Some(ref image_id) = options.image_id {
+        query.push(("image_id".to_string(), image_id.clone()));
+    }
+    if let Some(ref prefix) = options.image_name_prefix {
+        query.push(("image_name_prefix".to_string(), prefix.clone()));
+    }
+    if let Some(created_after) = options.created_after {
+        query.push((
+            "created_after_ms".to_string(),
+            created_after.timestamp_millis().to_string(),
+        ));
+    }
+    if let Some(created_before) = options.created_before {
+        query.push((
+            "created_before_ms".to_string(),
+            created_before.timestamp_millis().to_string(),
+        ));
+    }
+    if let Some(finished_after) = options.finished_after {
+        query.push((
+            "finished_after_ms".to_string(),
+            finished_after.timestamp_millis().to_string(),
+        ));
+    }
+    if let Some(finished_before) = options.finished_before {
+        query.push((
+            "finished_before_ms".to_string(),
+            finished_before.timestamp_millis().to_string(),
+        ));
+    }
+    if let Some(order_by) = options.order_by {
+        query.push(("order_by".to_string(), order_by.as_str().to_string()));
+    }
+    query.push(("limit".to_string(), options.limit.to_string()));
+    query.push(("offset".to_string(), options.offset.to_string()));
+
+    query
+}
+
 fn step_status_from_string(s: &str) -> StepStatus {
     match s {
         "completed" => StepStatus::Completed,
@@ -568,58 +632,7 @@ impl ManagementSdk {
     ) -> Result<ListInstancesResult> {
         debug!("Listing instances");
 
-        let mut query: Vec<(String, String)> = Vec::new();
-
-        if let Some(ref tenant_id) = options.tenant_id {
-            query.push(("tenant_id".to_string(), tenant_id.clone()));
-        }
-        if let Some(status) = options.status {
-            let status_str = match status {
-                InstanceStatus::Pending => "pending",
-                InstanceStatus::Running => "running",
-                InstanceStatus::Suspended => "suspended",
-                InstanceStatus::Completed => "completed",
-                InstanceStatus::Failed => "failed",
-                InstanceStatus::Cancelled => "cancelled",
-                InstanceStatus::Unknown => "unknown",
-            };
-            query.push(("status".to_string(), status_str.to_string()));
-        }
-        if let Some(ref image_id) = options.image_id {
-            query.push(("image_id".to_string(), image_id.clone()));
-        }
-        if let Some(ref prefix) = options.image_name_prefix {
-            query.push(("image_name_prefix".to_string(), prefix.clone()));
-        }
-        if let Some(created_after) = options.created_after {
-            query.push((
-                "created_after_ms".to_string(),
-                created_after.timestamp_millis().to_string(),
-            ));
-        }
-        if let Some(created_before) = options.created_before {
-            query.push((
-                "created_before_ms".to_string(),
-                created_before.timestamp_millis().to_string(),
-            ));
-        }
-        if let Some(finished_after) = options.finished_after {
-            query.push((
-                "finished_after_ms".to_string(),
-                finished_after.timestamp_millis().to_string(),
-            ));
-        }
-        if let Some(finished_before) = options.finished_before {
-            query.push((
-                "finished_before_ms".to_string(),
-                finished_before.timestamp_millis().to_string(),
-            ));
-        }
-        if let Some(order_by) = options.order_by {
-            query.push(("order_by".to_string(), order_by.as_str().to_string()));
-        }
-        query.push(("limit".to_string(), options.limit.to_string()));
-        query.push(("offset".to_string(), options.offset.to_string()));
+        let query = list_instances_query(&options);
 
         let resp = self
             .client
@@ -1710,5 +1723,48 @@ impl ManagementSdk {
 
         self.wait_for_completion(&result.instance_id, poll_interval)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn value_of<'a>(query: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        query
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn list_instances_query_omits_status_when_unset() {
+        let query = list_instances_query(&ListInstancesOptions::new().with_tenant_id("acme"));
+
+        assert_eq!(value_of(&query, "tenant_id"), Some("acme"));
+        assert_eq!(value_of(&query, "status"), None);
+        assert_eq!(value_of(&query, "statuses"), None);
+    }
+
+    #[test]
+    fn list_instances_query_sends_every_status() {
+        let query = list_instances_query(
+            &ListInstancesOptions::new()
+                .with_statuses([InstanceStatus::Failed, InstanceStatus::Cancelled]),
+        );
+
+        assert_eq!(value_of(&query, "statuses"), Some("failed,cancelled"));
+        // Kept for environments that do not understand `statuses`: narrowing to
+        // the first status beats dropping the filter entirely.
+        assert_eq!(value_of(&query, "status"), Some("failed"));
+    }
+
+    #[test]
+    fn list_instances_query_single_status_matches_both_forms() {
+        let query =
+            list_instances_query(&ListInstancesOptions::new().with_status(InstanceStatus::Running));
+
+        assert_eq!(value_of(&query, "status"), Some("running"));
+        assert_eq!(value_of(&query, "statuses"), Some("running"));
     }
 }

--- a/crates/runtara-management-sdk/src/types.rs
+++ b/crates/runtara-management-sdk/src/types.rs
@@ -26,6 +26,20 @@ pub enum InstanceStatus {
 }
 
 impl InstanceStatus {
+    /// The wire spelling used by the environment's query parameters, matching
+    /// the `instance_status` values stored in the database.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            InstanceStatus::Unknown => "unknown",
+            InstanceStatus::Pending => "pending",
+            InstanceStatus::Running => "running",
+            InstanceStatus::Suspended => "suspended",
+            InstanceStatus::Completed => "completed",
+            InstanceStatus::Failed => "failed",
+            InstanceStatus::Cancelled => "cancelled",
+        }
+    }
+
     /// Check if this is a terminal status.
     pub fn is_terminal(&self) -> bool {
         matches!(
@@ -394,8 +408,10 @@ impl ListInstancesOrder {
 pub struct ListInstancesOptions {
     /// Filter by tenant ID.
     pub tenant_id: Option<String>,
-    /// Filter by status.
-    pub status: Option<InstanceStatus>,
+    /// Filter by status — an instance matches if it holds any one of these.
+    /// Empty means the status is left unfiltered.
+    #[serde(default)]
+    pub statuses: Vec<InstanceStatus>,
     /// Filter by image ID (exact UUID match).
     pub image_id: Option<String>,
     /// Filter by image name prefix (e.g., "workflow_id:" matches "workflow_id:1", "workflow_id:2").
@@ -431,9 +447,23 @@ impl ListInstancesOptions {
         self
     }
 
-    /// Filter by status.
+    /// Filter by a single status.
     pub fn with_status(mut self, status: InstanceStatus) -> Self {
-        self.status = Some(status);
+        self.statuses = vec![status];
+        self
+    }
+
+    /// Filter by several statuses at once — an instance matches if it holds any
+    /// one of them. Repeats are collapsed, so callers can pass the result of a
+    /// lossy status mapping directly.
+    pub fn with_statuses(mut self, statuses: impl IntoIterator<Item = InstanceStatus>) -> Self {
+        let mut resolved: Vec<InstanceStatus> = Vec::new();
+        for status in statuses {
+            if !resolved.contains(&status) {
+                resolved.push(status);
+            }
+        }
+        self.statuses = resolved;
         self
     }
 
@@ -1676,9 +1706,45 @@ mod tests {
             .with_offset(10);
 
         assert_eq!(opts.tenant_id, Some("tenant-1".to_string()));
-        assert_eq!(opts.status, Some(InstanceStatus::Running));
+        assert_eq!(opts.statuses, vec![InstanceStatus::Running]);
         assert_eq!(opts.limit, 50);
         assert_eq!(opts.offset, 10);
+    }
+
+    #[test]
+    fn test_list_instances_options_with_statuses() {
+        let opts = ListInstancesOptions::new()
+            .with_statuses([InstanceStatus::Failed, InstanceStatus::Cancelled]);
+
+        assert_eq!(
+            opts.statuses,
+            vec![InstanceStatus::Failed, InstanceStatus::Cancelled]
+        );
+    }
+
+    #[test]
+    fn test_list_instances_options_with_statuses_collapses_repeats() {
+        // `failed` and `timeout` both map to Failed upstream, so the same status
+        // can arrive twice.
+        let opts = ListInstancesOptions::new().with_statuses([
+            InstanceStatus::Failed,
+            InstanceStatus::Failed,
+            InstanceStatus::Cancelled,
+        ]);
+
+        assert_eq!(
+            opts.statuses,
+            vec![InstanceStatus::Failed, InstanceStatus::Cancelled]
+        );
+    }
+
+    #[test]
+    fn test_list_instances_options_with_status_replaces_statuses() {
+        let opts = ListInstancesOptions::new()
+            .with_statuses([InstanceStatus::Failed, InstanceStatus::Cancelled])
+            .with_status(InstanceStatus::Running);
+
+        assert_eq!(opts.statuses, vec![InstanceStatus::Running]);
     }
 
     #[test]
@@ -1686,7 +1752,7 @@ mod tests {
         let opts = ListInstancesOptions::new();
 
         assert!(opts.tenant_id.is_none());
-        assert!(opts.status.is_none());
+        assert!(opts.statuses.is_empty());
         assert!(opts.image_id.is_none());
         assert!(opts.created_after.is_none());
         assert!(opts.created_before.is_none());

--- a/crates/runtara-management-sdk/tests/types_test.rs
+++ b/crates/runtara-management-sdk/tests/types_test.rs
@@ -104,9 +104,20 @@ fn test_list_instances_options_builder() {
         .with_offset(10);
 
     assert_eq!(opts.tenant_id, Some("tenant-abc".to_string()));
-    assert_eq!(opts.status, Some(InstanceStatus::Running));
+    assert_eq!(opts.statuses, vec![InstanceStatus::Running]);
     assert_eq!(opts.limit, 50);
     assert_eq!(opts.offset, 10);
+}
+
+#[test]
+fn test_list_instances_options_multi_status_builder() {
+    let opts = ListInstancesOptions::new()
+        .with_statuses([InstanceStatus::Failed, InstanceStatus::Cancelled]);
+
+    assert_eq!(
+        opts.statuses,
+        vec![InstanceStatus::Failed, InstanceStatus::Cancelled]
+    );
 }
 
 #[test]
@@ -114,7 +125,7 @@ fn test_list_instances_options_defaults() {
     let opts = ListInstancesOptions::new();
 
     assert!(opts.tenant_id.is_none());
-    assert!(opts.status.is_none());
+    assert!(opts.statuses.is_empty());
     assert_eq!(opts.limit, 100);
     assert_eq!(opts.offset, 0);
 }

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -6992,7 +6992,11 @@ export class Api<
         size?: number;
         /** Filter by workflow ID */
         workflowId?: string;
-        /** Filter by status (comma-separated, lowercase: queued,completed,failed,running,compiling,timeout,cancelled) */
+        /**
+         * Filter by status. Comma-separated, lowercase; an execution matches if it
+         * holds any one of them (queued, compiling, running, suspended, completed,
+         * failed, timeout, cancelled).
+         */
         status?: string;
         /**
          * Filter by created date - from (inclusive, ISO 8601)

--- a/crates/runtara-server/src/api/dto/executions.rs
+++ b/crates/runtara-server/src/api/dto/executions.rs
@@ -19,7 +19,9 @@ pub struct ListAllExecutionsQuery {
     #[serde(rename = "workflowId")]
     pub workflow_id: Option<String>,
 
-    /// Filter by status (comma-separated, lowercase: queued,completed,failed,running,compiling,timeout,cancelled)
+    /// Filter by status. Comma-separated, lowercase; an execution matches if it
+    /// holds any one of them (queued, compiling, running, suspended, completed,
+    /// failed, timeout, cancelled).
     pub status: Option<String>,
 
     /// Filter by created date - from (inclusive, ISO 8601)

--- a/crates/runtara-server/src/api/handlers/executions.rs
+++ b/crates/runtara-server/src/api/handlers/executions.rs
@@ -77,12 +77,15 @@ fn parse_filters(query: &ListAllExecutionsQuery) -> Result<ExecutionFilters, Str
             .collect::<Vec<_>>()
     });
 
-    // Validate statuses (must be lowercase to match DB and API response format)
+    // Validate statuses (must be lowercase to match DB and API response format).
+    // `suspended` belongs here too: it is a status listings report, so it has to
+    // be one callers can filter on.
     if let Some(ref status_list) = statuses {
         let valid_statuses = [
             "queued",
             "compiling",
             "running",
+            "suspended",
             "completed",
             "failed",
             "timeout",
@@ -91,8 +94,9 @@ fn parse_filters(query: &ListAllExecutionsQuery) -> Result<ExecutionFilters, Str
         for status in status_list {
             if !valid_statuses.contains(&status.as_str()) {
                 return Err(format!(
-                    "Invalid status '{}'. Valid values: queued, compiling, running, completed, failed, timeout, cancelled",
-                    status
+                    "Invalid status '{}'. Valid values: {}",
+                    status,
+                    valid_statuses.join(", ")
                 ));
             }
         }
@@ -136,4 +140,75 @@ fn parse_filters(query: &ListAllExecutionsQuery) -> Result<ExecutionFilters, Str
         sort_by: sort_column.to_string(),
         sort_order: sort_order_sql.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query_with_status(status: Option<&str>) -> ListAllExecutionsQuery {
+        ListAllExecutionsQuery {
+            page: None,
+            size: None,
+            workflow_id: None,
+            status: status.map(|s| s.to_string()),
+            created_from: None,
+            created_to: None,
+            completed_from: None,
+            completed_to: None,
+            sort_by: None,
+            sort_order: None,
+        }
+    }
+
+    #[test]
+    fn parse_filters_without_status_leaves_it_unset() {
+        let filters = parse_filters(&query_with_status(None)).expect("valid query");
+
+        assert!(filters.statuses.is_none());
+    }
+
+    #[test]
+    fn parse_filters_keeps_every_status() {
+        let filters = parse_filters(&query_with_status(Some("failed,cancelled"))).expect("valid");
+
+        assert_eq!(
+            filters.statuses,
+            Some(vec!["failed".to_string(), "cancelled".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_filters_trims_and_drops_blank_entries() {
+        let filters = parse_filters(&query_with_status(Some(" failed , ,cancelled "))).expect("ok");
+
+        assert_eq!(
+            filters.statuses,
+            Some(vec!["failed".to_string(), "cancelled".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_filters_rejects_an_invalid_status_anywhere_in_the_list() {
+        let error = parse_filters(&query_with_status(Some("failed,bogus")))
+            .expect_err("bogus is not a status");
+
+        assert!(error.contains("bogus"), "error should name the bad value");
+    }
+
+    #[test]
+    fn parse_filters_accepts_suspended() {
+        // Listings report `suspended`, so it has to be filterable too.
+        let filters = parse_filters(&query_with_status(Some("suspended"))).expect("valid");
+
+        assert_eq!(filters.statuses, Some(vec!["suspended".to_string()]));
+    }
+
+    #[test]
+    fn parse_filters_accepts_every_status_the_api_documents() {
+        let all = "queued,compiling,running,suspended,completed,failed,timeout,cancelled";
+        let filters = parse_filters(&query_with_status(Some(all))).expect("valid");
+
+        assert_eq!(filters.statuses.expect("statuses").len(), 8);
+    }
 }

--- a/crates/runtara-server/src/mcp/tools/executions.rs
+++ b/crates/runtara-server/src/mcp/tools/executions.rs
@@ -29,7 +29,7 @@ pub struct ListExecutionsParams {
     #[schemars(description = "Filter by workflow ID")]
     pub workflow_id: Option<String>,
     #[schemars(
-        description = "Comma-separated statuses: queued,compiling,running,completed,failed,timeout,cancelled"
+        description = "Comma-separated statuses — matches executions holding any one of them: queued,compiling,running,suspended,completed,failed,timeout,cancelled"
     )]
     pub status: Option<String>,
     #[schemars(description = "Page number (0-based)")]

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -37,7 +37,7 @@ use crate::product_events::{ActorType, EventSource, EventType, ProductEvent, Pro
 use crate::runtime_client::{RuntimeClient, RuntimeError};
 use crate::workers::CancellationHandle;
 use crate::workers::runtara_dto::{
-    ExecutionWithMetadata, enrich_pending_input, execution_status_to_runtara, parse_image_id,
+    ExecutionWithMetadata, enrich_pending_input, execution_statuses_to_runtara, parse_image_id,
     runtara_info_to_dto, runtara_info_to_execution_with_metadata,
     runtara_instance_to_dto_with_info,
 };
@@ -1587,11 +1587,11 @@ impl ExecutionEngine {
             options = options.with_image_name_prefix(&image_name_prefix);
         }
 
-        if let Some(ref statuses) = filters.statuses
-            && let Some(first_status) = statuses.first()
-            && let Some(runtara_status) = execution_status_to_runtara(first_status)
-        {
-            options = options.with_status(runtara_status);
+        if let Some(ref statuses) = filters.statuses {
+            let runtara_statuses = execution_statuses_to_runtara(statuses);
+            if !runtara_statuses.is_empty() {
+                options = options.with_statuses(runtara_statuses);
+            }
         }
 
         if let Some(created_from) = filters.created_from {

--- a/crates/runtara-server/src/workers/runtara_dto.rs
+++ b/crates/runtara-server/src/workers/runtara_dto.rs
@@ -63,6 +63,25 @@ pub fn execution_status_to_runtara(status: &str) -> Option<RuntaraInstanceStatus
     }
 }
 
+/// Convert a set of local execution statuses to the Runtara statuses a listing
+/// should match.
+///
+/// The mapping is many-to-one — `queued` and `compiling` both mean `Pending`,
+/// `failed` and `timeout` both mean `Failed` — so repeats are collapsed and the
+/// result can be shorter than the input. Unrecognized entries are dropped;
+/// callers validate the vocabulary before getting here.
+pub fn execution_statuses_to_runtara(statuses: &[String]) -> Vec<RuntaraInstanceStatus> {
+    let mut mapped: Vec<RuntaraInstanceStatus> = Vec::new();
+    for status in statuses {
+        if let Some(runtara_status) = execution_status_to_runtara(status)
+            && !mapped.contains(&runtara_status)
+        {
+            mapped.push(runtara_status);
+        }
+    }
+    mapped
+}
+
 /// Execution duration in seconds derived from the instance timestamps.
 ///
 /// Returns `None` unless both timestamps are present and `finished_at` is at
@@ -525,6 +544,61 @@ mod tests {
     #[test]
     fn test_execution_status_to_runtara_unknown() {
         assert_eq!(execution_status_to_runtara("invalid_status"), None);
+    }
+
+    // =========================================================================
+    // execution_statuses_to_runtara tests
+    // =========================================================================
+
+    fn statuses(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_execution_statuses_to_runtara_keeps_every_status() {
+        assert_eq!(
+            execution_statuses_to_runtara(&statuses(&["failed", "cancelled"])),
+            vec![
+                RuntaraInstanceStatus::Failed,
+                RuntaraInstanceStatus::Cancelled
+            ]
+        );
+    }
+
+    #[test]
+    fn test_execution_statuses_to_runtara_collapses_shared_mappings() {
+        // failed/timeout and queued/compiling each collapse onto one runtime
+        // status; the filter must not ask for it twice.
+        assert_eq!(
+            execution_statuses_to_runtara(&statuses(&["failed", "timeout"])),
+            vec![RuntaraInstanceStatus::Failed]
+        );
+        assert_eq!(
+            execution_statuses_to_runtara(&statuses(&["queued", "compiling"])),
+            vec![RuntaraInstanceStatus::Pending]
+        );
+    }
+
+    #[test]
+    fn test_execution_statuses_to_runtara_preserves_order() {
+        assert_eq!(
+            execution_statuses_to_runtara(&statuses(&["cancelled", "running", "completed"])),
+            vec![
+                RuntaraInstanceStatus::Cancelled,
+                RuntaraInstanceStatus::Running,
+                RuntaraInstanceStatus::Completed
+            ]
+        );
+    }
+
+    #[test]
+    fn test_execution_statuses_to_runtara_drops_unknown_entries() {
+        assert_eq!(
+            execution_statuses_to_runtara(&statuses(&["nonsense", "running"])),
+            vec![RuntaraInstanceStatus::Running]
+        );
+        assert!(execution_statuses_to_runtara(&statuses(&["nonsense"])).is_empty());
+        assert!(execution_statuses_to_runtara(&[]).is_empty());
     }
 
     // =========================================================================

--- a/e2e/test_multi_status_execution_filter.sh
+++ b/e2e/test_multi_status_execution_filter.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# E2E Test: a multi-status execution filter must apply every status it is given.
+#
+# `GET /api/runtime/executions?status=failed,cancelled` documents a
+# comma-separated list, and the handler validates every entry — but the runtime
+# query used to be built from the first entry alone, so the rest were dropped
+# with no error. The caller got a page (and a totalElements count) narrower than
+# what it asked for, presented as if it were complete.
+#
+# This exercises the whole chain the unit tests only cover in pieces: HTTP
+# handler -> execution engine -> management SDK -> environment HTTP -> SQL.
+#
+# The runtime rows are seeded directly, one per status, so the assertions are
+# about the filter and not about how a run happens to end.
+#
+# Asserts:
+#   * status=failed,cancelled returns exactly the failed + cancelled runs
+#   * totalElements agrees with the page (both come from the same filter)
+#   * failed,timeout collapses onto one runtime status without double counting
+#   * a single status still filters to just that status
+#
+# On UNPATCHED code this FAILS: only the first status is applied, so
+# failed,cancelled comes back with the failed run alone.
+#
+# Prereqs: Postgres reachable on ${POSTGRES_HOST}:${POSTGRES_PORT} (host `psql`,
+# or a `runtara-dev-postgres` docker container as fallback), docker (isolated
+# Valkey), and a built runtara-server (cargo build -p runtara-server).
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+print_step()    { echo -e "${GREEN}[STEP]${NC} $1"; }
+print_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-smo_worker}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-GueUkDKea0CjKP4Rn5Bk0FDV}"
+PG_CONTAINER="${PG_CONTAINER:-runtara-dev-postgres}"
+
+TEST_DB_SERVER="multistatus_e2e_server_$$"
+TEST_DB_RUNTIME="multistatus_e2e_runtime_$$"
+TEST_PORT_PUBLIC="${TEST_PORT_PUBLIC:-17740}"
+TEST_PORT_INTERNAL="${TEST_PORT_INTERNAL:-17741}"
+TEST_CORE_PORT="${TEST_CORE_PORT:-18741}"
+TEST_ENV_PORT="${TEST_ENV_PORT:-18742}"
+TEST_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT:-18743}"
+TEST_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT:-18744}"
+TEST_VALKEY_PORT="${TEST_VALKEY_PORT:-16394}"
+TEST_DATA_DIR="$(mktemp -d -t runtara_multistatus_e2e_XXXXXX)"
+TEST_LOG="${TEST_DATA_DIR}/server.log"
+SERVER_PID=""
+VALKEY_CONTAINER=""
+TENANT="multistatus_e2e"
+
+RUNTARA_SERVER_BIN="${RUNTARA_SERVER_BIN:-${PROJECT_ROOT}/target/debug/runtara-server}"
+# The server refuses to boot without a components directory. Nothing here
+# executes a workflow, so the components only have to be present.
+COMPONENTS_DIR="${RUNTARA_AGENT_COMPONENTS_DIR:-${PROJECT_ROOT}/target/wasm32-wasip2/release}"
+SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
+SERVER_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_SERVER}"
+RUNTIME_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_RUNTIME}"
+API="http://127.0.0.1:${TEST_PORT_PUBLIC}/api/runtime"
+
+FAILURES=0
+
+# psql shim: prefer host psql, fall back to the dev postgres container.
+if command -v psql >/dev/null 2>&1; then
+    psql_quiet() { PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA "$@"; }
+elif docker exec "${PG_CONTAINER}" true >/dev/null 2>&1; then
+    print_warn "host psql not found — using docker exec ${PG_CONTAINER}"
+    psql_quiet() { docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${PG_CONTAINER}" psql -U "${POSTGRES_USER}" -tA "$@"; }
+else
+    print_error "no psql available (host psql or ${PG_CONTAINER} container required)"; exit 1
+fi
+
+# Statuses returned by GET /executions?status=<filter>, one per line, sorted.
+api_statuses() { curl -sS "${API}/executions?size=100&status=$1" | jq -r '.data.content[].status' | sort; }
+api_total()    { curl -sS "${API}/executions?size=100&status=$1" | jq -r '.data.totalElements'; }
+api_http_code() { curl -sS -o /dev/null -w '%{http_code}' "${API}/executions?size=100&status=$1"; }
+
+expect_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        echo "  ✓ ${label}: ${actual}"
+    else
+        print_error "${label}: expected [${expected}], got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+cleanup() {
+    if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        kill -9 "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+    fi
+    [ -n "${VALKEY_CONTAINER}" ] && docker rm -f "${VALKEY_CONTAINER}" >/dev/null 2>&1 || true
+    if [ "${KEEP_DB:-0}" = "1" ]; then
+        echo "KEEP_DB=1 — leaving ${TEST_DB_SERVER}/${TEST_DB_RUNTIME} and ${TEST_DATA_DIR}"
+        return
+    fi
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_SERVER}" >/dev/null 2>&1 || true
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_RUNTIME}" >/dev/null 2>&1 || true
+    rm -rf "${TEST_DATA_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+start_server() {
+    RUNTARA_SERVER_DATABASE_URL="${SERVER_DB_URL}" \
+    OBJECT_MODEL_DATABASE_URL="${SERVER_DB_URL}" \
+    RUNTARA_DATABASE_URL="${RUNTIME_DB_URL}" \
+    TENANT_ID="${TENANT}" \
+    SERVER_HOST=127.0.0.1 \
+    SERVER_PORT="${TEST_PORT_PUBLIC}" \
+    INTERNAL_PORT="${TEST_PORT_INTERNAL}" \
+    RUNTARA_CORE_PORT="${TEST_CORE_PORT}" \
+    RUNTARA_ENVIRONMENT_PORT="${TEST_ENV_PORT}" \
+    RUNTARA_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT}" \
+    RUNTARA_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT}" \
+    RUNTARA_AGENT_COMPONENTS_DIR="${COMPONENTS_DIR}" \
+    DATA_DIR="${TEST_DATA_DIR}" \
+    RUNTARA_DEV_MODE=false \
+    RUST_LOG="${RUST_LOG_OVERRIDE:-warn,runtara_server=info,runtara_environment=info,runtara_core=info}" \
+    AUTH_PROVIDER=local \
+    SESSION_TOKEN_SECRET=8efacf953eb244e07346edb64d1a8adca5bdf92049611737ce09e2c6388cb5f2 \
+    VALKEY_HOST=127.0.0.1 \
+    VALKEY_PORT="${TEST_VALKEY_PORT}" \
+    OTEL_SDK_DISABLED=true \
+    RUNTARA_SDK_BACKEND=http \
+    SQLX_OFFLINE="${SQLX_OFFLINE}" \
+    "${RUNTARA_SERVER_BIN}" >>"${TEST_LOG}" 2>&1 &
+    SERVER_PID=$!
+
+    for i in {1..60}; do
+        if curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${TEST_PORT_PUBLIC}/health" 2>/dev/null | grep -q "^2"; then
+            return 0
+        fi
+        sleep 1
+        if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            print_error "Server exited during boot."; tail -40 "${TEST_LOG}"; exit 1
+        fi
+    done
+    print_error "Server did not become healthy."; tail -40 "${TEST_LOG}"; exit 1
+}
+
+# One instance per status, all under the tenant the API reads.
+seed_instance() {
+    local instance_id="$1" status="$2"
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c "
+        INSERT INTO instances (instance_id, tenant_id, status, started_at, finished_at)
+        VALUES ('${instance_id}', '${TENANT}', '${status}'::instance_status, now(), now());
+        INSERT INTO instance_images (instance_id, image_id, tenant_id)
+        VALUES ('${instance_id}', '${IMAGE_ID}', '${TENANT}');
+    " >/dev/null
+}
+
+echo "==============================================================="
+echo "E2E: multi-status execution filter"
+echo "==============================================================="
+
+[ -x "${RUNTARA_SERVER_BIN}" ] || { print_error "Missing server bin ${RUNTARA_SERVER_BIN} (cargo build -p runtara-server --bin runtara-server)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { print_error "jq required"; exit 1; }
+[ -d "${COMPONENTS_DIR}" ] || { print_error "Missing components dir ${COMPONENTS_DIR} — run scripts/build-agent-components.sh"; exit 1; }
+psql_quiet -d postgres -c "SELECT 1" >/dev/null 2>&1 || { print_error "Cannot reach Postgres"; exit 1; }
+docker info >/dev/null 2>&1 || { print_error "docker required (isolated Valkey)"; exit 1; }
+
+print_step "Starting isolated Valkey on :${TEST_VALKEY_PORT}..."
+VALKEY_CONTAINER=$(docker run -d --rm -p "${TEST_VALKEY_PORT}:6379" valkey/valkey:8-alpine)
+for i in {1..20}; do (echo > /dev/tcp/127.0.0.1/${TEST_VALKEY_PORT}) 2>/dev/null && break; sleep 0.5; done
+
+print_step "Creating databases..."
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_SERVER}" >/dev/null
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_RUNTIME}" >/dev/null
+
+print_step "Starting runtara-server on :${TEST_PORT_PUBLIC}..."
+start_server
+echo "  Server up (PID ${SERVER_PID})"
+
+print_step "Seeding one instance per status..."
+IMAGE_ID="multistatus-image"
+psql_quiet -d "${TEST_DB_RUNTIME}" -c "
+    INSERT INTO images (image_id, tenant_id, name, binary_path, runner_type)
+    VALUES ('${IMAGE_ID}', '${TENANT}', 'multistatus:1', '/dev/null', 'wasm');
+" >/dev/null
+seed_instance "multistatus-failed"    failed
+seed_instance "multistatus-cancelled" cancelled
+seed_instance "multistatus-completed" completed
+seed_instance "multistatus-running"   running
+echo "  4 instances seeded (failed, cancelled, completed, running)"
+
+print_step "Asserting the filter applies every status..."
+
+# The bug: only `failed` was applied, so `cancelled` never came back.
+expect_eq "status=failed,cancelled returns both" \
+    "$(printf 'cancelled\nfailed')" "$(api_statuses 'failed,cancelled')"
+
+# totalElements comes from a separate count query against the same filter — it
+# has to agree with the page, or pagination lies about how much is there.
+expect_eq "status=failed,cancelled totalElements" "2" "$(api_total 'failed,cancelled')"
+
+# failed and timeout both mean the same runtime status; asking for both must not
+# double count.
+expect_eq "status=failed,timeout collapses to one status" \
+    "failed" "$(api_statuses 'failed,timeout')"
+expect_eq "status=failed,timeout totalElements" "1" "$(api_total 'failed,timeout')"
+
+# Three of the four, to catch an "any status matches" over-correction.
+expect_eq "status=failed,cancelled,completed returns three" \
+    "$(printf 'cancelled\ncompleted\nfailed')" "$(api_statuses 'failed,cancelled,completed')"
+
+# A single status must still behave exactly as before.
+expect_eq "status=failed alone" "failed" "$(api_statuses 'failed')"
+expect_eq "status=failed alone totalElements" "1" "$(api_total 'failed')"
+
+# No filter at all returns everything.
+expect_eq "no status filter totalElements" "4" \
+    "$(curl -sS "${API}/executions?size=100" | jq -r '.data.totalElements')"
+
+# `suspended` is a status listings report, so it has to be accepted as a filter.
+expect_eq "status=suspended is accepted" "200" "$(api_http_code 'suspended')"
+
+# An unknown status in the list is still rejected outright.
+expect_eq "status=failed,bogus is rejected" "400" "$(api_http_code 'failed,bogus')"
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+    print_success "All multi-status filter assertions passed"
+    exit 0
+fi
+print_error "${FAILURES} assertion(s) failed"
+tail -40 "${TEST_LOG}"
+exit 1


### PR DESCRIPTION
GET /api/runtime/executions documents `status` as a comma-separated list and validates every entry, but the runtime query was built from the first entry alone. The rest were dropped silently, so `status=failed,cancelled` returned failures only — with a totalElements count that agreed with the truncated page rather than the request.

Pass the whole set through instead: the environment matches any status in the list (`= ANY(...)`, in both the list and the count query), the SDK carries the set as `statuses`, and the server maps every entry rather than just the first. Because the local status vocabulary is many-to-one over the runtime's — queued/compiling both mean pending, failed/timeout both mean failed — repeats are collapsed on the way down.

The SDK keeps sending `status` alongside `statuses`: an environment that predates this ignores the unknown parameter, and would otherwise drop the status filter entirely instead of narrowing to the first entry.

Also accept `suspended` as a filter value. Listings report it, so callers could see a status they were not allowed to filter on.