### PR TITLE
SYN-612: Pass core's environment configuration to the embedded CoreRuntime

### DIFF
--- a/crates/runtara-core/src/config.rs
+++ b/crates/runtara-core/src/config.rs
@@ -3,8 +3,14 @@
 //! Configuration loading from environment variables.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use crate::runtime::DEFAULT_SHUTDOWN_GRACE;
+
+/// Cap the standalone binary applies when `RUNTARA_MAX_CONCURRENT_INSTANCES`
+/// is unset. A host that embeds the runtime does not inherit this: see
+/// [`RuntimeOverrides`].
+const DEFAULT_MAX_CONCURRENT_INSTANCES: u32 = 32;
 
 /// Runtara Core configuration
 #[derive(Debug, Clone)]
@@ -44,27 +50,14 @@ impl Config {
                 ConfigError::Invalid("RUNTARA_HTTP_PORT", "must be a valid port number")
             })?;
 
-        let max_concurrent_instances: u32 = std::env::var("RUNTARA_MAX_CONCURRENT_INSTANCES")
-            .unwrap_or_else(|_| "32".to_string())
-            .parse()
-            .map_err(|_| {
-                ConfigError::Invalid(
-                    "RUNTARA_MAX_CONCURRENT_INSTANCES",
-                    "must be a positive integer",
-                )
-            })?;
+        let max_concurrent_instances =
+            max_concurrent_instances_from_env()?.unwrap_or(DEFAULT_MAX_CONCURRENT_INSTANCES);
 
