### PR TITLE
SYN-614: Upsert the SQLite checkpoint save so a replay can re-save

### DIFF
--- a/crates/runtara-core/src/persistence/common/ops/checkpoints.rs
+++ b/crates/runtara-core/src/persistence/common/ops/checkpoints.rs
@@ -18,19 +18,21 @@
 //! inline in each backend and gains the same `wrap_checkpoint_save`
 //! treatment as a surgical fix, but its Rust plumbing isn't shared.
 //!
-//! Not migrated here either: `save_checkpoint`'s *SQL shape* differs —
-//! Postgres uses `ON CONFLICT ... DO UPDATE` (idempotent upsert);
-//! SQLite uses a plain `INSERT` that fails on a duplicate key. Both
-//! legacy behaviors are preserved via
-//! `Dialect::sql_save_checkpoint()`. Unifying the conflict semantics
-//! is out of scope for this refactor.
+//! `save_checkpoint` keeps a per-backend statement behind
+//! `Dialect::sql_save_checkpoint()` because the placeholder style and
+//! the current-time function differ, but the two now agree on
+//! semantics: both upsert on `(instance_id, checkpoint_id)`. A resumed
+//! instance re-saves checkpoints it already wrote, so the save has to
+//! be idempotent on every backend.
 
 macro_rules! impl_checkpoint_ops {
     ($Backend:ty, $Pool:ty, $Dialect:ty) => {
         impl $Backend {
-            /// INSERT (or UPSERT on Postgres) a checkpoint row. Wraps any
-            /// sqlx error into `CoreError::CheckpointSaveFailed` with the
-            /// instance ID attached.
+            /// Upsert a checkpoint row: a repeat save of the same
+            /// `(instance_id, checkpoint_id)` refreshes it instead of
+            /// failing. Wraps any sqlx error into
+            /// `CoreError::CheckpointSaveFailed` with the instance ID
+            /// attached.
             pub(crate) async fn op_save_checkpoint(
                 pool: &$Pool,
                 instance_id: &str,

--- a/crates/runtara-core/src/persistence/common/ops/parity_harness.rs
+++ b/crates/runtara-core/src/persistence/common/ops/parity_harness.rs
@@ -102,6 +102,42 @@ pub async fn run_parity_sequence<P: Persistence>(backend: &P) {
         .expect("count_checkpoints with filter failed");
     assert!(filtered_count >= 1);
 
+    // Re-save the same key. The engine replays from the start and reads
+    // checkpoints as a result cache, so this is the ordinary path on a
+    // resume — every backend must accept it, refresh the state, and leave
+    // exactly one row behind. A backend that inserts without an upsert
+    // fails here on the save itself.
+    let refreshed_state = b"opaque-state-v2".to_vec();
+    backend
+        .save_checkpoint(&instance_id, checkpoint_id, &refreshed_state)
+        .await
+        .expect("re-saving an existing checkpoint key must succeed");
+    let reloaded = backend
+        .load_checkpoint(&instance_id, checkpoint_id)
+        .await
+        .expect("load_checkpoint after re-save failed")
+        .expect("checkpoint must still exist after re-save");
+    assert_eq!(
+        reloaded.state, refreshed_state,
+        "re-save must refresh the stored state, not keep the original"
+    );
+    let count_after_resave = backend
+        .count_checkpoints(&instance_id, Some(checkpoint_id), None, None)
+        .await
+        .expect("count_checkpoints after re-save failed");
+    assert_eq!(
+        count_after_resave, 1,
+        "re-save must replace the row, not add a second one"
+    );
+    let total_after_resave = backend
+        .count_checkpoints(&instance_id, None, None, None)
+        .await
+        .expect("unfiltered count_checkpoints after re-save failed");
+    assert_eq!(
+        total_after_resave, 1,
+        "only one checkpoint has been saved for this instance"
+    );
+
     // --- update instance checkpoint pointer --------------------------------
     backend
         .update_instance_checkpoint(&instance_id, checkpoint_id)

--- a/crates/runtara-core/src/persistence/dialect/mod.rs
+++ b/crates/runtara-core/src/persistence/dialect/mod.rs
@@ -131,14 +131,15 @@ pub trait Dialect: Send + Sync + 'static {
     /// Binds (in order): instance_id, checkpoint_id.
     fn sql_take_pending_custom_signal() -> &'static str;
 
-    /// SQL for inserting/upserting a checkpoint row.
+    /// SQL for upserting a checkpoint row.
     ///
     /// Binds (in order): instance_id, checkpoint_id, state.
     ///
-    /// - Postgres: `INSERT ... ON CONFLICT DO UPDATE` (idempotent upsert).
-    /// - SQLite: plain `INSERT` — a duplicate `(instance_id, checkpoint_id)`
-    ///   causes a UNIQUE-constraint violation. Preserves legacy behavior;
-    ///   unifying to upsert is a separate decision (not Phase 3 scope).
+    /// Both backends use `INSERT ... ON CONFLICT DO UPDATE` on
+    /// `(instance_id, checkpoint_id)`, refreshing `state` and `created_at`.
+    /// The save is idempotent by design: the engine replays from the start
+    /// and reads checkpoints as a result cache, so a resumed instance
+    /// re-saves keys it already wrote.
     fn sql_save_checkpoint() -> &'static str;
 
     /// SQL for `list_checkpoints` (binds: instance_id, checkpoint_id_filter,

--- a/crates/runtara-core/src/persistence/dialect/sqlite.rs
+++ b/crates/runtara-core/src/persistence/dialect/sqlite.rs
@@ -105,11 +105,17 @@ impl Dialect for SqliteDialect {
     }
 
     fn sql_save_checkpoint() -> &'static str {
-        // Plain INSERT (no ON CONFLICT) — preserves legacy SQLite semantics
-        // where a duplicate `(instance_id, checkpoint_id)` raises a UNIQUE
-        // violation. Unifying to upsert is a separate decision.
+        // Upsert, matching Postgres: the engine replays from the start and
+        // treats checkpoints as a result cache, so re-saving the same
+        // `(instance_id, checkpoint_id)` is the ordinary path on a resume,
+        // not a conflict. `excluded.created_at` is this statement's own
+        // CURRENT_TIMESTAMP, so the refreshed row still sorts newest-first
+        // under `sql_list_checkpoints`.
         "INSERT INTO checkpoints (instance_id, checkpoint_id, state, created_at) \
-         VALUES (?1, ?2, ?3, CURRENT_TIMESTAMP)"
+         VALUES (?1, ?2, ?3, CURRENT_TIMESTAMP) \
+         ON CONFLICT(instance_id, checkpoint_id) DO UPDATE SET \
+             state = excluded.state, \
+             created_at = excluded.created_at"
     }
 
     fn sql_list_checkpoints() -> &'static str {

--- a/crates/runtara-core/src/persistence/dialect/sqlite.rs
+++ b/crates/runtara-core/src/persistence/dialect/sqlite.rs
@@ -109,8 +109,11 @@ impl Dialect for SqliteDialect {
         // treats checkpoints as a result cache, so re-saving the same
         // `(instance_id, checkpoint_id)` is the ordinary path on a resume,
         // not a conflict. `excluded.created_at` is this statement's own
-        // CURRENT_TIMESTAMP, so the refreshed row still sorts newest-first
-        // under `sql_list_checkpoints`.
+        // CURRENT_TIMESTAMP rather than the stored row's, so a re-save
+        // advances the timestamp the way Postgres's `NOW()` does. Note it is
+        // only second-resolution here and `sql_list_checkpoints` orders on it
+        // with no tiebreaker, so rows written within the same second have no
+        // defined order between them.
         "INSERT INTO checkpoints (instance_id, checkpoint_id, state, created_at) \
          VALUES (?1, ?2, ?3, CURRENT_TIMESTAMP) \
          ON CONFLICT(instance_id, checkpoint_id) DO UPDATE SET \


### PR DESCRIPTION
## What changed

`SqliteDialect::sql_save_checkpoint` now upserts on `(instance_id, checkpoint_id)`, matching what `PostgresDialect` has always done. The conflict target already existed in the schema; no migration is needed.

The three comments documenting the divergence as a deliberate deferral are retired — they described behavior that no longer exists.

## Why

The engine is replay-from-start with checkpoints as a result cache, so re-saving the same `(instance_id, checkpoint_id)` is the *ordinary* path on a resume, not an edge case. Postgres upserted; SQLite ran a plain `INSERT` and tripped `UNIQUE(instance_id, checkpoint_id)`. The same operation was a silent no-op on one backend and a hard error on the other.

The reachable failure is on `/sleep`, which saves unconditionally before sleeping — exactly what a replayed `Delay` step does. `/checkpoint` masked the bug behind its read-through cache (it returns an existing checkpoint instead of re-saving), but its check-then-save is not atomic, so concurrent branches can still both reach the `INSERT`.

## Test

Pinned in the **cross-backend parity harness**, not beside the SQLite implementation. The harness saved `ckpt-1` exactly once, and the divergence only surfaces on a *second* save — which is why a purpose-built parity harness never caught it. It now re-saves the key and asserts the save succeeds, the state is refreshed, and exactly one row remains. That runs against SQLite on every `cargo test` and against Postgres under `db-integration-tests`.

## Verification

- New harness assertions **fail on the old SQL** with the ticket's exact error (`CheckpointSaveFailed { reason: "(code: 2067) UNIQUE constraint failed: checkpoints.instance_id, checkpoints.checkpoint_id" }`) and pass with the fix.
- `cargo test -p runtara-core --features db-integration-tests` — 176 passed, 0 failed, including the Postgres side of the harness against a real PostgreSQL 18.
- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- **Live, over real HTTP** against a standalone `runtara-core` on SQLite: two `/sleep` calls at the same `checkpoint_id`. Before: the second answers `503 SLEEP_ERROR ... UNIQUE constraint failed`. After: `200`, one row, refreshed state, no checkpoint errors in the log.

## Noted, not fixed here

- `SqlitePersistence::save_retry_attempt` writes to the same `checkpoints` table with its own inline plain `INSERT` while Postgres upserts — same class of divergence, different statement, not named by this ticket.
- The harness's testcontainers fallback pins `postgres:11-alpine`, which rejects core migration 9's `ALTER TYPE ... ADD VALUE` in a transaction. That path has been dead since the migration landed; CI never hits it because it sets `TEST_RUNTARA_DATABASE_URL`.

[SYN-614](https://linear.app/syncmyordershq/issue/SYN-614/sqlite-save-checkpoint-raises-a-unique-violation-where-postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)