### PR TITLE
SYN-604: Resolve pending input for running executions concurrently

### DIFF
--- a/crates/runtara-server/src/api/services/pending_inputs.rs
+++ b/crates/runtara-server/src/api/services/pending_inputs.rs
@@ -25,6 +25,9 @@ use crate::runtime_client::RuntimeClient;
 /// A failed request lookup is an error — the caller decides what an unknown
 /// state means. A failed *end* lookup degrades to "nothing has completed",
 /// which keeps open requests visible rather than hiding them.
+///
+/// Both lookups are needed on every call, so they are issued together instead
+/// of back to back; one instance costs one round trip rather than two.
 pub async fn fetch_input_and_end_events(
     client: &RuntimeClient,
     instance_id: &str,
@@ -35,22 +38,19 @@ pub async fn fetch_input_and_end_events(
         .with_subtype("external_input_requested")
         .with_sort_order(EventSortOrder::Asc);
 
-    let input_events = client
-        .list_events(instance_id, Some(input_options))
-        .await
-        .map_err(|error| error.to_string())?
-        .events;
-
     let end_options = ListEventsOptions::new()
         .with_limit(1000)
         .with_event_type("custom")
         .with_subtype("step_debug_end");
 
-    let end_events = client
-        .list_events(instance_id, Some(end_options))
-        .await
-        .map(|result| result.events)
-        .unwrap_or_default();
+    let (input_result, end_result) = tokio::join!(
+        client.list_events(instance_id, Some(input_options)),
+        client.list_events(instance_id, Some(end_options)),
+    );
+
+    let input_events = input_result.map_err(|error| error.to_string())?.events;
+
+    let end_events = end_result.map(|result| result.events).unwrap_or_default();
 
     Ok((input_events, end_events))
 }

--- a/crates/runtara-server/src/workers/runtara_dto.rs
+++ b/crates/runtara-server/src/workers/runtara_dto.rs
@@ -9,6 +9,7 @@
 //! service.
 
 use chrono::{DateTime, Utc};
+use futures::StreamExt;
 use runtara_management_sdk::{InstanceInfo, InstanceStatus as RuntaraInstanceStatus};
 use serde_json::Value;
 
@@ -104,24 +105,47 @@ fn duration_seconds(
 /// shared with the per-instance pending-input and action endpoints (see
 /// `api::services::pending_inputs`) so the list and the detail views cannot
 /// disagree about the same run.
+///
+/// Each lookup is a round trip to the environment service, so they run
+/// concurrently rather than one row at a time — a page holds up to 100
+/// instances and the executions views poll it on a 10s interval, which would
+/// otherwise make list latency scale with how busy the tenant is.
 pub async fn enrich_pending_input(instances: &mut [WorkflowInstanceDto], client: &RuntimeClient) {
+    // Bounded rather than unbounded: the executions views poll this endpoint
+    // per open tab and per tenant, so a full page fanning out at once would
+    // turn one slow list into a burst against the environment service.
+    const MAX_CONCURRENT_LOOKUPS: usize = 8;
+
+    // `iter_mut` hands each future a disjoint borrow of its own row, so results
+    // are written back in place and completion order does not matter. The
+    // futures are built in an explicit loop (concrete lifetimes, no closure
+    // HRTB) as elsewhere in this codebase, since a `map` closure yielding a
+    // future that borrows its argument mutably does not infer.
+    let mut lookups = Vec::new();
     for instance in instances.iter_mut() {
         if instance.status != ExecutionStatus::Running {
             continue;
         }
 
-        match has_open_inputs(client, &instance.id).await {
-            Ok(has_open) => instance.has_pending_input = has_open,
-            // The flag stays false, so the indicator is hidden rather than
-            // wrongly shown for every running row during a runtime hiccup —
-            // but the hiccup itself must not pass silently.
-            Err(error) => tracing::warn!(
-                instance_id = %instance.id,
-                error = %error,
-                "Failed to resolve pending input state; reporting none"
-            ),
-        }
+        lookups.push(async move {
+            match has_open_inputs(client, &instance.id).await {
+                Ok(has_open) => instance.has_pending_input = has_open,
+                // The flag stays false, so the indicator is hidden rather than
+                // wrongly shown for every running row during a runtime hiccup —
+                // but the hiccup itself must not pass silently.
+                Err(error) => tracing::warn!(
+                    instance_id = %instance.id,
+                    error = %error,
+                    "Failed to resolve pending input state; reporting none"
+                ),
+            }
+        });
     }
+
+    futures::stream::iter(lookups)
+        .buffer_unordered(MAX_CONCURRENT_LOOKUPS)
+        .for_each(|()| std::future::ready(()))
+        .await;
 }
 
 /// Convert Runtara `InstanceSummary` to `WorkflowInstanceDto` with workflow

--- a/crates/runtara-server/tests/pending_input_enrichment.rs
+++ b/crates/runtara-server/tests/pending_input_enrichment.rs
@@ -1,0 +1,219 @@
+//! Integration tests for `enrich_pending_input` — the executions-list pass that
+//! flags running rows still waiting on human input.
+//!
+//! These drive the real `RuntimeClient` -> SDK -> HTTP path against `wiremock`
+//! standing in for the environment service, so they cover the wiring rather
+//! than the pairing logic alone (that has its own unit tests next to it).
+//!
+//! Every response is served with a fixed delay, which makes the enrichment's
+//! request pattern observable: the elapsed time of the whole pass says whether
+//! the per-instance lookups were issued together or one after another.
+
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use runtara_server::api::dto::workflows::{InstanceInputs, WorkflowInstanceDto};
+use runtara_server::runtime_client::RuntimeClient;
+use runtara_server::types::ExecutionStatus;
+use runtara_server::workers::runtara_dto::enrich_pending_input;
+
+/// How long the stand-in environment service takes to answer one events query.
+const RESPONSE_DELAY: Duration = Duration::from_millis(200);
+
+/// Running rows in the fixture. Matches the enrichment's concurrency bound, so
+/// a correctly batched pass resolves all of them in a single wave.
+const RUNNING_ROWS: usize = 8;
+
+/// One event in the environment service's wire shape: the payload travels as
+/// base64-encoded JSON.
+fn event(id: i64, instance_id: &str, subtype: &str, payload: Value) -> Value {
+    json!({
+        "id": id,
+        "instance_id": instance_id,
+        "event_type": "custom",
+        "subtype": subtype,
+        "payload": STANDARD.encode(payload.to_string()),
+        "created_at_ms": 1_700_000_000_000i64,
+    })
+}
+
+fn events_body(events: Vec<Value>) -> Value {
+    let total_count = events.len() as u32;
+    json!({
+        "events": events,
+        "total_count": total_count,
+        "limit": 100,
+        "offset": 0,
+    })
+}
+
+fn instance(id: &str, status: ExecutionStatus) -> WorkflowInstanceDto {
+    WorkflowInstanceDto {
+        id: id.to_string(),
+        created: "2026-08-21T00:00:00Z".to_string(),
+        updated: "2026-08-21T00:00:00Z".to_string(),
+        status,
+        termination_type: None,
+        error: None,
+        workflow_id: "workflow-1".to_string(),
+        workflow_name: None,
+        inputs: InstanceInputs {
+            data: Value::Null,
+            variables: Value::Null,
+        },
+        outputs: None,
+        tags: vec![],
+        used_version: 1,
+        steps: vec![],
+        execution_duration_seconds: None,
+        max_memory_mb: None,
+        queue_duration_seconds: None,
+        processing_overhead_seconds: None,
+        has_pending_input: false,
+    }
+}
+
+/// Serve both event queries the enrichment makes for one instance.
+async fn mount_instance(
+    server: &MockServer,
+    instance_id: &str,
+    input_events: Vec<Value>,
+    end_events: Vec<Value>,
+) {
+    let events_path = format!("/api/v1/instances/{}/events", instance_id);
+
+    Mock::given(method("GET"))
+        .and(path(events_path.clone()))
+        .and(query_param("subtype", "external_input_requested"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(events_body(input_events))
+                .set_delay(RESPONSE_DELAY),
+        )
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(events_path))
+        .and(query_param("subtype", "step_debug_end"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(events_body(end_events))
+                .set_delay(RESPONSE_DELAY),
+        )
+        .mount(server)
+        .await;
+}
+
+/// A page of running executions is enriched concurrently, and each row still
+/// gets the flag its own events imply.
+///
+/// The pass previously walked the page one row at a time, awaiting both event
+/// queries per row in turn, so this fixture cost `RUNNING_ROWS * 2 *
+/// RESPONSE_DELAY` (~3.2s) of serialized round trips. Batched, it is one wave
+/// (~200ms). The one-second bound sits well clear of both.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn enriches_a_page_of_running_instances_concurrently() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "healthy": true,
+            "version": "test",
+            "uptime_ms": 0,
+        })))
+        .mount(&server)
+        .await;
+
+    let mut instances = Vec::new();
+
+    // One row whose request has already been answered: its `step_debug_end`
+    // carries the same signal id, so nothing is left open.
+    mount_instance(
+        &server,
+        "resolved",
+        vec![event(
+            1,
+            "resolved",
+            "external_input_requested",
+            json!({ "signal_id": "signal-resolved" }),
+        )],
+        vec![event(
+            2,
+            "resolved",
+            "step_debug_end",
+            json!({
+                "step_id": "step-1",
+                "outputs": { "signal_id": "signal-resolved" },
+            }),
+        )],
+    )
+    .await;
+    instances.push(instance("resolved", ExecutionStatus::Running));
+
+    // The rest are genuinely waiting: a request with no matching end event.
+    for index in 0..RUNNING_ROWS - 1 {
+        let id = format!("open-{}", index);
+        mount_instance(
+            &server,
+            &id,
+            vec![event(
+                10 + index as i64,
+                &id,
+                "external_input_requested",
+                json!({ "signal_id": format!("signal-{}", index) }),
+            )],
+            vec![],
+        )
+        .await;
+        instances.push(instance(&id, ExecutionStatus::Running));
+    }
+
+    // A finished row must not be looked up at all — wiremock asserts the
+    // expectation on drop.
+    Mock::given(method("GET"))
+        .and(path("/api/v1/instances/finished/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(events_body(vec![])))
+        .expect(0)
+        .mount(&server)
+        .await;
+    instances.push(instance("finished", ExecutionStatus::Completed));
+
+    let client = RuntimeClient::with_address(&server.address().to_string());
+    // Connect up front so the measured window covers only the event lookups,
+    // not a one-off health check racing across every future.
+    client.connect().await.expect("connect to mock environment");
+
+    let started = Instant::now();
+    enrich_pending_input(&mut instances, &client).await;
+    let elapsed = started.elapsed();
+
+    let by_id = |id: &str| {
+        instances
+            .iter()
+            .find(|instance| instance.id == id)
+            .unwrap_or_else(|| panic!("instance {} missing", id))
+            .has_pending_input
+    };
+
+    assert!(!by_id("resolved"), "answered request must not stay pending");
+    for index in 0..RUNNING_ROWS - 1 {
+        let id = format!("open-{}", index);
+        assert!(by_id(&id), "{} still has an unanswered request", id);
+    }
+    assert!(!by_id("finished"), "a finished run has nothing pending");
+
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "expected the page to resolve in roughly one round trip, took {:?} \
+         (serialized would be about {:?})",
+        elapsed,
+        RESPONSE_DELAY * (RUNNING_ROWS as u32) * 2,
+    );
+}

