### PR TITLE
SYN-603: Pair pending-input requests to their resolutions in the executions list

### DIFF
--- a/crates/runtara-server/src/api/handlers/step_events.rs
+++ b/crates/runtara-server/src/api/handlers/step_events.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
+use crate::api::services::pending_inputs::{fetch_input_and_end_events, open_input_events};
 use crate::api::services::workflow_runtime::{
     SubmitWorkflowActionRequest, WorkflowRuntimeError, list_instance_actions,
     list_workflow_actions, submit_workflow_action as submit_runtime_workflow_action,
@@ -491,18 +492,10 @@ pub async fn get_pending_input(
         }
     };
 
-    // Query all custom events with subtype "external_input_requested"
-    let input_options = ListEventsOptions::new()
-        .with_limit(100)
-        .with_event_type("custom")
-        .with_subtype("external_input_requested")
-        .with_sort_order(EventSortOrder::Asc);
-
-    let input_events = match client.list_events(&instance_id, Some(input_options)).await {
-        Ok(result) => result.events,
-        Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("not found") {
+    let (input_events, end_events) = match fetch_input_and_end_events(&client, &instance_id).await {
+        Ok(events) => events,
+        Err(message) => {
+            if message.contains("not found") {
                 return (
                     StatusCode::NOT_FOUND,
                     Json(json!({
@@ -516,61 +509,16 @@ pub async fn get_pending_input(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({
                     "success": false,
-                    "message": format!("Failed to query events: {}", msg),
+                    "message": format!("Failed to query events: {}", message),
                     "data": Value::Null
                 })),
             );
         }
     };
 
-    // Query all step_debug_end events to find completed steps
-    // (both AiAgentToolCall and WaitForSignal)
-    let end_options = ListEventsOptions::new()
-        .with_limit(1000)
-        .with_event_type("custom")
-        .with_subtype("step_debug_end");
-
-    let end_events = match client.list_events(&instance_id, Some(end_options)).await {
-        Ok(result) => result.events,
-        Err(_) => vec![], // If we can't query, assume none completed
-    };
-
-    // Collect completed step IDs from step_debug_end events
     // The payload fields are at the top level (not nested under "data")
-    let completed_tool_ids: std::collections::HashSet<String> = end_events
-        .iter()
-        .filter_map(|event| {
-            event
-                .payload
-                .as_ref()
-                .and_then(|p| p.get("step_id"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-        })
-        .collect();
-
-    // A resolved WaitForSignal's step_debug_end carries its signal id inside
-    // the outputs envelope. Standalone waits are matched by SIGNAL id below —
-    // signal ids are per-invocation-site (one child step can wait at several
-    // sites in one instance, embedded or composed), so a completed wait at
-    // one site must not hide another site's open wait on the same step id.
-    let completed_signal_ids: std::collections::HashSet<String> = end_events
-        .iter()
-        .filter_map(|event| {
-            event
-                .payload
-                .as_ref()
-                .and_then(|p| p.get("outputs"))
-                .and_then(|outputs| outputs.get("signal_id"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-        })
-        .collect();
-
-    // Filter to only pending requests (where the tool call hasn't completed)
-    // The payload fields are at the top level (not nested under "data")
-    let pending: Vec<PendingInputResponse> = input_events
-        .iter()
+    let pending: Vec<PendingInputResponse> = open_input_events(&input_events, &end_events)
+        .into_iter()
         .filter_map(|event| {
             let data = event.payload.as_ref()?;
 
@@ -581,25 +529,6 @@ pub async fn get_pending_input(
                 .get("call_number")
                 .and_then(|v| v.as_u64())
                 .map(|v| v as u32);
-
-            // Skip requests that already resolved. AI Agent tool calls
-            // complete under the synthetic step id
-            // "{ai_step_id}.tool.{tool_name}.{call_number}"; standalone
-            // WaitForSignal steps are matched by their per-site signal id
-            // (a bare step id is NOT unique across invocation sites).
-            match (ai_step_id, tool_name, call_number) {
-                (Some(step), Some(tool), Some(num)) => {
-                    let check_step_id = format!("{}.tool.{}.{}", step, tool, num);
-                    if completed_tool_ids.contains(&check_step_id) {
-                        return None;
-                    }
-                }
-                _ => {
-                    if completed_signal_ids.contains(&signal_id) {
-                        return None;
-                    }
-                }
-            }
 
             Some(PendingInputResponse {
                 signal_id,

--- a/crates/runtara-server/src/api/services/mod.rs
+++ b/crates/runtara-server/src/api/services/mod.rs
@@ -10,6 +10,7 @@ pub mod file_storage;
 pub mod input_validation;
 pub mod object_model;
 pub mod operators;
+pub mod pending_inputs;
 pub mod reports;
 pub mod schema_validator;
 pub mod session_queue;

--- a/crates/runtara-server/src/api/services/pending_inputs.rs
+++ b/crates/runtara-server/src/api/services/pending_inputs.rs
@@ -1,0 +1,293 @@
+//! Shared matching of `external_input_requested` events against the
+//! `step_debug_end` events that resolve them.
+//!
+//! Every caller that needs to know whether a running instance is still waiting
+//! on human input derives it from the same two event streams, so the pairing
+//! lives here rather than being reimplemented per call site — the executions
+//! list, the per-instance pending-input endpoint and the workflow action APIs
+//! must not disagree about the same run.
+//!
+//! Pairing cannot be done on timestamps alone: `step_debug_end` is emitted for
+//! every step type, not just the ones that requested input, and branches
+//! genuinely overlap (Split carries a `parallelism` setting), so a step that
+//! ends after a request says nothing about whether that request was answered.
+
+use std::collections::HashSet;
+
+use runtara_management_sdk::{EventSortOrder, EventSummary, ListEventsOptions};
+use serde_json::Value;
+
+use crate::runtime_client::RuntimeClient;
+
+/// Fetch the `external_input_requested` and `step_debug_end` events for an
+/// instance, oldest request first.
+///
+/// A failed request lookup is an error — the caller decides what an unknown
+/// state means. A failed *end* lookup degrades to "nothing has completed",
+/// which keeps open requests visible rather than hiding them.
+pub async fn fetch_input_and_end_events(
+    client: &RuntimeClient,
+    instance_id: &str,
+) -> Result<(Vec<EventSummary>, Vec<EventSummary>), String> {
+    let input_options = ListEventsOptions::new()
+        .with_limit(100)
+        .with_event_type("custom")
+        .with_subtype("external_input_requested")
+        .with_sort_order(EventSortOrder::Asc);
+
+    let input_events = client
+        .list_events(instance_id, Some(input_options))
+        .await
+        .map_err(|error| error.to_string())?
+        .events;
+
+    let end_options = ListEventsOptions::new()
+        .with_limit(1000)
+        .with_event_type("custom")
+        .with_subtype("step_debug_end");
+
+    let end_events = client
+        .list_events(instance_id, Some(end_options))
+        .await
+        .map(|result| result.events)
+        .unwrap_or_default();
+
+    Ok((input_events, end_events))
+}
+
+/// The subset of `input_events` that no `step_debug_end` event has resolved.
+///
+/// AI Agent tool calls complete under the synthetic step id
+/// `{ai_step_id}.tool.{tool_name}.{call_number}`. Standalone waits are matched
+/// by SIGNAL id instead — signal ids are per-invocation-site (one child step
+/// can wait at several sites in one instance, embedded or composed), so a
+/// completed wait at one site must not hide another site's open wait on the
+/// same step id.
+pub fn open_input_events<'a>(
+    input_events: &'a [EventSummary],
+    end_events: &[EventSummary],
+) -> Vec<&'a EventSummary> {
+    let completed_step_ids: HashSet<&str> = end_events
+        .iter()
+        .filter_map(|event| {
+            event
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.get("step_id"))
+                .and_then(Value::as_str)
+        })
+        .collect();
+
+    // A resolved WaitForSignal's `step_debug_end` carries its signal id inside
+    // the outputs envelope.
+    let completed_signal_ids: HashSet<&str> = end_events
+        .iter()
+        .filter_map(|event| {
+            event
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.get("outputs"))
+                .and_then(|outputs| outputs.get("signal_id"))
+                .and_then(Value::as_str)
+        })
+        .collect();
+
+    input_events
+        .iter()
+        .filter(|event| {
+            let Some(payload) = event.payload.as_ref() else {
+                return false;
+            };
+            let Some(signal_id) = payload.get("signal_id").and_then(Value::as_str) else {
+                return false;
+            };
+
+            match (
+                payload.get("ai_agent_step_id").and_then(Value::as_str),
+                payload.get("tool_name").and_then(Value::as_str),
+                payload.get("call_number").and_then(Value::as_u64),
+            ) {
+                (Some(step), Some(tool), Some(number)) => !completed_step_ids
+                    .contains(format!("{}.tool.{}.{}", step, tool, number).as_str()),
+                _ => !completed_signal_ids.contains(signal_id),
+            }
+        })
+        .collect()
+}
+
+/// Whether the instance still has at least one unresolved input request.
+pub async fn has_open_inputs(client: &RuntimeClient, instance_id: &str) -> Result<bool, String> {
+    let (input_events, end_events) = fetch_input_and_end_events(client, instance_id).await?;
+    Ok(!open_input_events(&input_events, &end_events).is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde_json::json;
+
+    fn at(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000 + seconds, 0).unwrap()
+    }
+
+    fn event(id: i64, subtype: &str, created_at: DateTime<Utc>, payload: Value) -> EventSummary {
+        EventSummary {
+            id,
+            instance_id: "instance-1".to_string(),
+            event_type: "custom".to_string(),
+            checkpoint_id: None,
+            payload: Some(payload),
+            created_at,
+            subtype: Some(subtype.to_string()),
+        }
+    }
+
+    /// A standalone wait, identified by its per-invocation-site signal id.
+    fn wait_request(id: i64, seconds: i64, step_id: &str, signal_id: &str) -> EventSummary {
+        event(
+            id,
+            "external_input_requested",
+            at(seconds),
+            json!({ "step_id": step_id, "signal_id": signal_id }),
+        )
+    }
+
+    fn wait_resolved(id: i64, seconds: i64, step_id: &str, signal_id: &str) -> EventSummary {
+        event(
+            id,
+            "step_debug_end",
+            at(seconds),
+            json!({ "step_id": step_id, "outputs": { "signal_id": signal_id } }),
+        )
+    }
+
+    fn signal_ids(events: &[&EventSummary]) -> Vec<String> {
+        events
+            .iter()
+            .map(|event| {
+                event.payload.as_ref().unwrap()["signal_id"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn concurrent_split_iterations_stay_open_when_one_is_answered() {
+        // Four iterations of one Split step, each waiting on an approval at its
+        // own invocation site.
+        let requests: Vec<EventSummary> = (1..=4)
+            .map(|iteration| {
+                wait_request(
+                    iteration,
+                    iteration,
+                    "approve",
+                    &format!("signal-{}", iteration),
+                )
+            })
+            .collect();
+
+        // Iteration 1 is approved, and its end event lands after every other
+        // iteration's request — the trap a latest-timestamp comparison falls
+        // into.
+        let ends = vec![wait_resolved(10, 20, "approve", "signal-1")];
+
+        let open = open_input_events(&requests, &ends);
+
+        assert_eq!(signal_ids(&open), vec!["signal-2", "signal-3", "signal-4"]);
+    }
+
+    #[test]
+    fn unrelated_step_completions_do_not_resolve_a_request() {
+        let requests = vec![wait_request(1, 1, "approve", "signal-1")];
+        // A plain step finishing later carries neither a matching signal id nor
+        // a synthetic tool step id.
+        let ends = vec![event(
+            2,
+            "step_debug_end",
+            at(30),
+            json!({ "step_id": "fetch_orders", "outputs": { "count": 12 } }),
+        )];
+
+        let open = open_input_events(&requests, &ends);
+
+        assert_eq!(signal_ids(&open), vec!["signal-1"]);
+    }
+
+    #[test]
+    fn agent_tool_calls_match_on_the_synthetic_step_id() {
+        let tool_request = |id: i64, call_number: u64, signal_id: &str| {
+            event(
+                id,
+                "external_input_requested",
+                at(id),
+                json!({
+                    "signal_id": signal_id,
+                    "ai_agent_step_id": "agent",
+                    "tool_name": "ask_human",
+                    "call_number": call_number,
+                }),
+            )
+        };
+        let requests = vec![
+            tool_request(1, 1, "signal-1"),
+            tool_request(2, 2, "signal-2"),
+        ];
+
+        // Only the first call completed; the same tool at a later call number
+        // is a different request.
+        let ends = vec![event(
+            3,
+            "step_debug_end",
+            at(30),
+            json!({ "step_id": "agent.tool.ask_human.1" }),
+        )];
+
+        let open = open_input_events(&requests, &ends);
+
+        assert_eq!(signal_ids(&open), vec!["signal-2"]);
+    }
+
+    #[test]
+    fn a_completed_wait_does_not_hide_another_site_on_the_same_step() {
+        // One child step waiting at two invocation sites — the step ids are
+        // identical, only the signal ids differ.
+        let requests = vec![
+            wait_request(1, 1, "approve", "signal-site-a"),
+            wait_request(2, 2, "approve", "signal-site-b"),
+        ];
+        let ends = vec![wait_resolved(3, 3, "approve", "signal-site-a")];
+
+        let open = open_input_events(&requests, &ends);
+
+        assert_eq!(signal_ids(&open), vec!["signal-site-b"]);
+    }
+
+    #[test]
+    fn every_request_is_open_without_end_events() {
+        let requests = vec![
+            wait_request(1, 1, "approve", "signal-1"),
+            wait_request(2, 2, "approve", "signal-2"),
+        ];
+
+        let open = open_input_events(&requests, &[]);
+
+        assert_eq!(signal_ids(&open), vec!["signal-1", "signal-2"]);
+    }
+
+    #[test]
+    fn answering_the_last_open_request_leaves_nothing() {
+        let requests = vec![
+            wait_request(1, 1, "approve", "signal-1"),
+            wait_request(2, 2, "approve", "signal-2"),
+        ];
+        let ends = vec![
+            wait_resolved(3, 3, "approve", "signal-1"),
+            wait_resolved(4, 4, "approve", "signal-2"),
+        ];
+
+        assert!(open_input_events(&requests, &ends).is_empty());
+    }
+}

--- a/crates/runtara-server/src/api/services/workflow_runtime.rs
+++ b/crates/runtara-server/src/api/services/workflow_runtime.rs
@@ -1,7 +1,4 @@
-use std::collections::HashSet;
-
 use chrono::{DateTime, Utc};
-use runtara_management_sdk::{EventSortOrder, ListEventsOptions};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
@@ -9,6 +6,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::api::services::input_validation::{is_empty_schema, validate_inputs};
+use crate::api::services::pending_inputs::{fetch_input_and_end_events, open_input_events};
 use crate::runtime_client::RuntimeClient;
 use crate::workers::execution_engine::{ExecutionEngine, ExecutionError};
 
@@ -85,61 +83,12 @@ pub async fn list_instance_actions(
 ) -> Result<Vec<WorkflowRuntimeAction>, WorkflowRuntimeError> {
     validate_instance_id(instance_id)?;
 
-    let input_options = ListEventsOptions::new()
-        .with_limit(100)
-        .with_event_type("custom")
-        .with_subtype("external_input_requested")
-        .with_sort_order(EventSortOrder::Asc);
-
-    let input_events = client
-        .list_events(instance_id, Some(input_options))
+    let (input_events, end_events) = fetch_input_and_end_events(client, instance_id)
         .await
-        .map_err(|error| map_runtime_error(error.to_string(), instance_id))?
-        .events;
+        .map_err(|error| map_runtime_error(error, instance_id))?;
 
-    let end_options = ListEventsOptions::new()
-        .with_limit(1000)
-        .with_event_type("custom")
-        .with_subtype("step_debug_end");
-
-    let end_events = client
-        .list_events(instance_id, Some(end_options))
-        .await
-        .map(|result| result.events)
-        .unwrap_or_default();
-
-    let completed_step_ids: HashSet<String> = end_events
-        .iter()
-        .filter_map(|event| {
-            event
-                .payload
-                .as_ref()
-                .and_then(|payload| payload.get("step_id"))
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        })
-        .collect();
-
-    // A resolved WaitForSignal's step_debug_end carries its signal id inside
-    // the outputs envelope. Standalone waits are matched by SIGNAL id below —
-    // signal ids are per-invocation-site (one child step can wait at several
-    // sites in one instance, embedded or composed), so a completed wait at
-    // one site must not hide another site's open wait on the same step id.
-    let completed_signal_ids: HashSet<String> = end_events
-        .iter()
-        .filter_map(|event| {
-            event
-                .payload
-                .as_ref()
-                .and_then(|payload| payload.get("outputs"))
-                .and_then(|outputs| outputs.get("signal_id"))
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        })
-        .collect();
-
-    let actions = input_events
-        .iter()
+    let actions = open_input_events(&input_events, &end_events)
+        .into_iter()
         .filter_map(|event| {
             let payload = event.payload.as_ref()?;
             let signal_id = payload.get("signal_id")?.as_str()?.to_string();
@@ -151,24 +100,6 @@ pub async fn list_instance_actions(
                 .get("call_number")
                 .and_then(Value::as_u64)
                 .map(|value| value as u32);
-
-            // AI Agent tool calls complete under the synthetic
-            // "{ai_step_id}.tool.{tool_name}.{call_number}" step id;
-            // standalone waits are matched by their per-site signal id
-            // (a bare step id is NOT unique across invocation sites).
-            match (ai_agent_step_id, tool_name, call_number) {
-                (Some(step), Some(tool), Some(number)) => {
-                    let check_step_id = format!("{}.tool.{}.{}", step, tool, number);
-                    if completed_step_ids.contains(&check_step_id) {
-                        return None;
-                    }
-                }
-                _ => {
-                    if completed_signal_ids.contains(&signal_id) {
-                        return None;
-                    }
-                }
-            }
 
             let input_schema = payload.get("response_schema").cloned();
             let action_key = payload

--- a/crates/runtara-server/src/workers/runtara_dto.rs
+++ b/crates/runtara-server/src/workers/runtara_dto.rs
@@ -9,12 +9,11 @@
 //! service.
 
 use chrono::{DateTime, Utc};
-use runtara_management_sdk::{
-    EventSortOrder, InstanceInfo, InstanceStatus as RuntaraInstanceStatus, ListEventsOptions,
-};
+use runtara_management_sdk::{InstanceInfo, InstanceStatus as RuntaraInstanceStatus};
 use serde_json::Value;
 
 use crate::api::dto::workflows::{InstanceInputs, WorkflowInstanceDto};
+use crate::api::services::pending_inputs::has_open_inputs;
 use crate::runtime_client::RuntimeClient;
 use crate::types::ExecutionStatus;
 
@@ -98,52 +97,29 @@ fn duration_seconds(
     (ms >= 0).then(|| ms as f64 / 1000.0)
 }
 
-/// Enrich running instances with `has_pending_input` by checking for unresolved
-/// `external_input_requested` events. Only queries events for running instances.
+/// Enrich running instances with `has_pending_input` by checking for
+/// unresolved `external_input_requested` events.
+///
+/// Only queries events for running instances. The request/resolution pairing is
+/// shared with the per-instance pending-input and action endpoints (see
+/// `api::services::pending_inputs`) so the list and the detail views cannot
+/// disagree about the same run.
 pub async fn enrich_pending_input(instances: &mut [WorkflowInstanceDto], client: &RuntimeClient) {
     for instance in instances.iter_mut() {
         if instance.status != ExecutionStatus::Running {
             continue;
         }
 
-        // Check for external_input_requested events
-        let options = ListEventsOptions::new()
-            .with_limit(1)
-            .with_event_type("custom")
-            .with_subtype("external_input_requested")
-            .with_sort_order(EventSortOrder::Desc);
-
-        match client.list_events(&instance.id, Some(options)).await {
-            Ok(result) if !result.events.is_empty() => {
-                // Found at least one external_input_requested event.
-                // Check if the most recent one has been resolved by looking for
-                // a corresponding step_debug_end event (covers both
-                // AiAgentToolCall and standalone WaitForSignal).
-                let end_options = ListEventsOptions::new()
-                    .with_limit(1)
-                    .with_event_type("custom")
-                    .with_subtype("step_debug_end")
-                    .with_sort_order(EventSortOrder::Desc);
-
-                let has_completion = match client.list_events(&instance.id, Some(end_options)).await
-                {
-                    Ok(end_result) => {
-                        // If the latest end event is newer than the latest request,
-                        // the most recent request has been resolved
-                        if let (Some(req), Some(end)) =
-                            (result.events.first(), end_result.events.first())
-                        {
-                            end.created_at >= req.created_at
-                        } else {
-                            false
-                        }
-                    }
-                    Err(_) => false,
-                };
-
-                instance.has_pending_input = !has_completion;
-            }
-            _ => {}
+        match has_open_inputs(client, &instance.id).await {
+            Ok(has_open) => instance.has_pending_input = has_open,
+            // The flag stays false, so the indicator is hidden rather than
+            // wrongly shown for every running row during a runtime hiccup —
+            // but the hiccup itself must not pass silently.
+            Err(error) => tracing::warn!(
+                instance_id = %instance.id,
+                error = %error,
+                "Failed to resolve pending input state; reporting none"
+            ),
         }
     }
 }

--- a/e2e/run_all.sh
+++ b/e2e/run_all.sh
@@ -68,6 +68,7 @@ run_test "SMO pgvector + Levenshtein (Tier 3)" "${SCRIPT_DIR}/test_smo_vector_se
 run_test "Object-model raw SQL (query-sql / execute-sql)" "${SCRIPT_DIR}/test_obm_sql_workflow.sh"
 run_test "Negative duration on suspend/relaunch (regression)" "${SCRIPT_DIR}/test_negative_duration_on_resume.sh"
 run_test "Stale artifact + trigger replay idempotency (regression)" "${SCRIPT_DIR}/test_trigger_replay_idempotency.sh"
+run_test "Pending input across concurrent branches (regression)" "${SCRIPT_DIR}/test_pending_input_concurrent_branches.sh"
 
 # Microsoft Teams. These boot their OWN isolated runtara-server + Valkey (docker)
 # on dedicated high ports and mock the Bot Framework, so they are self-contained

--- a/e2e/test_pending_input_concurrent_branches.sh
+++ b/e2e/test_pending_input_concurrent_branches.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+# E2E Test: the executions list must keep reporting pending input while any
+# branch of a run is still blocked.
+#
+# The list used to derive `hasPendingInput` from a whole-instance timestamp
+# heuristic: the newest `external_input_requested` versus the newest
+# `step_debug_end`, with "end is newer" taken to mean "answered". But
+# `step_debug_end` is emitted for every step type, and branches genuinely
+# overlap (Split carries a `parallelism` setting), so answering ONE iteration
+# produced an end event newer than every other iteration's still-open request —
+# and the indicator vanished while the run sat blocked.
+#
+# The per-instance pending-input endpoint always paired properly (by synthetic
+# tool step id, and by per-invocation-site signal id for standalone waits), so
+# the list and the detail view actively disagreed about the same run.
+#
+# This exercises the whole chain the unit tests only cover in pieces: HTTP
+# handler -> execution engine -> DTO enrichment -> management SDK ->
+# environment HTTP -> SQL.
+#
+# The instance rows and their events are seeded directly, so the assertions are
+# about the pairing and not about how a Split happens to schedule its branches.
+#
+# Asserts:
+#   * a run with 3 of 4 branches still waiting reports hasPendingInput=true
+#   * the detail endpoint lists exactly those 3 open requests
+#   * the list and the detail endpoint agree on the same run
+#   * the open-actions endpoint (gated on the same flag) returns those 3
+#   * a fully answered run reports false, and offers no actions
+#   * a step completing later on an unrelated step id resolves nothing
+#
+# On UNPATCHED code this FAILS: the answered branch's end event is newer than
+# the other branches' requests, so the list reports hasPendingInput=false and
+# the actions endpoint short-circuits to an empty list.
+#
+# Prereqs: Postgres reachable on ${POSTGRES_HOST}:${POSTGRES_PORT} (host `psql`,
+# or a `runtara-dev-postgres` docker container as fallback), docker (isolated
+# Valkey), and a built runtara-server (cargo build -p runtara-server).
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+print_step()    { echo -e "${GREEN}[STEP]${NC} $1"; }
+print_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-smo_worker}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-GueUkDKea0CjKP4Rn5Bk0FDV}"
+PG_CONTAINER="${PG_CONTAINER:-runtara-dev-postgres}"
+
+TEST_DB_SERVER="pendinginput_e2e_server_$$"
+TEST_DB_RUNTIME="pendinginput_e2e_runtime_$$"
+TEST_PORT_PUBLIC="${TEST_PORT_PUBLIC:-17750}"
+TEST_PORT_INTERNAL="${TEST_PORT_INTERNAL:-17751}"
+TEST_CORE_PORT="${TEST_CORE_PORT:-18751}"
+TEST_ENV_PORT="${TEST_ENV_PORT:-18752}"
+TEST_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT:-18753}"
+TEST_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT:-18754}"
+TEST_VALKEY_PORT="${TEST_VALKEY_PORT:-16395}"
+TEST_DATA_DIR="$(mktemp -d -t runtara_pendinginput_e2e_XXXXXX)"
+TEST_LOG="${TEST_DATA_DIR}/server.log"
+SERVER_PID=""
+VALKEY_CONTAINER=""
+TENANT="pendinginput_e2e"
+
+# The instance -> workflow link is checked by image_name prefix, so the image is
+# named "{WORKFLOW}:1" and no workflow row is needed for the detail endpoints.
+WORKFLOW="syn-split-approvals"
+IMAGE_ID="pendinginput-image"
+# Instance ids reach UUID-validating handlers, so they have to be real UUIDs.
+INSTANCE_BLOCKED="11111111-1111-4111-8111-111111111111"
+INSTANCE_ANSWERED="22222222-2222-4222-8222-222222222222"
+
+RUNTARA_SERVER_BIN="${RUNTARA_SERVER_BIN:-${PROJECT_ROOT}/target/debug/runtara-server}"
+# The server refuses to boot without a components directory. Nothing here
+# executes a workflow, so the components only have to be present.
+COMPONENTS_DIR="${RUNTARA_AGENT_COMPONENTS_DIR:-${PROJECT_ROOT}/target/wasm32-wasip2/release}"
+SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
+SERVER_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_SERVER}"
+RUNTIME_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_RUNTIME}"
+API="http://127.0.0.1:${TEST_PORT_PUBLIC}/api/runtime"
+
+FAILURES=0
+
+# psql shim: prefer host psql, fall back to the dev postgres container.
+if command -v psql >/dev/null 2>&1; then
+    psql_quiet() { PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA "$@"; }
+elif docker exec "${PG_CONTAINER}" true >/dev/null 2>&1; then
+    print_warn "host psql not found — using docker exec ${PG_CONTAINER}"
+    psql_quiet() { docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${PG_CONTAINER}" psql -U "${POSTGRES_USER}" -tA "$@"; }
+else
+    print_error "no psql available (host psql or ${PG_CONTAINER} container required)"; exit 1
+fi
+
+# hasPendingInput for one instance, as the executions list reports it.
+list_flag() {
+    curl -sS "${API}/executions?size=100" \
+        | jq -r --arg id "$1" '.data.content[] | select(.id == $id) | .hasPendingInput'
+}
+# Signal ids the per-instance detail endpoint reports as still open, sorted.
+detail_signals() {
+    curl -sS "${API}/workflows/${WORKFLOW}/instances/$1/pending-input" \
+        | jq -r '.data.pendingInputs[].signalId' | sort
+}
+# Signal ids the open-actions endpoint offers — gated on hasPendingInput.
+action_signals() {
+    curl -sS "${API}/workflows/${WORKFLOW}/instances/$1/actions" \
+        | jq -r '.data.actions[].signalId' | sort
+}
+
+expect_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        echo "  ✓ ${label}: ${actual}"
+    else
+        print_error "${label}: expected [${expected}], got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+cleanup() {
+    if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        kill -9 "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+    fi
+    [ -n "${VALKEY_CONTAINER}" ] && docker rm -f "${VALKEY_CONTAINER}" >/dev/null 2>&1 || true
+    if [ "${KEEP_DB:-0}" = "1" ]; then
+        echo "KEEP_DB=1 — leaving ${TEST_DB_SERVER}/${TEST_DB_RUNTIME} and ${TEST_DATA_DIR}"
+        return
+    fi
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_SERVER}" >/dev/null 2>&1 || true
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_RUNTIME}" >/dev/null 2>&1 || true
+    rm -rf "${TEST_DATA_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+start_server() {
+    RUNTARA_SERVER_DATABASE_URL="${SERVER_DB_URL}" \
+    OBJECT_MODEL_DATABASE_URL="${SERVER_DB_URL}" \
+    RUNTARA_DATABASE_URL="${RUNTIME_DB_URL}" \
+    TENANT_ID="${TENANT}" \
+    SERVER_HOST=127.0.0.1 \
+    SERVER_PORT="${TEST_PORT_PUBLIC}" \
+    INTERNAL_PORT="${TEST_PORT_INTERNAL}" \
+    RUNTARA_CORE_PORT="${TEST_CORE_PORT}" \
+    RUNTARA_ENVIRONMENT_PORT="${TEST_ENV_PORT}" \
+    RUNTARA_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT}" \
+    RUNTARA_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT}" \
+    RUNTARA_AGENT_COMPONENTS_DIR="${COMPONENTS_DIR}" \
+    DATA_DIR="${TEST_DATA_DIR}" \
+    RUNTARA_DEV_MODE=false \
+    RUST_LOG="${RUST_LOG_OVERRIDE:-warn,runtara_server=info,runtara_environment=info,runtara_core=info}" \
+    AUTH_PROVIDER=local \
+    SESSION_TOKEN_SECRET=8efacf953eb244e07346edb64d1a8adca5bdf92049611737ce09e2c6388cb5f2 \
+    VALKEY_HOST=127.0.0.1 \
+    VALKEY_PORT="${TEST_VALKEY_PORT}" \
+    OTEL_SDK_DISABLED=true \
+    RUNTARA_SDK_BACKEND=http \
+    SQLX_OFFLINE="${SQLX_OFFLINE}" \
+    "${RUNTARA_SERVER_BIN}" >>"${TEST_LOG}" 2>&1 &
+    SERVER_PID=$!
+
+    for i in {1..60}; do
+        if curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${TEST_PORT_PUBLIC}/health" 2>/dev/null | grep -q "^2"; then
+            return 0
+        fi
+        sleep 1
+        if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            print_error "Server exited during boot."; tail -40 "${TEST_LOG}"; exit 1
+        fi
+    done
+    print_error "Server did not become healthy."; tail -40 "${TEST_LOG}"; exit 1
+}
+
+seed_instance() {
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c "
+        INSERT INTO instances (instance_id, tenant_id, status, started_at)
+        VALUES ('$1', '${TENANT}', 'running'::instance_status, now());
+        INSERT INTO instance_images (instance_id, image_id, tenant_id)
+        VALUES ('$1', '${IMAGE_ID}', '${TENANT}');
+    " >/dev/null
+}
+
+# Event payloads are stored as JSON bytes. `offset_seconds` places the event on
+# the instance timeline, which is what the old heuristic keyed off.
+seed_event() {
+    local instance_id="$1" subtype="$2" offset_seconds="$3" payload="$4"
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c "
+        INSERT INTO instance_events (instance_id, event_type, subtype, payload, created_at)
+        VALUES ('${instance_id}', 'custom'::instance_event_type, '${subtype}',
+                convert_to(\$json\$${payload}\$json\$, 'UTF8'),
+                now() + interval '${offset_seconds} seconds');
+    " >/dev/null
+}
+
+echo "==============================================================="
+echo "E2E: pending input across concurrent branches"
+echo "==============================================================="
+
+[ -x "${RUNTARA_SERVER_BIN}" ] || { print_error "Missing server bin ${RUNTARA_SERVER_BIN} (cargo build -p runtara-server --bin runtara-server)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { print_error "jq required"; exit 1; }
+[ -d "${COMPONENTS_DIR}" ] || { print_error "Missing components dir ${COMPONENTS_DIR} — run scripts/build-agent-components.sh"; exit 1; }
+psql_quiet -d postgres -c "SELECT 1" >/dev/null 2>&1 || { print_error "Cannot reach Postgres"; exit 1; }
+docker info >/dev/null 2>&1 || { print_error "docker required (isolated Valkey)"; exit 1; }
+
+print_step "Starting isolated Valkey on :${TEST_VALKEY_PORT}..."
+VALKEY_CONTAINER=$(docker run -d --rm -p "${TEST_VALKEY_PORT}:6379" valkey/valkey:8-alpine)
+for i in {1..20}; do (echo > /dev/tcp/127.0.0.1/${TEST_VALKEY_PORT}) 2>/dev/null && break; sleep 0.5; done
+
+print_step "Creating databases..."
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_SERVER}" >/dev/null
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_RUNTIME}" >/dev/null
+
+print_step "Starting runtara-server on :${TEST_PORT_PUBLIC}..."
+start_server
+echo "  Server up (PID ${SERVER_PID})"
+
+print_step "Seeding a blocked run and a fully answered run..."
+psql_quiet -d "${TEST_DB_RUNTIME}" -c "
+    INSERT INTO images (image_id, tenant_id, name, binary_path, runner_type)
+    VALUES ('${IMAGE_ID}', '${TENANT}', '${WORKFLOW}:1', '/dev/null', 'wasm');
+" >/dev/null
+seed_instance "${INSTANCE_BLOCKED}"
+seed_instance "${INSTANCE_ANSWERED}"
+
+# Four iterations of one Split step, each waiting at its own invocation site.
+# The step id is deliberately shared — only the signal ids differ.
+for i in 1 2 3 4; do
+    seed_event "${INSTANCE_BLOCKED}" external_input_requested "${i}" \
+        "{\"step_id\":\"approve\",\"step_name\":\"Approve order\",\"signal_id\":\"signal-${i}\",\"iteration\":${i}}"
+done
+# Iteration 1 is answered. Its end event lands AFTER every other iteration's
+# request — exactly the ordering the old heuristic read as "all resolved".
+seed_event "${INSTANCE_BLOCKED}" step_debug_end 20 \
+    "{\"step_id\":\"approve\",\"outputs\":{\"signal_id\":\"signal-1\"}}"
+# An unrelated step finishing even later must not resolve anything either.
+seed_event "${INSTANCE_BLOCKED}" step_debug_end 25 \
+    "{\"step_id\":\"fetch_orders\",\"outputs\":{\"count\":12}}"
+echo "  ${INSTANCE_BLOCKED}: 4 requests, 1 answered, 2 later step completions"
+
+seed_event "${INSTANCE_ANSWERED}" external_input_requested 1 \
+    "{\"step_id\":\"approve\",\"step_name\":\"Approve order\",\"signal_id\":\"signal-only\"}"
+seed_event "${INSTANCE_ANSWERED}" step_debug_end 2 \
+    "{\"step_id\":\"approve\",\"outputs\":{\"signal_id\":\"signal-only\"}}"
+echo "  ${INSTANCE_ANSWERED}: 1 request, answered"
+
+print_step "Asserting the list keeps the indicator while branches are blocked..."
+
+# The bug: the answered branch's end event hid the other three.
+expect_eq "blocked run reports hasPendingInput" "true" "$(list_flag "${INSTANCE_BLOCKED}")"
+
+# The detail endpoint always paired correctly — this is what the list must match.
+expect_eq "detail endpoint lists the 3 open branches" \
+    "$(printf 'signal-2\nsignal-3\nsignal-4')" "$(detail_signals "${INSTANCE_BLOCKED}")"
+
+# The disagreement in the ticket: list said "nothing pending", detail said 3.
+BLOCKED_DETAIL_COUNT="$(detail_signals "${INSTANCE_BLOCKED}" | grep -c .)"
+expect_eq "list and detail agree that work is pending" \
+    "true" "$([ "$(list_flag "${INSTANCE_BLOCKED}")" = "true" ] && [ "${BLOCKED_DETAIL_COUNT}" -gt 0 ] && echo true || echo false)"
+
+# The actions endpoint short-circuits on the same flag, so a wrong flag makes
+# the still-open branches unanswerable, not merely invisible.
+expect_eq "open actions are offered for the blocked branches" \
+    "$(printf 'signal-2\nsignal-3\nsignal-4')" "$(action_signals "${INSTANCE_BLOCKED}")"
+
+print_step "Asserting a fully answered run reports nothing pending..."
+
+# Guards against an over-correction that just always reports true.
+expect_eq "answered run reports no pending input" "false" "$(list_flag "${INSTANCE_ANSWERED}")"
+expect_eq "answered run lists no open requests" "" "$(detail_signals "${INSTANCE_ANSWERED}")"
+expect_eq "answered run offers no actions" "" "$(action_signals "${INSTANCE_ANSWERED}")"
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+    print_success "All pending-input assertions passed"
+    exit 0
+fi
+print_error "${FAILURES} assertion(s) failed"
+tail -40 "${TEST_LOG}"
+exit 1


### PR DESCRIPTION
Fixes [SYN-603](https://linear.app/syncmyordershq/issue/SYN-603/pending-input-indicator-disappears-from-the-executions-list-while-a).

## The bug

The executions list derived `hasPendingInput` from a whole-instance timestamp heuristic: the newest `external_input_requested` against the newest `step_debug_end`, with "end is newer" taken to mean "answered".

That is wrong for two independent reasons — `step_debug_end` is emitted for *every* step type, not just ones that requested input, and branches genuinely overlap (Split carries a `parallelism` setting). So on a Split with `parallelism: 4` where each iteration waits on an approval, answering iteration 1 produced an end event newer than iterations 2-4's still-open requests, and the indicator vanished while three iterations stayed blocked.

**This is a gate, not just a badge.** `submit_workflow_action` and `list_workflow_instance_open_actions` both short-circuit on the same flag, so the still-open branches became *unanswerable* through the action API — not merely invisible.

## The fix

The correct per-site pairing already existed twice — in the `/pending-input` endpoint and in `list_instance_actions` — matching agent tool calls by the synthetic `{ai_step_id}.tool.{tool_name}.{call_number}` step id and standalone waits by per-invocation-site signal id (one child step can wait at several sites in one instance, so a completed wait at one site must not hide another's).

This extracts that logic into `api::services::pending_inputs` and routes all three callers through it, so the list and the detail views can no longer disagree about the same run. The two existing copies are deleted rather than left to drift.

A failed events lookup also no longer passes silently — it logs a warning instead of folding into "nothing pending". (Previously it was inconsistent too: an error on the first lookup hid the badge, an error on the second showed it.)

Considered and rejected: having the runtime expose the flag on the instance directly. Nothing in the runtime tracks open signals today — `InstanceInfo` has no such field and MCP `list_pending_signals` proxies back to the events-derived endpoint — so it means new cross-crate state. That belongs with the round-trip discussion in SYN-604, not with this bug.

Out of scope: SYN-604 (sequential round trips per running row). This keeps the same two calls per running instance.

## Verification

- 6 new unit tests over the pairing. Against the reinstated old heuristic, 4 fail — the ticket's repro returns `[]` where it should return `["signal-2", "signal-3", "signal-4"]`.
- New `e2e/test_pending_input_concurrent_branches.sh` drives the whole chain over HTTP (handler → engine → DTO enrichment → SDK → environment → SQL), registered in `run_all.sh`. Against unpatched code it reproduces the ticket's exact disagreement: list reports `hasPendingInput=false`, the detail endpoint lists 3 open requests, and the actions endpoint returns nothing. All assertions pass after the fix.
- `cargo test -p runtara-server --lib`: 992 passed, 0 failed. Clippy and `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)