-        let shutdown_grace_ms: u64 = match std::env::var("RUNTARA_CORE_SHUTDOWN_GRACE_MS") {
-            Ok(raw) => raw.parse().map_err(|_| {
-                ConfigError::Invalid(
-                    "RUNTARA_CORE_SHUTDOWN_GRACE_MS",
-                    "must be a non-negative integer number of milliseconds",
-                )
-            })?,
+        let shutdown_grace_ms = shutdown_grace_from_env()?
             // Read the runtime's own constant rather than repeating the number,
             // so the documented default cannot drift from the applied one.
-            Err(_) => DEFAULT_SHUTDOWN_GRACE.as_millis() as u64,
-        };
+            .unwrap_or(DEFAULT_SHUTDOWN_GRACE)
+            .as_millis() as u64;
 
         Ok(Self {
             database_url,
@@ -72,6 +65,70 @@ impl Config {
             max_concurrent_instances,
             shutdown_grace_ms,
         })
+    }
+}
+
+/// The [`CoreRuntime`](crate::runtime::CoreRuntime) knobs a host that *embeds*
+/// the runtime can take from the environment, each `None` when its variable is
+/// unset.
+///
+/// [`Config`] is for a process that *is* runtara-core: it owns the database URL
+/// and the listen port, and it substitutes its own default for anything unset.
+/// An embedding host supplies persistence and bind address itself and wants
+/// only the rest — and must not have a concurrency cap it never asked for
+/// switched on underneath it by an upgrade. Optional fields are what separate
+/// "unset" from "set to the same value as the default", so
+/// [`apply_overrides`](crate::runtime::CoreRuntimeBuilder::apply_overrides) can
+/// leave the builder's own default in place.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeOverrides {
+    /// `RUNTARA_MAX_CONCURRENT_INSTANCES`, when set.
+    pub max_concurrent_instances: Option<u32>,
+    /// `RUNTARA_CORE_SHUTDOWN_GRACE_MS`, when set.
+    pub shutdown_grace: Option<Duration>,
+}
+
+impl RuntimeOverrides {
+    /// Read both variables from the environment.
+    ///
+    /// An unset variable is not an error — it yields `None`. A malformed one
+    /// is, so a typo in a deployment's configuration fails startup instead of
+    /// being silently ignored.
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Ok(Self {
+            max_concurrent_instances: max_concurrent_instances_from_env()?,
+            shutdown_grace: shutdown_grace_from_env()?,
+        })
+    }
+}
+
+/// Parse `RUNTARA_MAX_CONCURRENT_INSTANCES`, returning `None` when it is unset
+/// so each caller can apply its own default.
+fn max_concurrent_instances_from_env() -> Result<Option<u32>, ConfigError> {
+    match std::env::var("RUNTARA_MAX_CONCURRENT_INSTANCES") {
+        Ok(raw) => raw.parse::<u32>().map(Some).map_err(|_| {
+            ConfigError::Invalid(
+                "RUNTARA_MAX_CONCURRENT_INSTANCES",
+                "must be a positive integer",
+            )
+        }),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Parse `RUNTARA_CORE_SHUTDOWN_GRACE_MS`, returning `None` when it is unset.
+fn shutdown_grace_from_env() -> Result<Option<Duration>, ConfigError> {
+    match std::env::var("RUNTARA_CORE_SHUTDOWN_GRACE_MS") {
+        Ok(raw) => raw
+            .parse::<u64>()
+            .map(|ms| Some(Duration::from_millis(ms)))
+            .map_err(|_| {
+                ConfigError::Invalid(
+                    "RUNTARA_CORE_SHUTDOWN_GRACE_MS",
+                    "must be a non-negative integer number of milliseconds",
+                )
+            }),
+        Err(_) => Ok(None),
     }
 }
 
@@ -291,6 +348,101 @@ mod tests {
 
         let result = Config::from_env();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_runtime_overrides_unset_are_none() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+
+        guard.remove("RUNTARA_MAX_CONCURRENT_INSTANCES");
+        guard.remove("RUNTARA_CORE_SHUTDOWN_GRACE_MS");
+
+        // `None`, not the standalone binary's defaults: an embedding host must
+        // keep its own behaviour when a deployment sets nothing.
+        assert_eq!(
+            RuntimeOverrides::from_env().unwrap(),
+            RuntimeOverrides::default()
+        );
+    }
+
+    #[test]
+    fn test_runtime_overrides_read_both_variables() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "7");
+        guard.set("RUNTARA_CORE_SHUTDOWN_GRACE_MS", "1500");
+
+        let overrides = RuntimeOverrides::from_env().unwrap();
+
+        assert_eq!(overrides.max_concurrent_instances, Some(7));
+        assert_eq!(overrides.shutdown_grace, Some(Duration::from_millis(1500)));
+    }
+
+    #[test]
+    fn test_runtime_overrides_zero_cap_is_explicit() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "0");
+        guard.remove("RUNTARA_CORE_SHUTDOWN_GRACE_MS");
+
+        // `Some(0)`, distinct from unset — disabling the cap is a choice a
+        // deployment can make, not the absence of one.
+        assert_eq!(
+            RuntimeOverrides::from_env()
+                .unwrap()
+                .max_concurrent_instances,
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_runtime_overrides_invalid_values_are_errors() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "lots");
+        guard.remove("RUNTARA_CORE_SHUTDOWN_GRACE_MS");
+        assert!(matches!(
+            RuntimeOverrides::from_env().unwrap_err(),
+            ConfigError::Invalid("RUNTARA_MAX_CONCURRENT_INSTANCES", _)
+        ));
+
+        guard.remove("RUNTARA_MAX_CONCURRENT_INSTANCES");
+        guard.set("RUNTARA_CORE_SHUTDOWN_GRACE_MS", "30s");
+        assert!(matches!(
+            RuntimeOverrides::from_env().unwrap_err(),
+            ConfigError::Invalid("RUNTARA_CORE_SHUTDOWN_GRACE_MS", _)
+        ));
+    }
+
+    #[test]
+    fn test_config_defaults_where_overrides_are_none() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+
+        guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
+        guard.remove("RUNTARA_MAX_CONCURRENT_INSTANCES");
+        guard.remove("RUNTARA_CORE_SHUTDOWN_GRACE_MS");
+
+        let config = Config::from_env().unwrap();
+
+        assert!(
+            RuntimeOverrides::from_env()
+                .unwrap()
+                .shutdown_grace
+                .is_none()
+        );
+        assert_eq!(
+            config.max_concurrent_instances,
+            DEFAULT_MAX_CONCURRENT_INSTANCES
+        );
+        assert_eq!(
+            config.shutdown_grace_ms,
+            DEFAULT_SHUTDOWN_GRACE.as_millis() as u64
+        );
     }
 
     #[test]

