### PR TITLE
SYN-610: Map instance-protocol errors onto real HTTP status codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4728,6 +4728,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/runtara-core/Cargo.toml
+++ b/crates/runtara-core/Cargo.toml
@@ -64,6 +64,9 @@ async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
+# Drives the real axum router in the HTTP-layer tests (ServiceExt::oneshot),
+# so they cover routing and extraction rather than the handlers alone.
+tower = { version = "0.5", features = ["util"] }
 # Testcontainers for automatic PostgreSQL setup in tests
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }

--- a/crates/runtara-core/src/instance_handlers/registration.rs
+++ b/crates/runtara-core/src/instance_handlers/registration.rs
@@ -11,6 +11,7 @@ use super::types::{
     ERROR_MAX_CONCURRENT_INSTANCES, ERROR_SERVER_DRAINING, RegisterInstanceRequest,
     RegisterInstanceResponse,
 };
+use crate::error::CoreError;
 use crate::persistence::EventRecord;
 
 /// Handle instance registration request.
@@ -23,15 +24,16 @@ use crate::persistence::EventRecord;
 /// Two distinct channels, because the caller has to tell them apart:
 ///
 /// A `success: false` response means the caller cannot register right now and
-/// the fault is theirs or the cluster's — empty `instance_id`/`tenant_id`, a
-/// `checkpoint_id` that doesn't exist, the core draining, the concurrency cap.
-/// The HTTP layer renders these as 4xx (or the 503/429 the drain and cap
-/// sentinels ask for).
+/// the fault is theirs or the cluster's — empty `instance_id`/`tenant_id`, the
+/// core draining, the concurrency cap. The HTTP layer renders these as 4xx (or
+/// the 503/429 the drain and cap sentinels ask for).
 ///
-/// An `Err` means the write itself failed. That is the server's problem and is
-/// worth retrying, so it carries the underlying [`CoreError`] and the HTTP layer
-/// renders it as a 5xx. Reporting it as `success: false` would tell the caller
-/// its request was wrong and to stop.
+/// An `Err` carries a [`CoreError`] and lets the HTTP layer pick the status from
+/// it: `CheckpointNotFound` for a resume naming a checkpoint that isn't there
+/// (404, matching what the checkpoint route answers for the same fact), and the
+/// persistence errors for a read or write that failed (503, because that is the
+/// server's problem and is worth retrying). Reporting a failed write as
+/// `success: false` would instead tell the caller its request was wrong.
 #[instrument(skip(state, request), fields(
     instance_id = %request.instance_id,
     tenant_id = %request.tenant_id,
