### PR TITLE
Validate the instance in handle_sleep before saving its checkpoint

### DIFF
--- a/crates/runtara-core/src/instance_handlers/checkpoint.rs
+++ b/crates/runtara-core/src/instance_handlers/checkpoint.rs
@@ -37,25 +37,7 @@ pub async fn handle_checkpoint(
     );
 
     // 1. Validate instance exists and is running
-    let instance = state.persistence.get_instance(&request.instance_id).await?;
-    match instance {
-        Some(inst) => {
-            if inst.status != "running" {
-                return Err(CoreError::InvalidInstanceState {
-                    instance_id: request.instance_id.clone(),
-                    expected: "running".to_string(),
-                    actual: inst.status,
-                }
-                .into());
-            }
-        }
-        None => {
-            return Err(CoreError::InstanceNotFound {
-                instance_id: request.instance_id.clone(),
-            }
-            .into());
-        }
-    }
+    ensure_instance_running(state.persistence.as_ref(), &request.instance_id).await?;
 
     // 2. Check if checkpoint already exists
     if let Some(existing) = state
@@ -147,6 +129,31 @@ pub async fn handle_checkpoint(
         custom_signal,
         last_error: None,
     })
+}
+
+/// Validate that an instance exists and is still running.
+///
+/// Every handler that writes on an instance's behalf owes the caller this
+/// check first. Falling straight through to the write turns "you named an
+/// instance that does not exist" into whatever the storage layer happens to
+/// say — on SQLite, a foreign-key violation surfaced as
+/// `CheckpointSaveFailed`, which is classified `Transient` and tells the
+/// client to retry a request that can never succeed.
+async fn ensure_instance_running(
+    persistence: &dyn Persistence,
+    instance_id: &str,
+) -> std::result::Result<(), CoreError> {
+    match persistence.get_instance(instance_id).await? {
+        Some(inst) if inst.status == "running" => Ok(()),
+        Some(inst) => Err(CoreError::InvalidInstanceState {
+            instance_id: instance_id.to_string(),
+            expected: "running".to_string(),
+            actual: inst.status,
+        }),
+        None => Err(CoreError::InstanceNotFound {
+            instance_id: instance_id.to_string(),
+        }),
+    }
 }
 
 /// Helper to get the pending instance-wide signal for an instance.
@@ -247,7 +254,15 @@ pub async fn handle_sleep(
         "Processing sleep request"
     );
 
