### PR TITLE
SYN-615: Filter acknowledged signals out of the SQLite pending-signal read

### DIFF
--- a/crates/runtara-core/src/instance_handlers/signal.rs
+++ b/crates/runtara-core/src/instance_handlers/signal.rs
@@ -81,8 +81,10 @@ pub async fn handle_poll_signals(
 
 /// Handle signal acknowledgement (fire-and-forget).
 ///
-/// Marks a signal as acknowledged by the instance.
-/// If acknowledging a cancel signal, also updates instance status to cancelled.
+/// Applies the signal's status transition — a cancel ack also moves the
+/// instance to `cancelled` — and only then marks the signal acknowledged, so a
+/// transition that fails leaves the signal pending to be retried rather than
+/// consumed.
 #[instrument(skip(state, ack), fields(
     instance_id = %ack.instance_id,
     signal_type = ?ack.signal_type(),
@@ -95,12 +97,6 @@ pub async fn handle_signal_ack(state: &InstanceHandlerState, ack: SignalAck) -> 
     );
 
     if ack.acknowledged {
-        // Mark signal as acknowledged
-        state
-            .persistence
-            .acknowledge_signal(&ack.instance_id)
-            .await?;
-
         // Handle signal-specific side effects
         match ack.signal_type() {
             SignalType::SignalCancel => {
@@ -147,6 +143,19 @@ pub async fn handle_signal_ack(state: &InstanceHandlerState, ack: SignalAck) -> 
                 info!("Instance suspended for shutdown");
             }
         }
+
+        // Acknowledge last, once the status transition above has landed.
+        // Acknowledging first consumes the signal whether or not the
+        // transition succeeded, and callers log-and-continue on the error, so
+        // a transient database failure would leave an instance that was told
+        // to cancel recorded as a clean success: the guest's next poll would
+        // no longer see the signal, and the end-of-run cancel backstop would
+        // find nothing to enforce. Acking here instead leaves an unhandled
+        // signal pending, which is what both of those retry paths key on.
+        state
+            .persistence
+            .acknowledge_signal(&ack.instance_id)
+            .await?;
     } else {
         warn!("Signal was not acknowledged by instance");
     }
@@ -223,6 +232,38 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    /// A failed status transition must leave the signal pending. Consuming it
+    /// regardless would strand the instance: callers of this handler log the
+    /// error and continue, so nothing else would ever retry the cancel, and the
+    /// run would record as a clean success despite having been cancelled.
+    #[tokio::test]
+    async fn test_signal_ack_leaves_signal_pending_when_the_transition_fails() {
+        // No instance registered, so `complete_instance` fails with
+        // InstanceNotFound — the transition never lands.
+        let persistence =
+            Arc::new(MockPersistence::new().with_signal(make_signal("inst-1", "cancel")));
+        let state = InstanceHandlerState::new(persistence.clone());
+
+        let ack = SignalAck {
+            instance_id: "inst-1".to_string(),
+            signal_type: SignalType::SignalCancel as i32,
+            acknowledged: true,
+        };
+
+        handle_signal_ack(&state, ack)
+            .await
+            .expect_err("a failed status transition must surface as an error");
+
+        assert!(
+            persistence
+                .get_pending_signal("inst-1")
+                .await
+                .unwrap()
+                .is_some(),
+            "the signal must stay pending so the next poll and the cancel backstop can retry it"
         );
     }
 