--- a/crates/runtara-server/tests/pending_input_fetch_overlap.rs
+++ b/crates/runtara-server/tests/pending_input_fetch_overlap.rs
@@ -1,0 +1,121 @@
+//! Integration test for the pair of event queries behind one instance's
+//! pending-input state.
+//!
+//! Resolving whether a run is still waiting needs both the
+//! `external_input_requested` stream and the `step_debug_end` stream that
+//! resolves it. Neither depends on the other, so they go out together — one
+//! instance costs one round trip, not two. The executions list multiplies this
+//! by the number of running rows on the page, so the saving is not marginal.
+//!
+//! This lives in its own test binary because pointing `RuntimeClient` at a mock
+//! sets a process-global environment variable; a second test in the same
+//! process would race with it.
+
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use runtara_server::api::services::pending_inputs::has_open_inputs;
+use runtara_server::runtime_client::RuntimeClient;
+
+/// Deliberately coarse: one delay and two must stay far apart under CI
+/// scheduling noise for the assertion below to mean anything.
+const RESPONSE_DELAY: Duration = Duration::from_millis(500);
+
+const INSTANCE_ID: &str = "instance-1";
+
+fn events_body(events: Vec<Value>) -> Value {
+    let total_count = events.len() as u32;
+    json!({
+        "events": events,
+        "total_count": total_count,
+        "limit": 100,
+        "offset": 0,
+    })
+}
+
+/// One event in the environment service's wire shape: the payload travels as
+/// base64-encoded JSON.
+fn event(id: i64, subtype: &str, payload: Value) -> Value {
+    json!({
+        "id": id,
+        "instance_id": INSTANCE_ID,
+        "event_type": "custom",
+        "subtype": subtype,
+        "payload": STANDARD.encode(payload.to_string()),
+        "created_at_ms": 1_700_000_000_000i64,
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn both_event_queries_for_one_instance_are_issued_together() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "healthy": true,
+            "version": "test",
+            "uptime_ms": 0,
+        })))
+        .mount(&server)
+        .await;
+
+    let events_path = format!("/api/v1/instances/{}/events", INSTANCE_ID);
+
+    // An unanswered request, so the lookup has to consult both streams before
+    // it can conclude anything.
+    Mock::given(method("GET"))
+        .and(path(events_path.clone()))
+        .and(query_param("subtype", "external_input_requested"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(events_body(vec![event(
+                    1,
+                    "external_input_requested",
+                    json!({ "signal_id": "signal-1" }),
+                )]))
+                .set_delay(RESPONSE_DELAY),
+        )
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(events_path))
+        .and(query_param("subtype", "step_debug_end"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(events_body(vec![]))
+                .set_delay(RESPONSE_DELAY),
+        )
+        .mount(&server)
+        .await;
+
+    let client = RuntimeClient::with_address(&server.address().to_string());
+    // Connect up front so the measured window covers only the two event
+    // queries, not the one-off health check.
+    client.connect().await.expect("connect to mock environment");
+
+    let started = Instant::now();
+    let has_open = has_open_inputs(&client, INSTANCE_ID)
+        .await
+        .expect("pending input lookup succeeds");
+    let elapsed = started.elapsed();
+
+    assert!(has_open, "the request was never answered, so it stays open");
+
+    // Halfway between one round trip and two: reachable only if the queries
+    // overlapped, and clear of both by a wide margin.
+    assert!(
+        elapsed < RESPONSE_DELAY * 3 / 2,
+        "expected both queries in about one round trip ({:?}), took {:?} \
+         (back to back would be about {:?})",
+        RESPONSE_DELAY,
+        elapsed,
+        RESPONSE_DELAY * 2,
+    );
+}


### PR DESCRIPTION
The executions list flags each running row with `has_pending_input` by reading that instance's events from the environment service. It walked the page one row at a time, and each row awaited its two event queries back to back, so a full page of 100 running rows cost ~200 serialized round trips. The workflow history views poll this every 10 seconds, so the cost was continuous and grew with how busy the tenant was.

Fan the per-instance lookups out with bounded concurrency, and issue an instance's two event queries together rather than in sequence. Behaviour is unchanged: same flag, same warn-on-error arm, same skip of non-running rows.

The bound is deliberate — the views poll per open tab and per tenant, so an unbounded fan-out would turn one slow list into a burst against the environment service.

Measured against a local stack with a full page of 100 running rows: 6.7s before, 0.4s after.