@@ -82,25 +84,26 @@ pub async fn handle_register_instance(
 
     // 4. If checkpoint_id provided, verify it exists
     if let Some(ref cp_id) = request.checkpoint_id {
-        let checkpoint = state
+        // A read that fails is the server's problem, propagated for the same
+        // reason as the writes below: reporting it as a refusal would tell a
+        // resuming caller its request was wrong and stop it retrying a blip.
+        // A checkpoint that is genuinely absent is the caller's problem, and
+        // carries the error the checkpoint route already uses for it so both
+        // routes answer the same status for the same fact.
+        match state
             .persistence
             .load_checkpoint(&request.instance_id, cp_id)
-            .await;
-        match checkpoint {
-            Ok(Some(_)) => {
+            .await?
+        {
+            Some(_) => {
                 debug!(checkpoint_id = %cp_id, "Checkpoint found for resume");
             }
-            Ok(None) => {
-                return Ok(RegisterInstanceResponse {
-                    success: false,
-                    error: format!("Checkpoint '{}' not found", cp_id),
-                });
-            }
-            Err(e) => {
-                return Ok(RegisterInstanceResponse {
-                    success: false,
-                    error: format!("Failed to verify checkpoint: {}", e),
-                });
+            None => {
+                return Err(CoreError::CheckpointNotFound {
+                    instance_id: request.instance_id.clone(),
+                    checkpoint_id: Some(cp_id.clone()),
+                }
+                .into());
             }
         }
     }
@@ -179,7 +182,6 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use super::*;
-    use crate::error::CoreError;
     use crate::instance_handlers::mock_persistence::{
         MockPersistence, make_checkpoint, make_instance,
     };
@@ -281,9 +283,15 @@ mod tests {
             checkpoint_id: Some("nonexistent".to_string()),
         };
 
-        let result = handle_register_instance(&state, request).await.unwrap();
-        assert!(!result.success);
-        assert!(result.error.contains("not found"));
+        let err = match handle_register_instance(&state, request).await {
+            Ok(_) => panic!("a missing checkpoint must not report success: false"),
+            Err(e) => e,
+        };
+        // Carries the same error the checkpoint route raises, so both answer 404.
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::CheckpointNotFound { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/runtara-core/src/instance_handlers/registration.rs
+++ b/crates/runtara-core/src/instance_handlers/registration.rs
@@ -20,9 +20,18 @@ use crate::persistence::EventRecord;
 ///
 /// # Errors
 ///
-/// Returns an error response if:
-/// - `instance_id` or `tenant_id` is empty
-/// - A specified `checkpoint_id` doesn't exist
+/// Two distinct channels, because the caller has to tell them apart:
+///
+/// A `success: false` response means the caller cannot register right now and
+/// the fault is theirs or the cluster's — empty `instance_id`/`tenant_id`, a
+/// `checkpoint_id` that doesn't exist, the core draining, the concurrency cap.
+/// The HTTP layer renders these as 4xx (or the 503/429 the drain and cap
+/// sentinels ask for).
+///
+/// An `Err` means the write itself failed. That is the server's problem and is
+/// worth retrying, so it carries the underlying [`CoreError`] and the HTTP layer
+/// renders it as a 5xx. Reporting it as `success: false` would tell the caller
+/// its request was wrong and to stop.
 #[instrument(skip(state, request), fields(
     instance_id = %request.instance_id,
     tenant_id = %request.tenant_id,
@@ -122,30 +131,24 @@ pub async fn handle_register_instance(
     if !instance_exists {
         // Self-registration: create instance record
         info!("Instance not found, creating self-registered instance");
-        if let Err(e) = state
+        // Propagate rather than reporting `success: false`. The response's error
+        // string is the caller's-fault channel — drain, cap, bad input — and the
+        // HTTP layer answers it with a 4xx. A persistence failure is the server's
+        // fault and must reach the caller as a 5xx it can retry, which only the
+        // `CoreError` carries.
+        state
             .persistence
             .register_instance(&request.instance_id, &request.tenant_id)
-            .await
-        {
-            return Ok(RegisterInstanceResponse {
-                success: false,
-                error: format!("Failed to create instance: {}", e),
-            });
-        }
+            .await?;
     }
 
     // 5. Update instance status to RUNNING
     let started_at = Utc::now();
-    if let Err(e) = state
+    // Propagated for the same reason as the registration write above.
+    state
         .persistence
         .update_instance_status(&request.instance_id, "running", Some(started_at))
-        .await
-    {
-        return Ok(RegisterInstanceResponse {
-            success: false,
-            error: format!("Failed to update instance status: {}", e),
-        });
-    }
+        .await?;
 
     // 6. Insert started event
     let event = EventRecord {
@@ -176,6 +179,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use super::*;
+    use crate::error::CoreError;
     use crate::instance_handlers::mock_persistence::{
         MockPersistence, make_checkpoint, make_instance,
     };
@@ -280,6 +284,54 @@ mod tests {
         let result = handle_register_instance(&state, request).await.unwrap();
         assert!(!result.success);
         assert!(result.error.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn a_failed_registration_write_is_an_error_not_a_refusal() {
+        // `success: false` means "the caller cannot register" — drain, cap, bad
+        // input — and the HTTP layer answers those with a 4xx. A write that
+        // failed is the server's problem, so it has to surface as an error the
+        // caller is told to retry, not as a refusal it is told to accept.
+        let persistence = MockPersistence::new();
+        persistence.set_fail_register();
+        let state = InstanceHandlerState::new(Arc::new(persistence));
+
+        let request = RegisterInstanceRequest {
+            instance_id: "inst-1".to_string(),
+            tenant_id: "tenant-1".to_string(),
+            checkpoint_id: None,
+        };
+
+        let err = match handle_register_instance(&state, request).await {
+            Ok(_) => panic!("a failed persistence write must not report success: false"),
+            Err(e) => e,
+        };
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::DatabaseError { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_failed_status_update_is_an_error_not_a_refusal() {
+        let persistence = MockPersistence::new();
+        persistence.set_fail_status_update();
+        let state = InstanceHandlerState::new(Arc::new(persistence));
+
+        let request = RegisterInstanceRequest {
+            instance_id: "inst-1".to_string(),
+            tenant_id: "tenant-1".to_string(),
+            checkpoint_id: None,
+        };
+
+        let err = match handle_register_instance(&state, request).await {
+            Ok(_) => panic!("a failed status update must not report success: false"),
+            Err(e) => e,
+        };
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::DatabaseError { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/runtara-core/src/server/http_server.rs
+++ b/crates/runtara-core/src/server/http_server.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{error, info, warn};
 
+use crate::error::CoreError;
 use crate::instance_handlers::{
     self, CheckpointRequest as HandlerCheckpointRequest,
     GetInstanceStatusRequest as HandlerGetStatusRequest, InstanceEvent as HandlerInstanceEvent,
@@ -185,6 +186,89 @@ fn event_type_from_string(s: &str) -> i32 {
 }
 
 // ============================================================================
+// Helper: map handler failures onto the wire
+// ============================================================================
+
+/// The HTTP status that describes a [`CoreError`].
+///
+/// 4xx says "stop, the request is wrong"; 5xx says "retry, I am unwell".
+/// Collapsing both onto 500 makes an ordinary drain race — a checkpoint landing
+/// on an instance that already finished — indistinguishable from the database
+/// being down.
+///
+/// The match is exhaustive on purpose: a new variant then fails to compile until
+/// someone decides what it means on the wire, rather than silently defaulting
+/// back to 500.
+fn status_for_core(err: &CoreError) -> StatusCode {
+    match err {
+        // The caller named something that is not there.
+        CoreError::InstanceNotFound { .. } | CoreError::CheckpointNotFound { .. } => {
+            StatusCode::NOT_FOUND
+        }
+        // The thing exists but is not in a state that accepts this request.
+        CoreError::InvalidInstanceState { .. } | CoreError::InstanceAlreadyExists { .. } => {
+            StatusCode::CONFLICT
+        }
+        // The request itself is malformed.
+        CoreError::ValidationError { .. } => StatusCode::BAD_REQUEST,
+        // The server could not do its job. Retrying may work.
+        CoreError::DatabaseError { .. }
+        | CoreError::CheckpointSaveFailed { .. }
+        | CoreError::SignalDeliveryFailed { .. } => StatusCode::SERVICE_UNAVAILABLE,
+    }
+}
+
+/// The status for a handler failure.
+///
+/// Handlers return `anyhow::Error`, so the classification is only available when
+/// a [`CoreError`] is underneath. When there is none, nothing has told us the
+/// failure is the caller's fault, and 500 is the honest answer.
+fn status_for(err: &anyhow::Error) -> StatusCode {
+    err.downcast_ref::<CoreError>()
+        .map(status_for_core)
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Render a handler failure: status from the error's own classification, body in
+/// the established `{error, code}` shape carrying the caller's route code.
+///
+/// Server-side failures log at `error`, caller mistakes at `warn` — a checkpoint
+/// racing a drain is routine and should stop reading like an outage.
+fn core_error_response(
+    route_code: &str,
+    context: &str,
+    err: impl Into<anyhow::Error>,
+) -> (StatusCode, Json<Value>) {
+    let err: anyhow::Error = err.into();
+    let status = status_for(&err);
+    if status.is_server_error() {
+        error!(
+            code = route_code,
+            status = status.as_u16(),
+            "{}: {}",
+            context,
+            err
+        );
+    } else {
+        warn!(
+            code = route_code,
+            status = status.as_u16(),
+            "{}: {}",
+            context,
+            err
+        );
+    }
+
+    (
+        status,
+        Json(json!({
+            "error": err.to_string(),
+            "code": route_code,
+        })),
+    )
+}
+
+// ============================================================================
 // HTTP handlers
 // ============================================================================
 
@@ -232,15 +316,7 @@ async fn register_handler(
             }
         }
         Err(e) => {
-            error!("Register handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "REGISTER_ERROR"
-                })),
-            )
-                .into_response()
+            core_error_response("REGISTER_ERROR", "Register handler error", e).into_response()
         }
     }
 }
@@ -312,15 +388,7 @@ async fn checkpoint_handler(
             .into_response()
         }
         Err(e) => {
-            error!("Checkpoint handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "CHECKPOINT_ERROR"
-                })),
-            )
-                .into_response()
+            core_error_response("CHECKPOINT_ERROR", "Checkpoint handler error", e).into_response()
         }
     }
 }
@@ -362,15 +430,7 @@ async fn poll_signals_handler(
             .into_response()
         }
         Err(e) => {
-            error!("Poll signals error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "POLL_SIGNALS_ERROR"
-                })),
-            )
-                .into_response()
+            core_error_response("POLL_SIGNALS_ERROR", "Poll signals error", e).into_response()
         }
     }
 }
