### PR TITLE
SYN-616: Assert insert_event preserves the caller's created_at

### DIFF
--- a/crates/runtara-core/src/persistence/common/ops/postgres_conformance.rs
+++ b/crates/runtara-core/src/persistence/common/ops/postgres_conformance.rs
@@ -151,14 +151,20 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
     assert_eq!(record.checkpoint_id.as_deref(), Some(checkpoint_id));
 
     // --- events -------------------------------------------------------------
+    // Backdated deliberately. `created_at` is the emitter's observation time
+    // and must survive the round trip untouched; a backend that defaults the
+    // column to its own write time stamps this event five minutes late. An
+    // event created at `Utc::now()` would read back the same under either
+    // behaviour, so it could not tell them apart.
+    let emitted_at = Utc::now() - Duration::minutes(5);
     let event = EventRecord {
         id: None,
         instance_id: instance_id.clone(),
         event_type: "custom".to_string(),
         checkpoint_id: Some(checkpoint_id.to_string()),
         payload: Some(br#"{"note":"hello"}"#.to_vec()),
-        created_at: Utc::now(),
-        subtype: Some("parity-test".to_string()),
+        created_at: emitted_at,
+        subtype: Some("conformance-test".to_string()),
     };
     backend
         .insert_event(&event)
@@ -173,6 +179,19 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
     assert!(
         !events.is_empty(),
         "list_events must return the inserted event"
+    );
+
+    let stored = events
+        .iter()
+        .find(|e| e.subtype.as_deref() == Some("conformance-test"))
+        .expect("the inserted event must come back from list_events");
+    let drift_ms = (stored.created_at - emitted_at).num_milliseconds().abs();
+    assert!(
+        drift_ms < 1_000,
+        "insert_event must persist the caller's created_at: emitted {emitted_at}, \
+         stored {}, drift {drift_ms}ms — a backend defaulting the column to its \
+         own write time drifts by the full backdate",
+        stored.created_at
     );
 
     let event_count = backend

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -488,6 +488,15 @@ pub trait Persistence: Send + Sync {
         created_before: Option<DateTime<Utc>>,
     ) -> Result<i64, CoreError>;
 
+    /// Append an event to an instance's timeline.
+    ///
+    /// `event.created_at` is the time the emitter observed, and an
+    /// implementation must store it verbatim — never substituting its own
+    /// write time by defaulting the column. The debug views order events by
+    /// this column and derive every step duration from the delta between a
+    /// step's paired start and end events, so a receive-time stamp silently
+    /// reorders the timeline and rewrites every duration into the interval
+    /// between two writes.
     async fn insert_event(&self, event: &EventRecord) -> Result<(), CoreError>;
 
     async fn insert_signal(


### PR DESCRIPTION
## What changed

Two small additions to `runtara-core`'s persistence layer:

- `common/ops/postgres_conformance.rs` — the harness now backdates its event by five minutes and asserts the stored `created_at` comes back within a second of it.
- `persistence/mod.rs` — `Persistence::insert_event` gets a doc comment stating that `event.created_at` is the emitter's observation time and must be stored verbatim.

No behaviour change. This is a regression guard plus the contract it guards.

## Why

[SYN-616](https://linear.app/syncmyordershq/issue/SYN-616/sqlite-insert-event-discards-the-callers-created-at-rewriting-event) reported that `SqlitePersistence::insert_event` hardcoded `CURRENT_TIMESTAMP`, discarding the caller's `created_at` and rewriting event order and every step duration into receive time.

**That bug is unreachable.** The whole SQLite backend was deleted from `main` on 2026-08-28 (`89d5a445`), along with `SqliteDialect`, `migrations/sqlite/` and the sqlx `sqlite` feature. Postgres — the only backend left — already binds the caller's value at `postgres.rs:369` and was never affected.

What the ticket exposed and the removal did not address is that **nothing held the surviving backend to that contract**:

- the conformance harness inserted its event at `Utc::now()`, which round-trips identically whether the backend stores the caller's timestamp or defaults the column to its own write time — an oracle that cannot fail;
- the trait method had no documentation at all, so the requirement lived only in a comment on a neighbouring module.

The ticket's own test note calls this out: "a test using `Utc::now()` for both would pass either way and prove nothing."

## How it was verified

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean (exit 0). Using the full CI gate rather than `-p` scoping, per the note on SYN-607 that `-p` hides downstream crates and silently skips `required-features` targets.
- `cargo test -p runtara-core --features db-integration-tests` against a real Postgres — **126 passed, 0 failed**.
- **Failing-first proof.** Temporarily reverted the Postgres bind to `Utc::now()` and reran: the new assertion fails with `drift 300000ms` — the full backdate — then passes again once reverted. The oracle can fail, which is the point.

## Also worth knowing

Two sibling tickets under SYN-607 look obsolete for the same reason, and I've left detailed comments on both:

- **SYN-617** — its requested fix has actually already landed; both bullets of its Fix section are implemented in `postgres_conformance.rs`.
- **SYN-645** — the defect is unreachable; one small piece of the ask (a repeat `save_retry_attempt` call, still unasserted at `postgres_conformance.rs:365`) survives in reduced form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)