-    // 1. Save checkpoint before sleeping (for durability)
+    // 1. Validate instance exists and is running, exactly as the checkpoint
+    // path does. The save below writes a row keyed on the instance, so an
+    // unknown instance would otherwise be reported as a checkpoint-save
+    // failure — a retryable-looking error for a caller mistake. The check is
+    // unconditional: sleeping out the clock on behalf of an instance that
+    // isn't running is just as wrong when there is no checkpoint to save.
+    ensure_instance_running(state.persistence.as_ref(), &request.instance_id).await?;
+
+    // 2. Save checkpoint before sleeping (for durability)
     if !request.checkpoint_id.is_empty() {
         state
             .persistence
@@ -263,7 +278,7 @@ pub async fn handle_sleep(
         debug!(checkpoint_id = %request.checkpoint_id, "Sleep checkpoint saved");
     }
 
-    // 2. Sleep in-process; environment may hibernate managed instances separately.
+    // 3. Sleep in-process; environment may hibernate managed instances separately.
     let deadline = Instant::now() + Duration::from_millis(request.duration_ms);
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -460,6 +475,89 @@ mod tests {
         let cs = result.custom_signal.unwrap();
         assert_eq!(cs.checkpoint_id, "cp-1");
         assert_eq!(cs.payload, b"custom payload");
+    }
+
+    /// A sleep against an instance that does not exist is a caller error and
+    /// must say so. It used to fall through to `save_checkpoint`, where SQLite
+    /// answered with a foreign-key violation reported as
+    /// `CheckpointSaveFailed` — classified `Transient`, so the client was told
+    /// to retry a request that can never succeed. `MockPersistence` does not
+    /// enforce the foreign key, so this asserts on the validation itself.
+    #[tokio::test(start_paused = true)]
+    async fn test_sleep_instance_not_found() {
+        let persistence = Arc::new(MockPersistence::new());
+        let state = InstanceHandlerState::new(persistence.clone());
+
+        let request = SleepRequest {
+            instance_id: "does-not-exist".to_string(),
+            duration_ms: 30_000,
+            checkpoint_id: "delay-1".to_string(),
+            state: b"sleep state".to_vec(),
+        };
+        let Err(error) = handle_sleep(&state, request).await else {
+            panic!("an unknown instance must be rejected, not slept on");
+        };
+
+        assert!(
+            matches!(
+                error.downcast_ref::<CoreError>(),
+                Some(CoreError::InstanceNotFound { instance_id }) if instance_id == "does-not-exist"
+            ),
+            "expected InstanceNotFound, got: {error:?}"
+        );
+        assert!(
+            persistence
+                .load_checkpoint("does-not-exist", "delay-1")
+                .await
+                .unwrap()
+                .is_none(),
+            "nothing may be written for an instance that does not exist"
+        );
+    }
+
+    /// The validation is unconditional: an empty `checkpoint_id` skips the save,
+    /// but sleeping out the clock for an instance that does not exist is just as
+    /// wrong, and returning `Ok` after it would be worse.
+    #[tokio::test(start_paused = true)]
+    async fn test_sleep_without_checkpoint_still_validates_instance() {
+        let persistence = Arc::new(MockPersistence::new());
+        let state = InstanceHandlerState::new(persistence);
+
+        let Err(error) = handle_sleep(&state, sleep_request(30_000)).await else {
+            panic!("an unknown instance must be rejected even with no checkpoint to save");
+        };
+
+        assert!(
+            matches!(
+                error.downcast_ref::<CoreError>(),
+                Some(CoreError::InstanceNotFound { .. })
+            ),
+            "expected InstanceNotFound, got: {error:?}"
+        );
+    }
+
+    /// A finished instance is the other caller error the checkpoint path already
+    /// reports: the sleep would park on a run nobody is waiting for.
+    #[tokio::test(start_paused = true)]
+    async fn test_sleep_instance_not_running() {
+        let persistence = Arc::new(MockPersistence::new().with_instance(make_instance(
+            "inst-1",
+            "tenant-1",
+            "cancelled",
+        )));
+        let state = InstanceHandlerState::new(persistence);
+
+        let Err(error) = handle_sleep(&state, sleep_request(30_000)).await else {
+            panic!("a terminal instance must be rejected");
+        };
+
+        assert!(
+            matches!(
+                error.downcast_ref::<CoreError>(),
+                Some(CoreError::InvalidInstanceState { actual, .. }) if actual == "cancelled"
+            ),
+            "expected InvalidInstanceState, got: {error:?}"
+        );
     }
 
     /// A sleep request for `duration_ms` against the shared test instance.


### PR DESCRIPTION
## Description

`handle_sleep` in `crates/runtara-core/src/instance_handlers/checkpoint.rs` called `save_checkpoint` without first checking that the instance exists. `handle_checkpoint`, right above it, did validate — the two paths had drifted apart.

Against a live SQLite-backed `runtara-core` binary:

```
POST /api/v1/instances/does-not-exist/sleep
  -> CoreError::CheckpointSaveFailed { reason: "error returned from database: (code: 787) FOREIGN KEY constraint failed" }
```

So a caller error came back as a checkpoint-save failure. `From<CoreError> for StructuredError` classifies `CheckpointSaveFailed` as Transient/RetryWithBackoff, which tells the client to retry a request that can never succeed.

This PR lifts the validation `handle_checkpoint` already performed into a shared `ensure_instance_running` helper and calls it from both handlers. An unknown instance now yields `CoreError::InstanceNotFound`, a non-running one `CoreError::InvalidInstanceState { expected: "running" }` — both Permanent, so the HTTP layer can answer 404/409 rather than 503.

Two judgment calls worth a reviewer's attention:

- **The check is unconditional**, not tucked inside the `if !request.checkpoint_id.is_empty()` branch. A sleep with an empty checkpoint id skips the save, but parking the wall clock on behalf of an instance that does not exist and returning `Ok` is the worse outcome, not the safer one.
- **Non-running is `InvalidInstanceState`**, matching `handle_checkpoint`. This contract is already effectively in force: the guest checkpoints constantly during a run, so any instance whose status leaves `"running"` is already failing its next checkpoint. The environment host's own fixture marks instances `"running"` before launch, and `durable_sleep_checkpoint` short-circuits on a cancelled run before it ever reaches here.

`handle_checkpoint`'s behaviour is unchanged — same three cases, no longer duplicated.

## Related Issue

<!-- No tracking issue; follow-up to the classification work in SYN-610. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [x] My changes don't introduce new warnings

## Testing

Three unit tests added against the existing `#[cfg(test)] MockPersistence`. The mock's `save_checkpoint` does not enforce the foreign key, so they assert on the validation path directly (downcast to `CoreError`) plus that nothing was written for the unknown instance:

- `test_sleep_instance_not_found` — unknown instance yields `InstanceNotFound`, and no checkpoint row is written
- `test_sleep_without_checkpoint_still_validates_instance` — empty `checkpoint_id` still validates
- `test_sleep_instance_not_running` — a `cancelled` instance yields `InvalidInstanceState`

Each was confirmed to fail with the validation removed and pass with it in place.

- `cargo test -p runtara-core` — 145 passed, 0 failed
- `cargo test -p runtara-environment` — 168 passed, 0 failed (drives `handle_sleep` through the persistence runtime host, including the SYN-606 cancel-during-sleep tests)
- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Additional Notes

On this branch the HTTP layer is not yet classification-aware: `sleep_handler` maps every error to a flat 500 `SLEEP_ERROR`, as does `checkpoint_handler`. So today the wire response for an unknown instance goes from a 500 saying "checkpoint save failed" to a 500 saying "instance not found"; it becomes 404/409 once SYN-610's mapping lands. The classification the mapping reads is now correct, which is the part that belongs in core — the HTTP layer is deliberately left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