@@ -402,17 +462,8 @@ async fn poll_custom_signal_handler(
             })
             .into_response()
         }
-        Err(e) => {
-            error!("Poll custom signal error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "POLL_CUSTOM_SIGNAL_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("POLL_CUSTOM_SIGNAL_ERROR", "Poll custom signal error", e)
+            .into_response(),
     }
 }
 
@@ -456,6 +507,8 @@ async fn instance_event_handler(
             if resp.success {
                 Json(SuccessResponse { success: true }).into_response()
             } else {
+                // No `CoreError` underneath to classify — this arm carries only a
+                // string, so 500 is the honest answer rather than a guess.
                 let error = resp.error.unwrap_or_else(|| "Unknown error".to_string());
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -467,17 +520,7 @@ async fn instance_event_handler(
                     .into_response()
             }
         }
-        Err(e) => {
-            error!("Instance event error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "EVENT_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("EVENT_ERROR", "Instance event error", e).into_response(),
     }
 }
 
@@ -519,15 +562,7 @@ async fn completed_handler(
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
         Err(e) => {
-            error!("Completed handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "COMPLETED_ERROR"
-                })),
-            )
-                .into_response()
+            core_error_response("COMPLETED_ERROR", "Completed handler error", e).into_response()
         }
     }
 }
@@ -554,17 +589,7 @@ async fn failed_handler(
 
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            error!("Failed handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "FAILED_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("FAILED_ERROR", "Failed handler error", e).into_response(),
     }
 }
 
@@ -585,15 +610,7 @@ async fn suspended_handler(
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
         Err(e) => {
-            error!("Suspended handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "SUSPENDED_ERROR"
-                })),
-            )
-                .into_response()
+            core_error_response("SUSPENDED_ERROR", "Suspended handler error", e).into_response()
         }
     }
 }
@@ -627,17 +644,7 @@ async fn sleep_handler(
 
     match instance_handlers::handle_sleep(&state, request).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            error!("Sleep handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "SLEEP_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("SLEEP_ERROR", "Sleep handler error", e).into_response(),
     }
 }
 
@@ -672,17 +679,7 @@ async fn signal_ack_handler(
 
     match instance_handlers::handle_signal_ack(&state, ack).await {
         Ok(()) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            warn!("Signal ack error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "SIGNAL_ACK_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("SIGNAL_ACK_ERROR", "Signal ack error", e).into_response(),
     }
 }
 
@@ -703,17 +700,7 @@ async fn retry_handler(
 
     match instance_handlers::handle_retry_attempt(&state, event).await {
         Ok(()) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            warn!("Retry attempt error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "RETRY_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("RETRY_ERROR", "Retry attempt error", e).into_response(),
     }
 }
 
@@ -771,17 +758,7 @@ async fn status_handler(
             })
             .into_response()
         }
-        Err(e) => {
-            error!("Status handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "STATUS_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("STATUS_ERROR", "Status handler error", e).into_response(),
     }
 }
 
@@ -818,17 +795,7 @@ async fn input_handler(
             })),
         )
             .into_response(),
-        Err(e) => {
-            error!("Input handler error: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": e.to_string(),
-                    "code": "INPUT_ERROR"
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => core_error_response("INPUT_ERROR", "Input handler error", e).into_response(),
     }
 }
 