--- a/crates/runtara-core/src/config.rs
+++ b/crates/runtara-core/src/config.rs
@@ -92,8 +92,11 @@ impl RuntimeOverrides {
     /// Read both variables from the environment.
     ///
     /// An unset variable is not an error — it yields `None`. A malformed one
-    /// is, so a typo in a deployment's configuration fails startup instead of
-    /// being silently ignored.
+    /// is, so a typo in a deployment's configuration surfaces at startup
+    /// instead of being silently ignored. What a host does with that error is
+    /// its own call: the `runtara-core` and `runtara-environment` binaries
+    /// exit, while `runtara-server` reports it and carries on without an
+    /// embedded runtime.
     pub fn from_env() -> Result<Self, ConfigError> {
         Ok(Self {
             max_concurrent_instances: max_concurrent_instances_from_env()?,

--- a/crates/runtara-core/src/lib.rs
+++ b/crates/runtara-core/src/lib.rs
@@ -132,10 +132,15 @@
 //! |----------|----------|---------|-------------|
 //! | `RUNTARA_DATABASE_URL` | Yes | - | PostgreSQL or SQLite connection string |
 //! | `RUNTARA_HTTP_PORT` | No | `8001` | Instance HTTP server port |
-//! | `RUNTARA_MAX_CONCURRENT_INSTANCES` | No | `32` | Max instances in `running` at once. Enforced at `register_instance`; fresh registrations past the cap receive `429 Too Many Requests`. Neither resumes nor `suspended` instances count against it, so work parked in a durable sleep or a signal-wait never holds the cap closed. Set to `0` to disable. |
+//! | `RUNTARA_MAX_CONCURRENT_INSTANCES` | No | `32` standalone, none embedded | Max instances in `running` at once. Enforced at `register_instance`; fresh registrations past the cap receive `429 Too Many Requests`. Neither resumes nor `suspended` instances count against it, so work parked in a durable sleep or a signal-wait never holds the cap closed. Set to `0` to disable. The default applies to the `runtara-core` binary only — a host embedding the runtime is left uncapped unless this is set, so an upgrade cannot start rejecting launches that used to succeed. |
 //! | `RUNTARA_CORE_SHUTDOWN_GRACE_MS` | No | `5000` | How long [`runtime::CoreRuntime::shutdown`] waits for in-flight instance-protocol requests before it stops waiting. This crate's own knob — not to be confused with the two rows below, which belong to the host processes. |
 //! | `RUNTARA_SHUTDOWN_GRACE_MS` | No | `60000` | On SIGTERM/SIGINT, how long to wait for running instances to reach a checkpoint before force-stopping. |
 //! | `RUNTARA_SHUTDOWN_INTAKE_GRACE_MS` | No | `5000` | On SIGTERM/SIGINT, how long to wait for intake workers to finish their current unit of work. |
+//!
+//! Both of core's own variables reach the runtime wherever it runs: the
+//! `runtara-core` binary reads them via [`config::Config`], and a host that
+//! embeds the runtime reads them via [`config::RuntimeOverrides`] and applies
+//! them with [`runtime::CoreRuntimeBuilder::apply_overrides`].
 //!
 //! # Modules
 //!

--- a/crates/runtara-core/src/runtime.rs
+++ b/crates/runtara-core/src/runtime.rs
@@ -42,6 +42,7 @@ use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
+use crate::config::RuntimeOverrides;
 use crate::instance_handlers::InstanceHandlerState;
 use crate::persistence::Persistence;
 use crate::server::InstanceServerState;
@@ -129,6 +130,22 @@ impl CoreRuntimeBuilder {
     /// flight.
     pub fn shutdown_grace(mut self, grace: Duration) -> Self {
         self.shutdown_grace = grace;
+        self
+    }
+
+    /// Apply the environment-derived [`RuntimeOverrides`], leaving any knob the
+    /// deployment did not set at its current value.
+    ///
+    /// Hosts that embed the runtime should prefer this to the individual
+    /// setters: it is one call for the whole set, so a call site cannot wire
+    /// half of core's configuration and silently drop the rest.
+    pub fn apply_overrides(mut self, overrides: RuntimeOverrides) -> Self {
+        if let Some(limit) = overrides.max_concurrent_instances {
+            self.max_concurrent_instances = limit;
+        }
+        if let Some(grace) = overrides.shutdown_grace {
+            self.shutdown_grace = grace;
+        }
         self
     }
 
@@ -780,6 +797,51 @@ mod tests {
         assert!(result.is_ok());
         let config = result.unwrap();
         assert_eq!(config.bind_addr.port(), 9002);
+    }
+
+    #[test]
+    fn test_builder_apply_overrides_sets_both_knobs() {
+        let builder = CoreRuntimeBuilder::new().apply_overrides(RuntimeOverrides {
+            max_concurrent_instances: Some(4),
+            shutdown_grace: Some(Duration::from_millis(250)),
+        });
+
+        assert_eq!(builder.max_concurrent_instances, 4);
+        assert_eq!(builder.shutdown_grace, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn test_builder_apply_overrides_leaves_unset_knobs_alone() {
+        // A deployment that configures only the grace must not acquire a
+        // concurrency cap as a side effect, and vice versa.
+        let grace_only = CoreRuntimeBuilder::new()
+            .max_concurrent_instances(9)
+            .apply_overrides(RuntimeOverrides {
+                max_concurrent_instances: None,
+                shutdown_grace: Some(Duration::from_millis(750)),
+            });
+        assert_eq!(grace_only.max_concurrent_instances, 9);
+        assert_eq!(grace_only.shutdown_grace, Duration::from_millis(750));
+
+        let empty = CoreRuntimeBuilder::new().apply_overrides(RuntimeOverrides::default());
+        assert_eq!(empty.max_concurrent_instances, 0);
+        assert_eq!(empty.shutdown_grace, DEFAULT_SHUTDOWN_GRACE);
+    }
+
+    #[test]
+    fn test_build_carries_overrides_into_config() {
+        let persistence = Arc::new(MockPersistence::new());
+        let config = CoreRuntimeBuilder::new()
+            .persistence(persistence)
+            .apply_overrides(RuntimeOverrides {
+                max_concurrent_instances: Some(3),
+                shutdown_grace: Some(Duration::from_millis(100)),
+            })
+            .build()
+            .unwrap();
+
+        assert_eq!(config.max_concurrent_instances, 3);
+        assert_eq!(config.shutdown_grace, Duration::from_millis(100));
     }
 
     #[test]

--- a/crates/runtara-environment/src/config.rs
+++ b/crates/runtara-environment/src/config.rs
@@ -94,54 +94,10 @@ pub(crate) fn parse_bool_lenient(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-    use std::sync::Mutex;
-
-    // Mutex to serialize tests that modify environment variables
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
-
-    /// Helper to set env vars for a test and restore them after
-    struct EnvGuard {
-        vars: Vec<(String, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn new() -> Self {
-            Self { vars: Vec::new() }
-        }
-
-        fn set(&mut self, key: &str, value: &str) {
-            let old = env::var(key).ok();
-            self.vars.push((key.to_string(), old));
-            // SAFETY: Tests are serialized via ENV_MUTEX, so no concurrent access
-            unsafe { env::set_var(key, value) };
-        }
-
-        fn remove(&mut self, key: &str) {
-            let old = env::var(key).ok();
-            self.vars.push((key.to_string(), old));
-            // SAFETY: Tests are serialized via ENV_MUTEX, so no concurrent access
-            unsafe { env::remove_var(key) };
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (key, value) in self.vars.drain(..).rev() {
-                // SAFETY: Tests are serialized via ENV_MUTEX, so no concurrent access
-                unsafe {
-                    match value {
-                        Some(v) => env::set_var(&key, v),
-                        None => env::remove_var(&key),
-                    }
-                }
-            }
-        }
-    }
+    use crate::test_env::EnvGuard;
 
     #[test]
     fn test_config_from_env_with_defaults() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -161,7 +117,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_with_custom_port() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -174,7 +129,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_with_custom_core_addr() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -187,7 +141,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_with_custom_data_dir() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -200,7 +153,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_skip_cert_verification_true() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -213,7 +165,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_skip_cert_verification_one() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -226,7 +177,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_skip_cert_verification_false() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -239,7 +189,6 @@ mod tests {
 
     #[test]
     fn test_config_from_env_all_custom() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://user:pass@db:5432/prod");
@@ -259,7 +208,6 @@ mod tests {
 
     #[test]
     fn test_config_missing_database_url() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.remove("RUNTARA_DATABASE_URL");
@@ -277,7 +225,6 @@ mod tests {
 
     #[test]
     fn test_config_invalid_port() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -292,7 +239,6 @@ mod tests {
 
     #[test]
     fn test_config_port_out_of_range() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -316,7 +262,6 @@ mod tests {
 
     #[test]
     fn test_config_debug() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");
@@ -333,7 +278,6 @@ mod tests {
 
     #[test]
     fn test_config_clone() {
-        let _lock = ENV_MUTEX.lock().unwrap();
         let mut guard = EnvGuard::new();
 
         guard.set("RUNTARA_DATABASE_URL", "postgres://localhost/test");

--- a/crates/runtara-environment/src/lib.rs
+++ b/crates/runtara-environment/src/lib.rs
@@ -205,5 +205,9 @@ pub mod runtime;
 /// the native replacement for the composed guest runtime's HTTP loopback.
 pub mod runtime_host;
 
+/// Shared environment-variable guard for this crate's tests.
+#[cfg(test)]
+pub(crate) mod test_env;
+
 pub use config::Config;
 pub use error::Error;

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -77,6 +77,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use runtara_core::config::RuntimeOverrides;
 use runtara_core::persistence::{CompleteInstanceParams, Persistence};
 use runtara_core::runtime::CoreRuntime;
 use sqlx::PgPool;
@@ -101,6 +102,7 @@ pub struct EnvironmentRuntimeBuilder {
     bind_addr: SocketAddr,
     core_addr: String,
     core_bind_addr: Option<SocketAddr>,
+    core_overrides: Option<RuntimeOverrides>,
     data_dir: PathBuf,
     wake_poll_interval: Duration,
     wake_batch_size: i64,
@@ -122,6 +124,7 @@ impl Default for EnvironmentRuntimeBuilder {
             bind_addr: "0.0.0.0:8002".parse().unwrap(),
             core_addr: "127.0.0.1:8001".to_string(),
             core_bind_addr: None,
+            core_overrides: None,
             data_dir: PathBuf::from(".data"),
             wake_poll_interval: Duration::from_secs(5),
             wake_batch_size: 10,
@@ -191,6 +194,20 @@ impl EnvironmentRuntimeBuilder {
     /// Default: `None` (no embedded Core)
     pub fn core_bind_addr(mut self, addr: SocketAddr) -> Self {
         self.core_bind_addr = Some(addr);
+        self
+    }
+
+    /// Set runtara-core's configuration for the embedded `CoreRuntime`.
+    ///
+    /// Default: read from the environment during [`build`](Self::build), which
+    /// is what a deployment configuring core through `RUNTARA_*` variables
+    /// expects. Set this to configure the embedded core from code instead —
+    /// tests do, so an ambient variable cannot change what they assert.
+    ///
+    /// Ignored when no [`core_bind_addr`](Self::core_bind_addr) is set: there
+    /// is no embedded core to configure.
+    pub fn core_overrides(mut self, overrides: RuntimeOverrides) -> Self {
+        self.core_overrides = Some(overrides);
         self
     }
 
@@ -287,6 +304,13 @@ impl EnvironmentRuntimeBuilder {
         let persistence = self
             .core_persistence
             .ok_or_else(|| anyhow::anyhow!("core_persistence is required"))?;
+        // Fall back to the environment rather than to bare builder defaults:
+        // this crate's binary embeds core, so a deployment's core settings have
+        // nowhere else to enter from.
+        let core_overrides = match self.core_overrides {
+            Some(overrides) => overrides,
+            None => RuntimeOverrides::from_env()?,
+        };
 
         Ok(EnvironmentRuntimeConfig {
             pool,
@@ -295,6 +319,7 @@ impl EnvironmentRuntimeBuilder {
             bind_addr: self.bind_addr,
             core_addr: self.core_addr,
             core_bind_addr: self.core_bind_addr,
+            core_overrides,
             data_dir: self.data_dir,
             wake_poll_interval: self.wake_poll_interval,
             wake_batch_size: self.wake_batch_size,
@@ -317,6 +342,7 @@ pub struct EnvironmentRuntimeConfig {
     bind_addr: SocketAddr,
     core_addr: String,
     core_bind_addr: Option<SocketAddr>,
+    core_overrides: RuntimeOverrides,
     data_dir: PathBuf,
     wake_poll_interval: Duration,
     wake_batch_size: i64,
@@ -342,6 +368,7 @@ impl EnvironmentRuntimeConfig {
             let core = CoreRuntime::builder()
                 .persistence(self.persistence.clone())
                 .bind_addr(core_bind_addr)
+                .apply_overrides(self.core_overrides)
                 .build()?
                 .start()
                 .await?;
@@ -1007,6 +1034,108 @@ mod tests {
         let builder = EnvironmentRuntimeBuilder::new();
 
         assert!(builder.core_bind_addr.is_none());
+    }
+
+    #[test]
+    fn test_builder_core_overrides_default_is_env() {
+        // `None` means "resolve from the environment in `build`" — the default
+        // has to stay that way for a deployment's core settings to reach the
+        // embedded runtime at all.
+        let builder = EnvironmentRuntimeBuilder::new();
+
+        assert!(builder.core_overrides.is_none());
+    }
+
+    #[test]
+    fn test_builder_core_overrides_explicit_wins() {
+        let overrides = RuntimeOverrides {
+            max_concurrent_instances: Some(5),
+            shutdown_grace: Some(Duration::from_millis(400)),
+        };
+        let builder = EnvironmentRuntimeBuilder::new().core_overrides(overrides);
+
+        assert_eq!(builder.core_overrides, Some(overrides));
+    }
+
+    /// Serializes the tests below, which mutate process-wide environment state.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// A builder with the three required fields filled in, so `build` can run.
+    /// The pool is lazy: nothing here connects to a database.
+    fn buildable() -> EnvironmentRuntimeBuilder {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://runtara:runtara@127.0.0.1/runtara")
+            .expect("lazy pool");
+        EnvironmentRuntimeBuilder::new()
+            .pool(pool.clone())
+            .runner(Arc::new(crate::runner::MockRunner::new()))
+            .core_persistence(Arc::new(
+                runtara_core::persistence::postgres::PostgresPersistence::new(pool),
+            ))
+    }
+
+    // A lazy pool spawns a maintenance task, so these need a reactor.
+    #[tokio::test]
+    async fn test_build_resolves_core_overrides_from_env() {
+        // A failing test poisons the mutex; the rest still need serializing.
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
+        // restored below.
+        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "11") };
+
+        let config = buildable().build().expect("build");
+
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
+
+        assert_eq!(config.core_overrides.max_concurrent_instances, Some(11));
+    }
+
+    // A lazy pool spawns a maintenance task, so these need a reactor.
+    #[tokio::test]
+    async fn test_build_rejects_malformed_core_config() {
+        // A failing test poisons the mutex; the rest still need serializing.
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
+        // restored below.
+        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "unlimited") };
+
+        let result = buildable().build();
+
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
+
+        let err = result
+            .err()
+            .expect("malformed core config must fail startup");
+        assert!(
+            err.to_string().contains("RUNTARA_MAX_CONCURRENT_INSTANCES"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // A lazy pool spawns a maintenance task, so these need a reactor.
+    #[tokio::test]
+    async fn test_build_explicit_core_overrides_ignore_env() {
+        // A failing test poisons the mutex; the rest still need serializing.
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
+        // restored below.
+        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "11") };
+
+        let config = buildable()
+            .core_overrides(RuntimeOverrides {
+                max_concurrent_instances: Some(2),
+                shutdown_grace: None,
+            })
+            .build()
+            .expect("build");
+
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
+
+        assert_eq!(config.core_overrides.max_concurrent_instances, Some(2));
+        assert!(config.core_overrides.shutdown_grace.is_none());
     }
 
     #[test]

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -204,8 +204,11 @@ impl EnvironmentRuntimeBuilder {
     /// expects. Set this to configure the embedded core from code instead —
     /// tests do, so an ambient variable cannot change what they assert.
     ///
-    /// Ignored when no [`core_bind_addr`](Self::core_bind_addr) is set: there
-    /// is no embedded core to configure.
+    /// The resulting configuration is unused when no
+    /// [`core_bind_addr`](Self::core_bind_addr) is set — there is no embedded
+    /// core to configure — but [`build`](Self::build) still reads and validates
+    /// the environment in that case, so a malformed value fails the build
+    /// wherever it appears rather than only where it would have been applied.
     pub fn core_overrides(mut self, overrides: RuntimeOverrides) -> Self {
         self.core_overrides = Some(overrides);
         self
@@ -957,6 +960,7 @@ async fn recover_orphaned_containers(pool: &PgPool, persistence: &dyn Persistenc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::EnvGuard;
 
     #[test]
     fn test_builder_default_values() {
@@ -1057,9 +1061,6 @@ mod tests {
         assert_eq!(builder.core_overrides, Some(overrides));
     }
 
-    /// Serializes the tests below, which mutate process-wide environment state.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// A builder with the three required fields filled in, so `build` can run.
     /// The pool is lazy: nothing here connects to a database.
     fn buildable() -> EnvironmentRuntimeBuilder {
@@ -1074,54 +1075,39 @@ mod tests {
             ))
     }
 
-    // A lazy pool spawns a maintenance task, so these need a reactor.
+    // A lazy pool spawns a maintenance task, so these need a reactor. The
+    // guard restores the environment even when an assertion panics, so an
+    // ambient value survives the suite either way.
     #[tokio::test]
     async fn test_build_resolves_core_overrides_from_env() {
-        // A failing test poisons the mutex; the rest still need serializing.
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
-        // restored below.
-        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "11") };
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "11");
 
         let config = buildable().build().expect("build");
-
-        // SAFETY: as above.
-        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
 
         assert_eq!(config.core_overrides.max_concurrent_instances, Some(11));
     }
 
-    // A lazy pool spawns a maintenance task, so these need a reactor.
     #[tokio::test]
     async fn test_build_rejects_malformed_core_config() {
-        // A failing test poisons the mutex; the rest still need serializing.
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
-        // restored below.
-        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "unlimited") };
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "unlimited");
 
-        let result = buildable().build();
-
-        // SAFETY: as above.
-        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
-
-        let err = result
+        let err = buildable()
+            .build()
             .err()
             .expect("malformed core config must fail startup");
+
         assert!(
             err.to_string().contains("RUNTARA_MAX_CONCURRENT_INSTANCES"),
             "unexpected error: {err}"
         );
     }
 
-    // A lazy pool spawns a maintenance task, so these need a reactor.
     #[tokio::test]
     async fn test_build_explicit_core_overrides_ignore_env() {
-        // A failing test poisons the mutex; the rest still need serializing.
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // SAFETY: env mutation is serialized by ENV_MUTEX, and the variable is
-        // restored below.
-        unsafe { std::env::set_var("RUNTARA_MAX_CONCURRENT_INSTANCES", "11") };
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_MAX_CONCURRENT_INSTANCES", "11");
 
         let config = buildable()
             .core_overrides(RuntimeOverrides {
@@ -1130,9 +1116,6 @@ mod tests {
             })
             .build()
             .expect("build");
-
-        // SAFETY: as above.
-        unsafe { std::env::remove_var("RUNTARA_MAX_CONCURRENT_INSTANCES") };
 
         assert_eq!(config.core_overrides.max_concurrent_instances, Some(2));
         assert!(config.core_overrides.shutdown_grace.is_none());

--- a/crates/runtara-environment/src/test_env.rs
+++ b/crates/runtara-environment/src/test_env.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Environment-variable guard shared by every test in this crate.
+//!
+//! The environment is process-wide, and so is the lock that protects it: one
+//! guard for the crate, never one per module. Two modules with a mutex each do
+//! not serialize against one another at all, which is the failure this module
+//! exists to make impossible — `set_var` is `unsafe` precisely because a
+//! concurrent `getenv` elsewhere in the process can read memory the write just
+//! freed.
+
+use std::env;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Sets environment variables for the lifetime of a test and restores their
+/// previous values on drop — including when the test panics part-way through.
+///
+/// Constructing one takes the crate-wide env lock, so holding a guard *is*
+/// what serializes a test against the others; there is no separate lock to
+/// remember to take.
+pub(crate) struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    vars: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// Acquire the env lock. Returns once this test has exclusive use of the
+    /// process environment.
+    pub(crate) fn new() -> Self {
+        Self {
+            // A test that panicked while holding the lock poisons it. The
+            // remaining tests still need serializing, and this guard restores
+            // whatever it finds, so recover the inner guard instead of turning
+            // one failure into a cascade of unrelated ones.
+            _lock: ENV_MUTEX
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vars: Vec::new(),
+        }
+    }
+
+    /// Set a variable, remembering what it held before.
+    pub(crate) fn set(&mut self, key: &str, value: &str) {
+        self.remember(key);
+        // SAFETY: this guard holds ENV_MUTEX, and every test in this crate
+        // mutates the environment through it, so no other thread is reading.
+        unsafe { env::set_var(key, value) };
+    }
+
+    /// Unset a variable, remembering what it held before.
+    pub(crate) fn remove(&mut self, key: &str) {
+        self.remember(key);
+        // SAFETY: as in `set`.
+        unsafe { env::remove_var(key) };
+    }
+
+    fn remember(&mut self, key: &str) {
+        let old = env::var(key).ok();
+        self.vars.push((key.to_string(), old));
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.vars.drain(..).rev() {
+            // SAFETY: the lock is still held — it is dropped after this.
+            unsafe {
+                match value {
+                    Some(v) => env::set_var(&key, v),
+                    None => env::remove_var(&key),
+                }
+            }
+        }
+    }
+}

--- a/crates/runtara-server/src/embedded_runtara.rs
+++ b/crates/runtara-server/src/embedded_runtara.rs
@@ -236,6 +236,12 @@ pub async fn maybe_start_embedded()
         return Ok(None);
     }
 
+    // Read core's own configuration before opening the pool, so a malformed
+    // value is caught before migrations run rather than after. It aborts the
+    // embedded start, which the caller reports and survives without workflow
+    // execution — the same treatment every other failure here gets.
+    let core_overrides = RuntimeOverrides::from_env()?;
+
     // Create Runtara database pool
     let pool = match create_runtara_pool().await? {
         Some(pool) => pool,
@@ -307,7 +313,7 @@ pub async fn maybe_start_embedded()
                 Some(SocketAddr::from(([127, 0, 0, 1], port)))
             }
         },
-        core_overrides: RuntimeOverrides::from_env()?,
+        core_overrides,
     };
 
     let runtara = EmbeddedRuntara::start(config).await?;

--- a/crates/runtara-server/src/embedded_runtara.rs
+++ b/crates/runtara-server/src/embedded_runtara.rs
@@ -15,6 +15,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use runtara_core::config::RuntimeOverrides;
 use runtara_core::persistence::Persistence;
 use runtara_core::persistence::postgres::PostgresPersistence;
 use runtara_core::runtime::CoreRuntime;
@@ -44,6 +45,10 @@ pub struct EmbeddedRuntaraConfig {
     /// Optional bind address for runtara-environment's HTTP management API.
     /// When set, an HTTP server is started alongside QUIC for the management protocol.
     pub env_http_bind_addr: Option<SocketAddr>,
+    /// runtara-core's own environment configuration (concurrency cap, shutdown
+    /// grace). Nothing else here carries it, so without this the embedded core
+    /// runs on builder defaults no matter how the deployment is configured.
+    pub core_overrides: RuntimeOverrides,
 }
 
 /// Handle to the running embedded Runtara servers.
@@ -77,6 +82,7 @@ impl EmbeddedRuntara {
         let core = CoreRuntime::builder()
             .persistence(persistence.clone())
             .bind_addr(core_http_addr)
+            .apply_overrides(config.core_overrides)
             .build()?
             .start()
             .await?;
@@ -213,6 +219,12 @@ pub async fn create_runtara_pool()
 /// - `RUNTARA_CORE_PORT` (default: 8001) - Port for instance connections
 /// - `RUNTARA_ENVIRONMENT_PORT` (default: 8002) - Port for management protocol
 /// - `DATA_DIR` (default: .data) - Directory for images and instance I/O
+///
+/// runtara-core's own variables (`RUNTARA_MAX_CONCURRENT_INSTANCES`,
+/// `RUNTARA_CORE_SHUTDOWN_GRACE_MS`) are read here too and applied to the
+/// embedded core. Neither has a default of its own in this host: unset leaves
+/// the runtime's builder default, so the cap stays disabled unless a
+/// deployment asks for one.
 pub async fn maybe_start_embedded()
 -> Result<Option<EmbeddedRuntara>, Box<dyn std::error::Error + Send + Sync>> {
     let embedded_enabled = std::env::var("RUNTARA_EMBEDDED")
@@ -295,6 +307,7 @@ pub async fn maybe_start_embedded()
                 Some(SocketAddr::from(([127, 0, 0, 1], port)))
             }
         },
+        core_overrides: RuntimeOverrides::from_env()?,
     };
 
     let runtara = EmbeddedRuntara::start(config).await?;


### PR DESCRIPTION
## What changed

Both hosts that embed `runtara-core` built the runtime bare —
`CoreRuntime::builder().persistence(..).bind_addr(..).build()` — so
`RUNTARA_MAX_CONCURRENT_INSTANCES` and `RUNTARA_CORE_SHUTDOWN_GRACE_MS` never
reached it:

- `crates/runtara-server/src/embedded_runtara.rs`
- `crates/runtara-environment/src/runtime.rs`

This adds `RuntimeOverrides` — the subset of core's configuration an embedding
host does not supply itself — plus `CoreRuntimeBuilder::apply_overrides`, which
applies the whole set in one call so a site cannot wire half of it. Both hosts
now read it: `runtara-server` in `maybe_start_embedded`, `runtara-environment`
in its runtime builder (with a `core_overrides()` setter for callers that
configure core from code).

## Why

The standalone `runtara-core` binary is not in the release bundle, is not the
Docker CMD, and has no systemd unit. Everything that ships runs core embedded,
so both knobs were inert exactly where they matter.

## Behaviour note

Unset variables leave the builder's defaults in place, so an embedded host stays
**uncapped** rather than acquiring core's documented default of 32 on upgrade
and starting to reject launches that used to succeed. The standalone binary
keeps its 32.

A malformed value is now an error rather than being ignored. What that costs
depends on the host: the `runtara-core` and `runtara-environment` binaries exit,
while `runtara-server` reports it and carries on without an embedded runtime —
the pre-existing treatment of every `maybe_start_embedded` failure
(`server.rs:1277`), unchanged here.

Two items from the ticket needed no work — they had already been fixed on `main`:
the standalone binary's own wiring landed with SYN-609, and the stale
`shutdown()` comment in `server.rs` was rewritten by SYN-608.

## How it was verified

- `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean
- `cargo test -p runtara-core -p runtara-environment -p runtara-server`: 165 / 148 / 996 pass, including new unit tests for override parsing, `apply_overrides` semantics, and the environment builder's env resolution
- **Ran both hosts locally against Postgres.** With `RUNTARA_MAX_CONCURRENT_INSTANCES=1`, registering two instances against the *embedded* core returns `200` then `429`, in `runtara-environment` and in `runtara-server`. With the variable unset, three registrations all return `200`. A malformed value refuses to start and names the variable.
- **Confirmed the bug on the base**: with the change stashed and the binary rebuilt, the same run returns `200` for the registration that should have been capped.
- A malformed value against a fresh database aborts the embedded start naming the variable, and leaves that database with zero tables — it is caught before migrations run.

The second commit addresses a review pass: the new tests had declared a second env mutex alongside the one the `config` tests already use (two mutexes in one test binary serialize against nothing, so the `SAFETY` comments were false), and they removed variables instead of restoring them. Both now go through one crate-wide guard that holds the lock itself and restores on drop.

Linear: https://linear.app/syncmyordershq/issue/SYN-612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