--- a/crates/runtara-core/src/persistence/common/ops/parity_harness.rs
+++ b/crates/runtara-core/src/persistence/common/ops/parity_harness.rs
@@ -197,6 +197,31 @@ pub async fn run_parity_sequence<P: Persistence>(backend: &P) {
         .acknowledge_signal(&instance_id)
         .await
         .expect("acknowledge_signal failed");
+    // The ack consumes the signal on both backends: a second read must come
+    // back empty. Re-reading is the whole point — a guest acknowledges on read,
+    // and a redelivered cancel would re-suspend a relaunched instance on a
+    // signal it already handled.
+    assert!(
+        backend
+            .get_pending_signal(&instance_id)
+            .await
+            .expect("get_pending_signal after ack failed")
+            .is_none(),
+        "an acknowledged signal must not be delivered again"
+    );
+    // A genuinely new signal for the same instance is still delivered: the
+    // insert resets the acknowledgement.
+    backend
+        .insert_signal(&instance_id, "shutdown", b"drain")
+        .await
+        .expect("insert_signal after ack failed");
+    let reinserted = backend
+        .get_pending_signal(&instance_id)
+        .await
+        .expect("get_pending_signal after re-insert failed")
+        .expect("a freshly inserted signal must be pending again");
+    assert_eq!(reinserted.signal_type, "shutdown");
+    assert!(reinserted.acknowledged_at.is_none());
 
     // --- custom checkpoint signals -----------------------------------------
     let custom_payload = br#"{"wait-key":"payment"}"#.to_vec();

--- a/crates/runtara-core/src/persistence/common/ops/signals.rs
+++ b/crates/runtara-core/src/persistence/common/ops/signals.rs
@@ -12,12 +12,6 @@
 //!   cross-backend normalization beyond the three approved in the
 //!   SYN-394 plan, so the insert paths remain per-backend for now.
 //!
-//! Preserved divergence (documented on the Dialect SQL strings):
-//! - `get_pending_signal` on Postgres filters `acknowledged_at IS NULL`;
-//!   SQLite returns any row for the instance, including acknowledged
-//!   ones. This is a legacy SQLite bug that's explicitly out of scope
-//!   for this refactor; see `SqliteDialect::sql_get_pending_signal`.
-//!
 //! `take_pending_custom_signal` is a **non-destructive** read via
 //! `Dialect::sql_take_pending_custom_signal` (a plain SELECT on both
 //! backends). The row is retained so replay-from-start re-reads the same
@@ -26,8 +20,9 @@
 macro_rules! impl_signal_ops {
     ($Backend:ty, $Pool:ty, $Dialect:ty) => {
         impl $Backend {
-            /// SELECT the pending signal for an instance. Postgres filters
-            /// out acknowledged rows; SQLite does not (legacy divergence).
+            /// SELECT the pending signal for an instance. Both backends
+            /// filter out acknowledged rows, so a signal a guest already
+            /// consumed is not handed back on the next read.
             pub(crate) async fn op_get_pending_signal(
                 pool: &$Pool,
                 instance_id: &str,

--- a/crates/runtara-core/src/persistence/dialect/mod.rs
+++ b/crates/runtara-core/src/persistence/dialect/mod.rs
@@ -151,8 +151,11 @@ pub trait Dialect: Send + Sync + 'static {
     fn sql_count_checkpoints() -> &'static str;
 
     /// SQL for selecting the pending signal for an instance (bind:
-    /// instance_id). Postgres returns only unacknowledged signals;
-    /// SQLite returns any signal row (legacy behavior preserved).
+    /// instance_id). Both backends filter `acknowledged_at IS NULL`, so an
+    /// acknowledged signal is never handed back: the guest acknowledges on
+    /// read precisely so the signal is consumed once, and a redelivered
+    /// cancel/shutdown would re-suspend a relaunched instance on a signal it
+    /// already handled.
     fn sql_get_pending_signal() -> &'static str;
 
     /// SQL for acknowledging a pending signal (bind: instance_id).

--- a/crates/runtara-core/src/persistence/dialect/sqlite.rs
+++ b/crates/runtara-core/src/persistence/dialect/sqlite.rs
@@ -142,12 +142,9 @@ impl Dialect for SqliteDialect {
     }
 
     fn sql_get_pending_signal() -> &'static str {
-        // Legacy SQLite behavior: returns any row for the instance, including
-        // already-acknowledged ones. Postgres filters `acknowledged_at IS NULL`.
-        // Divergence preserved here and documented on the trait method.
         "SELECT instance_id, signal_type, payload, created_at, acknowledged_at \
          FROM pending_signals \
-         WHERE instance_id = ?1"
+         WHERE instance_id = ?1 AND acknowledged_at IS NULL"
     }
 
     fn sql_acknowledge_signal() -> &'static str {

--- a/crates/runtara-core/src/persistence/sqlite.rs
+++ b/crates/runtara-core/src/persistence/sqlite.rs
@@ -908,13 +908,26 @@ mod tests {
             .await
             .expect("Failed to acknowledge signal");
 
+        // An acknowledged signal is consumed: it must not be handed back, or a
+        // relaunched instance would re-suspend on a cancel it already handled.
+        let signal = persistence.get_pending_signal(&instance_id).await.unwrap();
+        assert!(signal.is_none(), "acknowledged signal must not be pending");
+
+        // A genuinely new signal for the same instance is still delivered —
+        // `insert_signal` resets `acknowledged_at` on conflict.
+        persistence
+            .insert_signal(&instance_id, "shutdown", b"drain")
+            .await
+            .unwrap();
+
         let signal = persistence
             .get_pending_signal(&instance_id)
             .await
             .unwrap()
-            .unwrap();
-
-        assert!(signal.acknowledged_at.is_some());
+            .expect("a freshly inserted signal must be pending again");
+        assert_eq!(signal.signal_type, "shutdown");
+        assert_eq!(signal.payload, Some(b"drain".to_vec()));
+        assert!(signal.acknowledged_at.is_none());
     }
 
     #[tokio::test]

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -285,10 +285,9 @@ fn has_on_signal_wake(wakes: &[runtara_component_host::lifecycle::WorkflowWake])
 /// was requested and demonstrably not honoured, and reporting clean success for
 /// it is the failure mode this exists to prevent.
 async fn enforce_unacked_cancel(persistence: &Arc<dyn Persistence>, instance_id: &str) {
-    // `acknowledged_at` must be checked explicitly: SQLite's `get_pending_signal`
-    // returns acknowledged rows too (Postgres filters them), so the row's mere
-    // presence would otherwise re-cancel a run whose guest handled the signal
-    // properly.
+    // Both backends already filter acknowledged rows, so this re-checks what the
+    // query guarantees: this backstop overwrites a terminal status, so a
+    // regression there must not re-cancel a run whose guest handled the signal.
     match persistence.get_pending_signal(instance_id).await {
         Ok(Some(signal)) if signal.signal_type == "cancel" && signal.acknowledged_at.is_none() => {
             warn!(
@@ -1032,10 +1031,10 @@ mod tests {
         );
     }
 
-    /// The regression the SQLite dialect invites. `get_pending_signal` returns
-    /// ALREADY-ACKNOWLEDGED rows there (Postgres filters them), so a backstop
-    /// keyed on the row's presence would re-cancel a run whose guest handled the
-    /// signal correctly and then finished.
+    /// A backstop keyed on the row's mere presence would re-cancel a run whose
+    /// guest handled the signal correctly and then finished. Pins both halves of
+    /// the defence: the query filters acknowledged rows, and the caller checks
+    /// `acknowledged_at` anyway.
     #[tokio::test]
     async fn an_acknowledged_cancel_does_not_re_cancel_a_finished_run() {
         let (persistence, _dir) = backstop_fixture().await;

--- a/crates/runtara-environment/src/runtime_host.rs
+++ b/crates/runtara-environment/src/runtime_host.rs
@@ -736,13 +736,12 @@ mod tests {
             host.is_cancelled().await.unwrap(),
             "pending cancel detected"
         );
-        // Server-side ack ran: status transitioned. (No pending-row assertion:
-        // SQLite's get_pending_signal returns acknowledged rows — the
-        // documented legacy divergence in ops/signals.rs; Postgres filters.)
+        // Server-side ack ran: status transitioned, and the signal is consumed.
         assert_eq!(
             p.get_instance(INSTANCE).await.unwrap().unwrap().status,
             "cancelled"
         );
+        assert!(p.get_pending_signal(INSTANCE).await.unwrap().is_none());
         // Local latch short-circuits without any new signal.
         assert!(host.is_cancelled().await.unwrap());
     }
@@ -755,8 +754,7 @@ mod tests {
         assert!(host.check_signals().await.unwrap(), "pause handled");
         let inst = p.get_instance(INSTANCE).await.unwrap().unwrap();
         assert_eq!(inst.status, "suspended");
-        // (No pending-row assertion — SQLite returns acknowledged rows; see
-        // the legacy divergence note in ops/signals.rs.)
+        assert!(p.get_pending_signal(INSTANCE).await.unwrap().is_none());
         // A pause is not a cancel.
         assert!(!host.is_cancelled().await.unwrap());
     }
@@ -1042,16 +1040,9 @@ mod tests {
         );
 
         // The signal is acknowledged, so nothing is left for the escalation to
-        // act on as the guest winds down through further host calls. (Checked
-        // via `acknowledged_at`, not row absence: SQLite returns acknowledged
-        // rows from `get_pending_signal` where Postgres filters them.)
-        let signal = p
-            .get_pending_signal(INSTANCE)
-            .await
-            .unwrap()
-            .expect("sqlite keeps the row after acknowledgement");
+        // act on as the guest winds down through further host calls.
         assert!(
-            signal.acknowledged_at.is_some(),
+            p.get_pending_signal(INSTANCE).await.unwrap().is_none(),
             "the guest's poll must have acknowledged the cancel"
         );
         host.heartbeat().await.unwrap();

--- a/crates/runtara-environment/src/wake_scheduler.rs
+++ b/crates/runtara-environment/src/wake_scheduler.rs
@@ -164,9 +164,9 @@ impl WakeScheduler {
     /// error would strand a healthy sleeper.
     async fn cancel_pending(&self, instance_id: &str) -> bool {
         match self.persistence.get_pending_signal(instance_id).await {
-            // `acknowledged_at` is checked explicitly because SQLite's query
-            // returns acknowledged rows as well as unacknowledged ones, unlike
-            // Postgres — presence alone would re-cancel an already-handled run.
+            // Both backends already filter acknowledged rows, so this re-checks
+            // what the query guarantees: waking is destructive enough that a
+            // regression there must not silently re-cancel a handled run.
             Ok(Some(signal)) => signal.signal_type == "cancel" && signal.acknowledged_at.is_none(),
             Ok(None) => false,
             Err(e) => {


### PR DESCRIPTION
## What changed

`SqliteDialect::sql_get_pending_signal` selected **any** row for the instance; Postgres filters `AND acknowledged_at IS NULL`. This adds that filter to SQLite, so the two backends now have one behavior rather than two.

## Why

The divergence was documented as "a legacy SQLite bug that's explicitly out of scope", but it is not inert. The embedded SDK backend (`runtara-sdk/src/backend/embedded.rs`) acknowledges the lifecycle signal *on read*, with the comment "otherwise a recovered instance would immediately re-suspend on the same stale signal". On SQLite the ack landed in the row but the SELECT ignored it, so every later read handed the same cancel/shutdown back — a relaunched instance re-suspended on a signal it had already handled.

A genuinely new signal for the same instance is still delivered: `insert_signal` resets `acknowledged_at` to `NULL` in its `ON CONFLICT DO UPDATE`, and `pending_signals` holds one row per instance.

Also cleaned up what the bug had leaked into the code: the trait/module docs describing the divergence as intentional, and the comments at the two call sites (`wake_scheduler::cancel_pending`, `runner::embedded::enforce_unacked_cancel`) that explained their `acknowledged_at.is_none()` guards as a SQLite workaround. Those guards are kept deliberately — both paths are destructive (waking, and overwriting a terminal status), so a re-check of what the query now guarantees is worth its cost.

## Second commit: acknowledge after the transition, not before

Surfaced by review of the first commit. `handle_signal_ack` acknowledged the signal *first* and applied the status transition second, with no transaction around the pair. Callers log-and-continue on the error (`PersistenceRuntimeHost::ack_signal`), so a transient failure on the transition consumed the signal and stranded the instance: cancel-latched but never recorded `cancelled`, with the guest's next poll seeing nothing and `enforce_unacked_cancel` finding nothing to enforce — the run reports a clean success for something the user cancelled.

The hole is pre-existing and always applied to Postgres. SQLite's redelivery of acknowledged rows happened to mask it by handing the cancel back on the next poll, so the first commit removes that accidental net — which makes fixing the source part of this change rather than a follow-up.

Acknowledging last means a failed transition leaves the signal pending, which is exactly what both retry paths key on. A duplicate ack is harmless: the transition is idempotent and the backstop already re-runs this handler.

## Tests

- `persistence/sqlite.rs::test_acknowledge_signal` asserted the buggy behavior (acks, re-reads, expects the row back). It now asserts the re-read is `None`, plus a second half proving a fresh insert is delivered again.
- The parity harness stopped at the ack and never re-read — which is exactly why this survived. It now re-reads after the ack and re-inserts, so the semantics are pinned on **both** backends.
- `runtime_host.rs::fresh_artifact_polls_and_the_host_does_not_also_escalate` asserted `acknowledged_at.is_some()` on a returned row; rewritten to assert the signal is no longer pending. Two neighbouring tests gain the pending-row assertion they previously had to skip.
- New `test_signal_ack_leaves_signal_pending_when_the_transition_fails` pins the ordering: it fails on the old ack-first code (verified by reverting the reorder) and passes on the new.

## How it was verified

- **Live, before and after**: the `runtara-core` binary on a real SQLite file over real HTTP — poll → ack → poll. Unpatched it returned `{"signal":{"signal_type":"cancel"}}` on the second poll (the bug); patched it returns `{}`, and a freshly inserted `shutdown` is still delivered.
- `cargo test -p runtara-core -p runtara-environment --lib` — 165 + 148 passing.
- Postgres side pinned against a live Postgres: `postgres_backend_passes_parity_sequence` and both `test_acknowledge_signal` tests pass with `--features db-integration-tests`.
- `cargo clippy --workspace --all-targets --features "<GATE_FEATURES>" -- -D warnings` clean (minus `embed-ui`, which needs the CI frontend artifact), plus `cargo fmt --check`.

No migration; no Postgres SQL changed.

Linear: https://linear.app/syncmyordershq/issue/SYN-615/sqlite-redelivers-an-acknowledged-signal-forever-so-a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