@@ -956,4 +923,244 @@ pub async fn run_http_server_with_shutdown(
 
     info!("Instance HTTP server stopped");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance_handlers::mock_persistence::{MockPersistence, make_instance};
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn router_over(persistence: MockPersistence) -> Router {
+        instance_http_router(Arc::new(InstanceHandlerState::new(Arc::new(persistence))))
+    }
+
+    /// Drive a request through the real router and return `(status, body)`.
+    ///
+    /// Going through `oneshot` rather than calling the handler directly is the
+    /// point: it exercises the routing and extraction the handlers are wired
+    /// into, so a mapping that is correct in isolation but mis-wired still fails.
+    async fn send(router: Router, request: Request<Body>) -> (StatusCode, Value) {
+        let response = router.oneshot(request).await.expect("router call failed");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("failed to read body");
+        let body = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).expect("body was not JSON")
+        };
+        (status, body)
+    }
+
+    fn post(path: &str, body: Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("Content-Type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn get(path: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(path)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn checkpoint_body() -> Value {
+        json!({ "checkpoint_id": "cp-1", "state": "aGk=" })
+    }
+
+    #[test]
+    fn status_for_core_classifies_every_core_error() {
+        // Exhaustive by construction: `CoreError` has eight variants and all
+        // eight are listed here, so a new one cannot slip through untested.
+        let cases: Vec<(CoreError, StatusCode)> = vec![
+            (
+                CoreError::InstanceNotFound {
+                    instance_id: "i".into(),
+                },
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                CoreError::CheckpointNotFound {
+                    instance_id: "i".into(),
+                    checkpoint_id: Some("cp".into()),
+                },
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                CoreError::InvalidInstanceState {
+                    instance_id: "i".into(),
+                    expected: "running".into(),
+                    actual: "completed".into(),
+                },
+                StatusCode::CONFLICT,
+            ),
+            (
+                CoreError::InstanceAlreadyExists {
+                    instance_id: "i".into(),
+                },
+                StatusCode::CONFLICT,
+            ),
+            (
+                CoreError::ValidationError {
+                    field: "instance_id".into(),
+                    message: "required".into(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                CoreError::DatabaseError {
+                    operation: "insert".into(),
+                    details: "connection refused".into(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (
+                CoreError::CheckpointSaveFailed {
+                    instance_id: "i".into(),
+                    reason: "disk full".into(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (
+                CoreError::SignalDeliveryFailed {
+                    instance_id: "i".into(),
+                    signal_type: "cancel".into(),
+                    reason: "timeout".into(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(
+                status_for_core(&error),
+                expected,
+                "{:?} should map to {}",
+                error,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn an_error_with_no_core_error_underneath_stays_internal() {
+        // Handlers return `anyhow::Error`, so a failure can arrive with nothing
+        // that classifies it. That case must keep answering 500 rather than
+        // being guessed into a 4xx the caller would wrongly treat as final.
+        let opaque = anyhow::anyhow!("something went wrong");
+        assert_eq!(status_for(&opaque), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // ...and a `CoreError` still classifies once wrapped by anyhow, which is
+        // how every handler error actually reaches the HTTP layer.
+        let wrapped = anyhow::Error::from(CoreError::InstanceNotFound {
+            instance_id: "i".into(),
+        });
+        assert_eq!(status_for(&wrapped), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn core_error_response_keeps_the_route_code_in_the_body() {
+        // The status is what this ticket changes; the body shape is a contract
+        // existing clients already read, so it must not move with it.
+        let (status, body) = core_error_response(
+            "CHECKPOINT_ERROR",
+            "Checkpoint handler error",
+            CoreError::InstanceNotFound {
+                instance_id: "inst-1".into(),
+            },
+        );
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body.0["code"], "CHECKPOINT_ERROR");
+        assert!(body.0["error"].as_str().unwrap().contains("inst-1"));
+    }
+
+    #[tokio::test]
+    async fn checkpoint_on_an_unknown_instance_is_not_found() {
+        let (status, body) = send(
+            router_over(MockPersistence::new()),
+            post("/api/v1/instances/nope/checkpoint", checkpoint_body()),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["code"], "CHECKPOINT_ERROR");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_on_a_terminal_instance_is_a_conflict() {
+        // The drain race this ticket exists for: the instance finished between
+        // the client's last step and this checkpoint. The client is wrong, not
+        // the server, and retrying will never help.
+        let persistence =
+            MockPersistence::new().with_instance(make_instance("done", "t1", "completed"));
+
+        let (status, body) = send(
+            router_over(persistence),
+            post("/api/v1/instances/done/checkpoint", checkpoint_body()),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["code"], "CHECKPOINT_ERROR");
+    }
+
+    #[tokio::test]
+    async fn a_database_failure_is_service_unavailable() {
+        // The other half of the distinction: same route, but the server really
+        // is unwell, so the client should back off rather than give up.
+        let persistence = MockPersistence::new();
+        persistence.set_fail_register();
+
+        let (status, body) = send(
+            router_over(persistence),
+            post(
+                "/api/v1/instances/inst-1/register",
+                json!({ "tenant_id": "t1" }),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "REGISTER_ERROR");
+    }
+
+    #[tokio::test]
+    async fn input_of_an_unknown_instance_stays_not_found() {
+        // Already 404 before this change — pinned so the rewrite cannot regress it.
+        let (status, body) = send(
+            router_over(MockPersistence::new()),
+            get("/api/v1/instances/nope/input"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["found"], false);
+    }
+
+    #[tokio::test]
+    async fn a_checkpoint_that_succeeds_is_untouched() {
+        // The rewrite touched every error arm; this proves it left the happy
+        // path — and its response body — alone.
+        let persistence =
+            MockPersistence::new().with_instance(make_instance("live", "t1", "running"));
+
+        let (status, body) = send(
+            router_over(persistence),
+            post("/api/v1/instances/live/checkpoint", checkpoint_body()),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["found"], false);
+    }
 }

--- a/crates/runtara-core/src/server/http_server.rs
+++ b/crates/runtara-core/src/server/http_server.rs
@@ -15,7 +15,7 @@ use axum::{
     Router,
     extract::{Path, State},
     http::StatusCode,
-    response::{IntoResponse, Json},
+    response::{IntoResponse, Json, Response},
     routing::{get, post},
 };
 use base64::Engine;
@@ -229,16 +229,19 @@ fn status_for(err: &anyhow::Error) -> StatusCode {
         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
 }
 
+/// How long a client should wait before retrying, in seconds. Shared with the
+/// drain and concurrency-cap refusals so every "come back later" this server
+/// sends asks for the same delay.
+const RETRY_AFTER_SECONDS: &str = "30";
+
 /// Render a handler failure: status from the error's own classification, body in
 /// the established `{error, code}` shape carrying the caller's route code.
 ///
 /// Server-side failures log at `error`, caller mistakes at `warn` — a checkpoint
-/// racing a drain is routine and should stop reading like an outage.
-fn core_error_response(
-    route_code: &str,
-    context: &str,
-    err: impl Into<anyhow::Error>,
-) -> (StatusCode, Json<Value>) {
+/// racing a drain is routine and should stop reading like an outage. A 503 also
+/// carries `Retry-After`, since telling a client to retry without saying when
+/// invites it to hammer a server that is already struggling.
+fn core_error_response(route_code: &str, context: &str, err: impl Into<anyhow::Error>) -> Response {
     let err: anyhow::Error = err.into();
     let status = status_for(&err);
     if status.is_server_error() {
@@ -259,13 +262,16 @@ fn core_error_response(
         );
     }
 
-    (
-        status,
-        Json(json!({
-            "error": err.to_string(),
-            "code": route_code,
-        })),
-    )
+    let body = Json(json!({
+        "error": err.to_string(),
+        "code": route_code,
+    }));
+
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        (status, [("Retry-After", RETRY_AFTER_SECONDS)], body).into_response()
+    } else {
+        (status, body).into_response()
+    }
 }
 
 // ============================================================================
@@ -309,15 +315,13 @@ async fn register_handler(
                 if status == StatusCode::SERVICE_UNAVAILABLE
                     || status == StatusCode::TOO_MANY_REQUESTS
                 {
-                    (status, [("Retry-After", "30")], body).into_response()
+                    (status, [("Retry-After", RETRY_AFTER_SECONDS)], body).into_response()
                 } else {
                     (status, body).into_response()
                 }
             }
         }
-        Err(e) => {
-            core_error_response("REGISTER_ERROR", "Register handler error", e).into_response()
-        }
+        Err(e) => core_error_response("REGISTER_ERROR", "Register handler error", e),
     }
 }
 
@@ -387,9 +391,7 @@ async fn checkpoint_handler(
             })
             .into_response()
         }
-        Err(e) => {
-            core_error_response("CHECKPOINT_ERROR", "Checkpoint handler error", e).into_response()
-        }
+        Err(e) => core_error_response("CHECKPOINT_ERROR", "Checkpoint handler error", e),
     }
 }
 
@@ -429,9 +431,7 @@ async fn poll_signals_handler(
             })
             .into_response()
         }
-        Err(e) => {
-            core_error_response("POLL_SIGNALS_ERROR", "Poll signals error", e).into_response()
-        }
+        Err(e) => core_error_response("POLL_SIGNALS_ERROR", "Poll signals error", e),
     }
 }
 
@@ -462,8 +462,7 @@ async fn poll_custom_signal_handler(
             })
             .into_response()
         }
-        Err(e) => core_error_response("POLL_CUSTOM_SIGNAL_ERROR", "Poll custom signal error", e)
-            .into_response(),
+        Err(e) => core_error_response("POLL_CUSTOM_SIGNAL_ERROR", "Poll custom signal error", e),
     }
 }
 
@@ -520,7 +519,7 @@ async fn instance_event_handler(
                     .into_response()
             }
         }
-        Err(e) => core_error_response("EVENT_ERROR", "Instance event error", e).into_response(),
+        Err(e) => core_error_response("EVENT_ERROR", "Instance event error", e),
     }
 }
 
@@ -561,9 +560,7 @@ async fn completed_handler(
 
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            core_error_response("COMPLETED_ERROR", "Completed handler error", e).into_response()
-        }
+        Err(e) => core_error_response("COMPLETED_ERROR", "Completed handler error", e),
     }
 }
 
@@ -589,7 +586,7 @@ async fn failed_handler(
 
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => core_error_response("FAILED_ERROR", "Failed handler error", e).into_response(),
+        Err(e) => core_error_response("FAILED_ERROR", "Failed handler error", e),
     }
 }
 
@@ -609,9 +606,7 @@ async fn suspended_handler(
 
     match instance_handlers::handle_instance_event(&state, event).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => {
-            core_error_response("SUSPENDED_ERROR", "Suspended handler error", e).into_response()
-        }
+        Err(e) => core_error_response("SUSPENDED_ERROR", "Suspended handler error", e),
     }
 }
 
@@ -644,7 +639,7 @@ async fn sleep_handler(
 
     match instance_handlers::handle_sleep(&state, request).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => core_error_response("SLEEP_ERROR", "Sleep handler error", e).into_response(),
+        Err(e) => core_error_response("SLEEP_ERROR", "Sleep handler error", e),
     }
 }
 
@@ -679,7 +674,7 @@ async fn signal_ack_handler(
 
     match instance_handlers::handle_signal_ack(&state, ack).await {
         Ok(()) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => core_error_response("SIGNAL_ACK_ERROR", "Signal ack error", e).into_response(),
+        Err(e) => core_error_response("SIGNAL_ACK_ERROR", "Signal ack error", e),
     }
 }
 
@@ -700,7 +695,7 @@ async fn retry_handler(
 
     match instance_handlers::handle_retry_attempt(&state, event).await {
         Ok(()) => Json(SuccessResponse { success: true }).into_response(),
-        Err(e) => core_error_response("RETRY_ERROR", "Retry attempt error", e).into_response(),
+        Err(e) => core_error_response("RETRY_ERROR", "Retry attempt error", e),
     }
 }
 
@@ -758,7 +753,7 @@ async fn status_handler(
             })
             .into_response()
         }
-        Err(e) => core_error_response("STATUS_ERROR", "Status handler error", e).into_response(),
+        Err(e) => core_error_response("STATUS_ERROR", "Status handler error", e),
     }
 }
 
@@ -795,7 +790,7 @@ async fn input_handler(
             })),
         )
             .into_response(),
-        Err(e) => core_error_response("INPUT_ERROR", "Input handler error", e).into_response(),
+        Err(e) => core_error_response("INPUT_ERROR", "Input handler error", e),
     }
 }
 
@@ -944,7 +939,17 @@ mod tests {
     /// into, so a mapping that is correct in isolation but mis-wired still fails.
     async fn send(router: Router, request: Request<Body>) -> (StatusCode, Value) {
         let response = router.oneshot(request).await.expect("router call failed");
+        let (status, body, _) = read(response).await;
+        (status, body)
+    }
+
+    /// Unpack a response into `(status, body, retry_after)`.
+    async fn read(response: Response) -> (StatusCode, Value, Option<String>) {
         let status = response.status();
+        let retry_after = response
+            .headers()
+            .get("Retry-After")
+            .map(|v| v.to_str().expect("Retry-After was not text").to_string());
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("failed to read body");
@@ -953,7 +958,7 @@ mod tests {
         } else {
             serde_json::from_slice(&bytes).expect("body was not JSON")
         };
-        (status, body)
+        (status, body, retry_after)
     }
 
     fn post(path: &str, body: Value) -> Request<Body> {
@@ -1067,21 +1072,42 @@ mod tests {
         assert_eq!(status_for(&wrapped), StatusCode::NOT_FOUND);
     }
 
-    #[test]
-    fn core_error_response_keeps_the_route_code_in_the_body() {
+    #[tokio::test]
+    async fn core_error_response_keeps_the_route_code_in_the_body() {
         // The status is what this ticket changes; the body shape is a contract
         // existing clients already read, so it must not move with it.
-        let (status, body) = core_error_response(
+        let (status, body, retry_after) = read(core_error_response(
             "CHECKPOINT_ERROR",
             "Checkpoint handler error",
             CoreError::InstanceNotFound {
                 instance_id: "inst-1".into(),
             },
-        );
+        ))
+        .await;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(body.0["code"], "CHECKPOINT_ERROR");
-        assert!(body.0["error"].as_str().unwrap().contains("inst-1"));
+        assert_eq!(body["code"], "CHECKPOINT_ERROR");
+        assert!(body["error"].as_str().unwrap().contains("inst-1"));
+        // Retry-After belongs to "come back later", not to "you were wrong".
+        assert_eq!(retry_after, None);
+    }
+
+    #[tokio::test]
+    async fn a_503_says_when_to_come_back() {
+        // The drain and cap refusals already send this. A 503 without it invites
+        // a client to hammer a server that is already struggling.
+        let (status, _, retry_after) = read(core_error_response(
+            "REGISTER_ERROR",
+            "Register handler error",
+            CoreError::DatabaseError {
+                operation: "register_instance".into(),
+                details: "connection refused".into(),
+            },
+        ))
+        .await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(retry_after.as_deref(), Some(RETRY_AFTER_SECONDS));
     }
 
     #[tokio::test]
@@ -1121,16 +1147,37 @@ mod tests {
         let persistence = MockPersistence::new();
         persistence.set_fail_register();
 
+        let response = router_over(persistence)
+            .oneshot(post(
+                "/api/v1/instances/inst-1/register",
+                json!({ "tenant_id": "t1" }),
+            ))
+            .await
+            .expect("router call failed");
+        let (status, body, retry_after) = read(response).await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "REGISTER_ERROR");
+        assert_eq!(retry_after.as_deref(), Some(RETRY_AFTER_SECONDS));
+    }
+
+    #[tokio::test]
+    async fn resuming_from_a_missing_checkpoint_is_not_found() {
+        // The same fact as a missing checkpoint on the checkpoint route, so it
+        // has to get the same status — registration used to answer 400 here.
+        let persistence =
+            MockPersistence::new().with_instance(make_instance("inst-1", "t1", "pending"));
+
         let (status, body) = send(
             router_over(persistence),
             post(
                 "/api/v1/instances/inst-1/register",
-                json!({ "tenant_id": "t1" }),
+                json!({ "tenant_id": "t1", "checkpoint_id": "nope" }),
             ),
         )
         .await;
 
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body["code"], "REGISTER_ERROR");
     }
 

--- a/e2e/run_all.sh
+++ b/e2e/run_all.sh
@@ -87,6 +87,10 @@ run_test "Connection named endpoints (QuickBooks Online)" "${SCRIPT_DIR}/test_co
 # ./start.sh.
 run_test "runtara-core SIGTERM drain + concurrency cap (regression)" "${SCRIPT_DIR}/test_core_sigterm_drain.sh"
 
+# Instance-protocol status codes. Self-contained on the same terms as the
+# SIGTERM test above — its own core binary, SQLite file and free port.
+run_test "runtara-core instance protocol HTTP status codes (regression)" "${SCRIPT_DIR}/test_core_http_status_codes.sh"
+
 # Summary
 echo "=========================================="
 echo "Test Results"

--- a/e2e/test_core_http_status_codes.sh
+++ b/e2e/test_core_http_status_codes.sh
@@ -178,7 +178,18 @@ status="$(call -X POST "${API}/inst-live/checkpoint" -H 'Content-Type: applicati
 expect "checkpoint on running instance" 200 "" "${status}"
 
 # ---------------------------------------------------------------------------
-# 5. The logging half: a caller's mistake is a WARN, not an ERROR. Without this
+# 5. Registering a resume against a checkpoint that does not exist. The same
+#    fact as a missing checkpoint anywhere else, so it must get the same 404 —
+#    /register used to answer 400 for it, because it reports refusals through
+#    its own response shape rather than through the error type.
+# ---------------------------------------------------------------------------
+print_step "Resuming from a checkpoint that does not exist"
+status="$(call -X POST "${API}/inst-live/register" -H 'Content-Type: application/json' \
+    -d '{"tenant_id":"e2e-status","checkpoint_id":"no-such-checkpoint"}')"
+expect "register resuming from a missing checkpoint" 404 REGISTER_ERROR "${status}"
+
+# ---------------------------------------------------------------------------
+# 6. The logging half: a caller's mistake is a WARN, not an ERROR. Without this
 #    the status codes could be right while the logs still read like an outage.
 # ---------------------------------------------------------------------------
 print_step "Caller errors are logged at WARN, not ERROR"
@@ -189,5 +200,17 @@ if grep -q "ERROR.*Checkpoint handler error" "${LOG_FILE}"; then
     fail "a 4xx checkpoint failure was logged at ERROR — that is the noise this change removes"
 fi
 echo "  $(grep -c "WARN.*Checkpoint handler error" "${LOG_FILE}") WARN, 0 ERROR for checkpoint failures"
+
+# ---------------------------------------------------------------------------
+# 7. The drain refusal keeps its Retry-After. The header is shared with the new
+#    5xx answers, so a regression in one would show up here.
+# ---------------------------------------------------------------------------
+print_step "A refusal still tells the client when to come back"
+HEADERS="$(curl -sS -D - -o /dev/null -X POST "${API}/ghost-2/checkpoint" \
+    -H 'Content-Type: application/json' -d "${CHECKPOINT}")"
+if grep -qi "^retry-after:" <<<"${HEADERS}"; then
+    fail "a 404 carried Retry-After — that header belongs to \"come back later\", not \"you were wrong\""
+fi
+echo "  404 carries no Retry-After, as intended"
 
 print_success "Instance protocol status codes and log levels are correct"

--- a/e2e/test_core_http_status_codes.sh
+++ b/e2e/test_core_http_status_codes.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# E2E Test: the instance protocol must answer with the status code that
+# describes what actually went wrong.
+#
+# `CoreError` already classifies its failures, but the HTTP layer used to throw
+# that away and answer 500 for all of it. The cost is diagnosability: a
+# checkpoint landing on an instance that already finished — an ordinary race
+# during drain, the caller's problem, never fixable by retrying — looked
+# identical to the database being down.
+#
+# Asserts, against a real process over real HTTP:
+#   * a checkpoint against an unknown instance is 404, not 500,
+#   * a checkpoint against a terminal instance is 409, not 500,
+#   * an unknown instance's input is 404 (already true — pinned so the
+#     error-arm rewrite cannot regress it),
+#   * the per-route `code` in the body is unchanged, since clients read it,
+#   * and those 4xx answers are logged at WARN, not ERROR. That is the other
+#     half of the fix: a drain race should stop paging whoever reads the logs.
+#
+# Self-contained: needs cargo, curl and SQLite only. No docker, no Postgres, no
+# ./start.sh.
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+print_step()    { echo -e "${GREEN}[STEP]${NC} $1"; }
+print_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+WORK_DIR="$(mktemp -d)"
+LOG_FILE="${WORK_DIR}/core.log"
+CORE_PID=""
+
+cleanup() {
+    if [ -n "${CORE_PID}" ] && kill -0 "${CORE_PID}" 2>/dev/null; then
+        kill -KILL "${CORE_PID}" 2>/dev/null
+        wait "${CORE_PID}" 2>/dev/null
+    fi
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+fail() {
+    print_error "$1"
+    echo "----- core log -----"
+    cat "${LOG_FILE}" 2>/dev/null
+    echo "--------------------"
+    exit 1
+}
+
+# Pick a free port by binding and releasing it.
+pick_port() {
+    python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+print_step "Building runtara-core"
+
+# Build from the repo root, not the caller's cwd: rustup resolves
+# rust-toolchain.toml from the working directory, so invoking this from
+# elsewhere builds with whatever toolchain happens to be default.
+if ! (cd "${PROJECT_ROOT}" && cargo build -p runtara-core --bin runtara-core) >/dev/null 2>&1; then
+    (cd "${PROJECT_ROOT}" && cargo build -p runtara-core --bin runtara-core)
+    fail "cargo build failed"
+fi
+
+# Ask cargo where the binary landed rather than assuming ./target — a shared CI
+# cache sets CARGO_TARGET_DIR.
+TARGET_DIR="$(cd "${PROJECT_ROOT}" && cargo metadata --format-version 1 --no-deps |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+[ -n "${TARGET_DIR}" ] || fail "could not resolve cargo target directory"
+CORE_BIN="${TARGET_DIR}/debug/runtara-core"
+[ -x "${CORE_BIN}" ] || fail "runtara-core binary not found at ${CORE_BIN}"
+
+PORT="$(pick_port)"
+print_step "Starting runtara-core on 127.0.0.1:${PORT} (SQLite)"
+
+# `dotenvy` walks up to the repo root, so run from the temp dir to keep a
+# developer's own .env out of this test's configuration.
+(
+    cd "${WORK_DIR}" || exit 1
+    RUNTARA_DATABASE_URL="sqlite://${WORK_DIR}/core.db?mode=rwc" \
+    RUNTARA_HTTP_PORT="${PORT}" \
+    RUST_LOG="runtara_core=info" \
+    exec "${CORE_BIN}"
+) >"${LOG_FILE}" 2>&1 &
+CORE_PID=$!
+
+print_step "Waiting for /health"
+READY=0
+for _ in $(seq 1 100); do
+    if ! kill -0 "${CORE_PID}" 2>/dev/null; then
+        fail "runtara-core exited during startup"
+    fi
+    if curl -sf -o /dev/null "http://127.0.0.1:${PORT}/health"; then
+        READY=1
+        break
+    fi
+    sleep 0.2
+done
+[ "${READY}" = "1" ] || fail "runtara-core never became healthy on port ${PORT}"
+print_success "runtara-core is up (pid ${CORE_PID})"
+
+API="http://127.0.0.1:${PORT}/api/v1/instances"
+BODY_FILE="${WORK_DIR}/response.json"
+
+# Issue a request, leaving the response body in BODY_FILE and echoing the status.
+call() {
+    curl -sS -o "${BODY_FILE}" -w '%{http_code}' "$@"
+}
+
+# Assert status, and (when a third argument is given) the body's `code` field.
+expect() {
+    local label="$1" want_status="$2" want_code="${3:-}"
+    local got_status="$4"
+    local body; body="$(cat "${BODY_FILE}")"
+
+    echo "  ${label} -> ${got_status} ${body}"
+    [ "${got_status}" = "${want_status}" ] || \
+        fail "${label}: got ${got_status}, expected ${want_status} (body: ${body})"
+
+    if [ -n "${want_code}" ]; then
+        local got_code; got_code="$(python3 -c \
+            'import json,sys; print(json.load(sys.stdin).get("code",""))' <"${BODY_FILE}")"
+        [ "${got_code}" = "${want_code}" ] || \
+            fail "${label}: body code was '${got_code}', expected '${want_code}' — clients read this field"
+    fi
+}
+
+CHECKPOINT='{"checkpoint_id":"cp-1","state":"aGk="}'
+
+# ---------------------------------------------------------------------------
+# 1. A checkpoint against an instance that was never registered.
+#    The caller named something that does not exist: 404, not 500.
+# ---------------------------------------------------------------------------
+print_step "Checkpoint against an unknown instance"
+status="$(call -X POST "${API}/ghost/checkpoint" -H 'Content-Type: application/json' -d "${CHECKPOINT}")"
+expect "checkpoint on unknown instance" 404 CHECKPOINT_ERROR "${status}"
+
+# ---------------------------------------------------------------------------
+# 2. A checkpoint against an instance that already finished — the drain race
+#    this test exists for. The instance is real but is past accepting work:
+#    409, and emphatically not a 5xx the client would retry forever.
+# ---------------------------------------------------------------------------
+print_step "Checkpoint against a completed instance"
+call -X POST "${API}/inst-done/register" -H 'Content-Type: application/json' \
+    -d '{"tenant_id":"e2e-status"}' >/dev/null
+status="$(call -X POST "${API}/inst-done/completed" -H 'Content-Type: application/json' -d '{"output":"b2s="}')"
+expect "completing inst-done" 200 "" "${status}"
+
+status="$(call -X POST "${API}/inst-done/checkpoint" -H 'Content-Type: application/json' -d "${CHECKPOINT}")"
+expect "checkpoint on completed instance" 409 CHECKPOINT_ERROR "${status}"
+
+# ---------------------------------------------------------------------------
+# 3. An unknown instance's input. Already 404 before the error-arm rewrite;
+#    asserted here so it stays that way.
+# ---------------------------------------------------------------------------
+print_step "Input of an unknown instance"
+status="$(call "${API}/ghost/input")"
+expect "input of unknown instance" 404 "" "${status}"
+
+# ---------------------------------------------------------------------------
+# 4. The happy path is undisturbed by the rewrite.
+# ---------------------------------------------------------------------------
+print_step "A checkpoint on a running instance still succeeds"
+call -X POST "${API}/inst-live/register" -H 'Content-Type: application/json' \
+    -d '{"tenant_id":"e2e-status"}' >/dev/null
+status="$(call -X POST "${API}/inst-live/checkpoint" -H 'Content-Type: application/json' -d "${CHECKPOINT}")"
+expect "checkpoint on running instance" 200 "" "${status}"
+
+# ---------------------------------------------------------------------------
+# 5. The logging half: a caller's mistake is a WARN, not an ERROR. Without this
+#    the status codes could be right while the logs still read like an outage.
+# ---------------------------------------------------------------------------
+print_step "Caller errors are logged at WARN, not ERROR"
+if ! grep -q "WARN.*Checkpoint handler error" "${LOG_FILE}"; then
+    fail "expected a WARN for the 4xx checkpoint failures; none found"
+fi
+if grep -q "ERROR.*Checkpoint handler error" "${LOG_FILE}"; then
+    fail "a 4xx checkpoint failure was logged at ERROR — that is the noise this change removes"
+fi
+echo "  $(grep -c "WARN.*Checkpoint handler error" "${LOG_FILE}") WARN, 0 ERROR for checkpoint failures"
+
+print_success "Instance protocol status codes and log levels are correct"


### PR DESCRIPTION
## What changed

`CoreError::error_code()` already classifies runtara-core's failures, but the HTTP layer
discarded all of it — all 13 handler error arms in
`crates/runtara-core/src/server/http_server.rs` answered `500`. A checkpoint landing on an
already-terminal instance (an ordinary race during drain, entirely the caller's problem and
never fixable by retrying) was indistinguishable from the database being down.

Two new private helpers map a failure onto the wire:

| `CoreError` | status |
| -- | -- |
| `InstanceNotFound`, `CheckpointNotFound` | 404 |
| `InvalidInstanceState`, `InstanceAlreadyExists` | 409 |
| `ValidationError` | 400 |
| `DatabaseError`, `CheckpointSaveFailed`, `SignalDeliveryFailed` | 503 |
| no `CoreError` underneath | 500 |

5xx logs at `error`, 4xx at `warn`, both with structured `code` and `status` fields — a drain
race should stop reading like an outage. Every 503 carries `Retry-After`, sharing a constant
with the drain and concurrency-cap refusals that already sent it. The `CoreError` match is
exhaustive on purpose: a new variant fails to compile until someone decides what it means on the
wire, rather than silently defaulting back to 500.

**Response bodies are unchanged** — the same `{error, code}` shape with the same per-route code
(`CHECKPOINT_ERROR`, `SLEEP_ERROR`, …), so nothing on the wire moves except the status.

### `/register` needed three fixes to agree with the contract

The ticket asks to check that `/register` still agrees. It didn't, in three places, because it
reports refusals through its own response shape rather than through the error type — so anything
it put in that channel got a 4xx from the route's `_ => BAD_REQUEST` catch-all:

- **Failed persistence writes** became `Ok(success: false)` → **400**, telling a client its
  request was wrong when the truth was "the write failed, retry". Now propagate → 503.
- **A failed `load_checkpoint` during a resume** did the same → **400**, so a transient database
  blip permanently killed a resume a retry would have recovered. Now propagates → 503.
- **A genuinely missing checkpoint** answered **400**, while the byte-identical condition on the
  checkpoint route answers 404. It now carries `CoreError::CheckpointNotFound` → **404**, so both
  routes agree about the same fact.

The `success: false` channel keeps its real meaning (bad input, draining, concurrency cap), and
the drain/cap sentinels (503 + `Retry-After`, 429) are untouched.

## Why

Currently a diagnosability fix, not a behaviour change: the SDK collapses every status ≥ 400
into one `SdkError::Internal` (`crates/runtara-sdk/src/backend/http.rs:134`), so no client's
control flow moves. It's the prerequisite for any future retry policy that wants to tell "stop,
you're wrong" from "retry, I'm sick".

## Note: the ticket's third verified line doesn't reproduce

SYN-610 lists `input of unknown instance -> 404 (was 500)`. Measured against a live server,
`/input` **already returned 404** before this change — and `input_handler` is byte-identical
between the ticket's own baseline `29367fed` and `main`. There's no path from "unknown instance"
to 500 there: `instances.instance_id` is `TEXT`, and `op_get_instance` uses `fetch_optional`,
so a missing row is `Ok(None)`. Nothing was changed there; the 404 is now pinned by a test so it
can't regress.

## Verified

`cargo fmt --all -- --check`, the full CI gate
(`cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings`), and
`cargo test` for runtara-core + its dependents. Existing `e2e/test_core_sigterm_drain.sh` rerun
for register regressions.

Measured against a live SQLite-backed binary, before and after:

| case | before | after |
| -- | -- | -- |
| checkpoint on unknown instance | 500 | **404** |
| checkpoint on completed instance | 500 | **409** |
| register resuming from a missing checkpoint | 400 | **404** |
| register with a failed DB write or checkpoint read | 400 | **503** |
| input of unknown instance | 404 | 404 (unchanged) |
| checkpoint on a running instance | 200 | 200 (unchanged) |

New tests:
- `e2e/test_core_http_status_codes.sh` — self-contained (cargo + curl + SQLite, no docker),
  boots the real binary and asserts the statuses, the unchanged body `code`, that 4xx failures
  log at WARN and not ERROR, and that a 4xx does not carry `Retry-After`. Registered in
  `e2e/run_all.sh`.
- Router-level tests in `http_server.rs` driving the real axum router via
  `tower::ServiceExt::oneshot` (adds `tower` as a dev-dependency), so they cover the routing and
  extraction, not just the helper in isolation.
- Handler tests in `registration.rs` for the propagation paths.

**Known gap:** `ValidationError` → 400 is unreachable through today's routes — its only producer
is the empty-`instance_id` check in `event.rs`, and axum's `{instance_id}` segment can't match
empty. It's covered by the mapping unit test only.

## Follow-ups spotted, not fixed here

- `handle_sleep` never validates that the instance exists, so sleeping on an unknown one trips a
  foreign-key violation reported as `CheckpointSaveFailed` → 503, i.e. "retry" for something that
  can never succeed. A handler-validation bug rather than a status-mapping one.
- `CoreError::InstanceAlreadyExists` is constructed nowhere, because `op_register_instance` maps
  every sqlx error — primary-key violations included — to `DatabaseError`. So the 409 arm above
  is currently unreachable and two concurrent registrations of the same id get a 503 instead.
  That's a pre-existing persistence-layer defect; the mapping itself follows the ticket's table.

[SYN-610](https://linear.app/syncmyordershq/issue/SYN-610/every-instance-protocol-error-returns-http-500-so-clients-cannot-tell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
