### PR TITLE
SYN-618: Remove the never-implemented error-history API and unreachable suspend parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,7 +4650,6 @@ version = "8.7.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
  "chrono",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/crates/runtara-core/Cargo.toml
+++ b/crates/runtara-core/Cargo.toml
@@ -32,7 +32,6 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki",
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-base64 = "0.22"
 
 # Error handling
 thiserror = "2"

--- a/crates/runtara-core/src/error.rs
+++ b/crates/runtara-core/src/error.rs
@@ -5,8 +5,6 @@
 //! Provides a unified error type that maps to RPC error responses,
 //! including structured error types with category, severity, and retry hints.
 
-#![allow(dead_code)] // Variants and methods used in tests and for future expansion
-
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/runtara-core/src/instance_handlers/checkpoint.rs
+++ b/crates/runtara-core/src/instance_handlers/checkpoint.rs
@@ -68,9 +68,6 @@ pub async fn handle_checkpoint(
             state: existing.state,
             pending_signal,
             custom_signal,
-            // error_history was dropped in core migration 017 — it was created,
-            // indexed and never written. Nothing populates last_error today.
-            last_error: None,
         });
     }
 
@@ -86,7 +83,6 @@ pub async fn handle_checkpoint(
             pending_signal: get_pending_signal(state.persistence.as_ref(), &request.instance_id)
                 .await,
             custom_signal: None,
-            last_error: None,
         });
     }
 
@@ -127,7 +123,6 @@ pub async fn handle_checkpoint(
         state: Vec::new(),
         pending_signal,
         custom_signal,
-        last_error: None,
     })
 }
 

--- a/crates/runtara-core/src/instance_handlers/event.rs
+++ b/crates/runtara-core/src/instance_handlers/event.rs
@@ -125,86 +125,33 @@ pub async fn handle_instance_event(
             }
         }
         InstanceEventType::EventSuspended => {
-            // Check if this is a suspended-with-sleep event (has sleep data in payload)
-            if let (false, Some(checkpoint_id)) = (event.payload.is_empty(), &event.checkpoint_id) {
-                if let Some(sleep_data) = parse_sleep_payload(&event.payload) {
-                    // Save checkpoint with state from payload
-                    state
-                        .persistence
-                        .save_checkpoint(&event.instance_id, checkpoint_id, &sleep_data.state)
-                        .await?;
+            // A suspend event carries no payload. This arm once sniffed a
+            // `{wake_at_ms, state}` sleep payload out of it, but that producer
+            // disappeared with the move to HTTP-only transport: durable sleep
+            // now goes through the dedicated sleep endpoint, which calls
+            // `set_instance_sleep` directly. Warn if a payload ever turns up so
+            // a stale out-of-tree client is loud rather than silently parking
+            // with no wake armed.
+            if !event.payload.is_empty() {
+                warn!(
+                    payload_len = event.payload.len(),
+                    checkpoint_id = ?event.checkpoint_id,
+                    "Suspend event carried a payload; ignoring it, no wake armed"
+                );
+            }
 
-                    // Update instance checkpoint reference
-                    state
-                        .persistence
-                        .update_instance_checkpoint(&event.instance_id, checkpoint_id)
-                        .await?;
-
-                    // Set sleep_until for wake scheduler
-                    if let Some(wake_at) = sleep_data.wake_at {
-                        state
-                            .persistence
-                            .set_instance_sleep(&event.instance_id, wake_at)
-                            .await?;
-                    }
-
-                    // Mark as suspended with termination_reason "sleeping".
-                    // Guard with `if_running()` to prevent race condition with
-                    // the PID monitor.
-                    let applied = state
-                        .persistence
-                        .complete_instance(
-                            CompleteInstanceParams::new(&event.instance_id, "suspended")
-                                .if_running()
-                                .with_termination("sleeping", None)
-                                .with_checkpoint(checkpoint_id),
-                        )
-                        .await?;
-
-                    if applied {
-                        info!(
-                            checkpoint_id = %checkpoint_id,
-                            wake_at = ?sleep_data.wake_at,
-                            "Instance sleeping until scheduled wake"
-                        );
-                    } else {
-                        warn!(
-                            checkpoint_id = %checkpoint_id,
-                            "Instance sleep event skipped (already in terminal state)"
-                        );
-                    }
-                } else {
-                    // Payload present but not valid sleep data — just suspend.
-                    // Guard with `if_running()` to prevent race condition with
-                    // the PID monitor.
-                    let applied = state
-                        .persistence
-                        .complete_instance(
-                            CompleteInstanceParams::new(&event.instance_id, "suspended")
-                                .if_running(),
-                        )
-                        .await?;
-                    if applied {
-                        info!("Instance suspended (with payload but no valid sleep data)");
-                    } else {
-                        warn!("Instance suspend event skipped (already in terminal state)");
-                    }
-                }
+            // Guard with `if_running()` to prevent race condition with the PID
+            // monitor.
+            let applied = state
+                .persistence
+                .complete_instance(
+                    CompleteInstanceParams::new(&event.instance_id, "suspended").if_running(),
+                )
+                .await?;
+            if applied {
+                info!("Instance suspended");
             } else {
-                // No payload or no checkpoint_id — simple suspend.
-                // Guard with `if_running()` to prevent race condition with the
-                // PID monitor.
-                let applied = state
-                    .persistence
-                    .complete_instance(
-                        CompleteInstanceParams::new(&event.instance_id, "suspended").if_running(),
-                    )
-                    .await?;
-                if applied {
-                    info!("Instance suspended");
-                } else {
-                    warn!("Instance suspend event skipped (already in terminal state)");
-                }
+                warn!("Instance suspend event skipped (already in terminal state)");
             }
         }
         InstanceEventType::EventCustom => {
@@ -264,36 +211,6 @@ pub async fn handle_retry_attempt(
     debug!("Retry attempt recorded");
 
     Ok(())
-}
-
-/// Parsed sleep data from a suspended event payload.
-struct SleepPayload {
-    wake_at: Option<DateTime<Utc>>,
-    state: Vec<u8>,
-}
-
-/// Parse sleep data from a suspended event payload.
-///
-/// The SDK sends JSON with:
-/// - `wake_at_ms`: Unix timestamp in milliseconds for when to wake
-/// - `state`: Base64-encoded checkpoint state
-fn parse_sleep_payload(payload: &[u8]) -> Option<SleepPayload> {
-    use base64::Engine;
-
-    // Try to parse as JSON
-    let json: serde_json::Value = serde_json::from_slice(payload).ok()?;
-
-    // Extract wake_at_ms
-    let wake_at_ms = json.get("wake_at_ms")?.as_i64()?;
-    let wake_at = DateTime::from_timestamp_millis(wake_at_ms);
-
-    // Extract and decode state
-    let state_b64 = json.get("state")?.as_str()?;
-    let state = base64::engine::general_purpose::STANDARD
-        .decode(state_b64)
-        .ok()?;
-
-    Some(SleepPayload { wake_at, state })
 }
 
 #[cfg(test)]
@@ -428,20 +345,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_event_suspended_with_sleep() {
-        use base64::Engine;
-
+    async fn test_handle_event_suspended_with_payload_arms_no_sleep() {
         let persistence = Arc::new(
             MockPersistence::new().with_instance(make_instance("inst-1", "tenant-1", "running")),
         );
         let state = InstanceHandlerState::new(persistence.clone());
 
-        // Create sleep payload like SDK does
-        let wake_at = chrono::Utc::now() + chrono::Duration::hours(1);
-        let checkpoint_state = b"test checkpoint state";
+        // The shape a stale out-of-tree client would still send. Nothing in the
+        // repo produces it, and nothing consumes it any more.
         let payload = serde_json::json!({
-            "wake_at_ms": wake_at.timestamp_millis(),
-            "state": base64::engine::general_purpose::STANDARD.encode(checkpoint_state),
+            "wake_at_ms": (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp_millis(),
+            "state": "dGVzdCBjaGVja3BvaW50IHN0YXRl",
         });
 
         let event = InstanceEvent {
@@ -456,55 +370,18 @@ mod tests {
         let result = handle_instance_event(&state, event).await.unwrap();
         assert!(result.success);
 
-        // Verify instance was suspended with sleep data
+        // Plain suspend: no wake armed, no "sleeping" termination, no
+        // checkpoint written out of the payload.
         let inst = persistence.get_instance("inst-1").await.unwrap().unwrap();
         assert_eq!(inst.status, "suspended");
-        assert_eq!(inst.termination_reason.as_deref(), Some("sleeping"));
-        assert_eq!(inst.checkpoint_id.as_deref(), Some("sleep-cp-1"));
-        assert!(inst.sleep_until.is_some());
-
-        // Verify checkpoint was saved
-        let cp = persistence
-            .load_checkpoint("inst-1", "sleep-cp-1")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(cp.state, checkpoint_state);
-    }
-
-    #[test]
-    fn test_parse_sleep_payload_valid() {
-        use base64::Engine;
-
-        let state = b"test state";
-        let wake_at_ms = 1750000000000i64; // Some future timestamp
-        let payload = serde_json::json!({
-            "wake_at_ms": wake_at_ms,
-            "state": base64::engine::general_purpose::STANDARD.encode(state),
-        });
-
-        let result = parse_sleep_payload(&payload.to_string().into_bytes());
-        assert!(result.is_some());
-
-        let sleep_data = result.unwrap();
-        assert_eq!(sleep_data.state, state);
-        assert!(sleep_data.wake_at.is_some());
-        assert_eq!(sleep_data.wake_at.unwrap().timestamp_millis(), wake_at_ms);
-    }
-
-    #[test]
-    fn test_parse_sleep_payload_invalid_json() {
-        let result = parse_sleep_payload(b"not json");
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_parse_sleep_payload_missing_fields() {
-        let payload = serde_json::json!({
-            "wake_at_ms": 1750000000000i64,
-            // missing "state"
-        });
-        let result = parse_sleep_payload(&payload.to_string().into_bytes());
-        assert!(result.is_none());
+        assert!(inst.sleep_until.is_none());
+        assert_ne!(inst.termination_reason.as_deref(), Some("sleeping"));
+        assert!(
+            persistence
+                .load_checkpoint("inst-1", "sleep-cp-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/runtara-core/src/instance_handlers/types.rs
+++ b/crates/runtara-core/src/instance_handlers/types.rs
@@ -135,15 +135,6 @@ pub struct CustomSignal {
     pub payload: Vec<u8>,
 }
 
-/// Error info returned with checkpoint responses.
-#[derive(Debug, Clone)]
-pub struct CheckpointErrorInfo {
-    /// Machine-readable error code.
-    pub code: String,
-    /// Human-readable error message.
-    pub message: String,
-}
-
 /// Checkpoint response.
 pub struct CheckpointResponse {
     /// True if checkpoint already existed (resume case).
@@ -154,8 +145,6 @@ pub struct CheckpointResponse {
     pub pending_signal: Option<Signal>,
     /// Pending checkpoint-scoped custom signal.
     pub custom_signal: Option<CustomSignal>,
-    /// Last error from a previous checkpoint attempt.
-    pub last_error: Option<CheckpointErrorInfo>,
 }
 
 /// Get checkpoint request (read-only lookup).

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -232,37 +232,6 @@ pub struct ListStepSummariesFilter {
     pub step_ids: Option<Vec<String>>,
 }
 
-/// Error history record for structured error tracking.
-#[derive(Debug, Clone, sqlx::FromRow)]
-pub struct ErrorHistoryRecord {
-    /// Database primary key.
-    pub id: i64,
-    /// Instance this error belongs to.
-    pub instance_id: String,
-    /// Checkpoint ID where error occurred (if applicable).
-    pub checkpoint_id: Option<String>,
-    /// Step ID where error occurred (if applicable).
-    pub step_id: Option<String>,
-    /// Machine-readable error code (e.g., "RATE_LIMITED").
-    pub error_code: String,
-    /// Human-readable error message.
-    pub error_message: String,
-    /// Error category (unknown, transient, permanent, business).
-    pub category: String,
-    /// Error severity (info, warning, error, critical).
-    pub severity: String,
-    /// Retry hint (unknown, retry_immediately, retry_with_backoff, retry_after, do_not_retry).
-    pub retry_hint: Option<String>,
-    /// Milliseconds for retry_after hint.
-    pub retry_after_ms: Option<i64>,
-    /// Additional context as JSON.
-    pub attributes: Option<serde_json::Value>,
-    /// Cause error ID for error chains.
-    pub cause_error_id: Option<i64>,
-    /// When the error was recorded.
-    pub created_at: DateTime<Utc>,
-}
-
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
@@ -640,52 +609,6 @@ pub trait Persistence: Send + Sync {
         instance_id: &str,
         filter: &ListStepSummariesFilter,
     ) -> Result<i64, CoreError>;
-
-    // ========================================================================
-    // Structured Error Tracking (optional - default implementations no-op)
-    // ========================================================================
-
-    /// Record a structured error in the error history table.
-    ///
-    /// Returns the error ID for chaining or reference.
-    #[allow(clippy::too_many_arguments)]
-    async fn record_error(
-        &self,
-        _instance_id: &str,
-        _checkpoint_id: Option<&str>,
-        _step_id: Option<&str>,
-        _error_code: &str,
-        _error_message: &str,
-        _category: &str,
-        _severity: &str,
-        _retry_hint: Option<&str>,
-        _retry_after_ms: Option<i64>,
-        _attributes: Option<&serde_json::Value>,
-        _cause_error_id: Option<i64>,
-    ) -> Result<i64, CoreError> {
-        // Default: no-op, return 0
-        Ok(0)
-    }
-
-    /// Get the most recent error for an instance.
-    async fn get_last_error(
-        &self,
-        _instance_id: &str,
-    ) -> Result<Option<ErrorHistoryRecord>, CoreError> {
-        // Default: no-op
-        Ok(None)
-    }
-
-    /// List errors for an instance.
-    async fn list_errors(
-        &self,
-        _instance_id: &str,
-        _limit: i64,
-        _offset: i64,
-    ) -> Result<Vec<ErrorHistoryRecord>, CoreError> {
-        // Default: empty list
-        Ok(vec![])
-    }
 
     // ========================================================================
     // Data Retention / Cleanup (optional - default implementations no-op)

--- a/crates/runtara-core/src/persistence/postgres.rs
+++ b/crates/runtara-core/src/persistence/postgres.rs
@@ -4,8 +4,6 @@
 //!
 //! Provides all durable storage access functions for instances, checkpoints, events, and signals.
 
-#![allow(dead_code)] // Fields and functions used in tests and by handlers
-
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/runtara-server/src/core_runtime/http_server.rs
+++ b/crates/runtara-server/src/core_runtime/http_server.rs
@@ -85,9 +85,6 @@ pub struct CheckpointResponse {
     /// Pending custom signal (WaitForSignal)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_signal: Option<CustomSignalInfo>,
-    /// Last error from a previous checkpoint attempt
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_error: Option<ErrorInfo>,
 }
 
 /// Signal information
@@ -104,13 +101,6 @@ pub struct CustomSignalInfo {
     pub checkpoint_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<String>,
-}
-
-/// Error information
-#[derive(Debug, Serialize)]
-pub struct ErrorInfo {
-    pub code: String,
-    pub message: String,
 }
 
 /// Poll signals response
@@ -370,11 +360,6 @@ async fn checkpoint_handler(
                 },
             });
 
-            let last_error = resp.last_error.map(|e| ErrorInfo {
-                code: e.code,
-                message: e.message,
-            });
-
             Json(CheckpointResponse {
                 found: resp.found,
                 state: if resp.state.is_empty() {
@@ -384,7 +369,6 @@ async fn checkpoint_handler(
                 },
                 signal,
                 custom_signal,
-                last_error,
             })
             .into_response()
         }

--- a/crates/runtara-server/tests/core_instance_api.rs
+++ b/crates/runtara-server/tests/core_instance_api.rs
@@ -190,3 +190,75 @@ async fn draining_refuses_new_instances_but_keeps_serving() {
 
     runtime.shutdown().await.expect("shutdown");
 }
+
+/// A suspend event that carries a payload parks the instance without arming a
+/// wake, and says so in the log.
+///
+/// The generic `/events` endpoint takes an arbitrary base64 payload, so an
+/// out-of-tree client can still post the `{wake_at_ms, state}` shape that core
+/// used to sniff for sleep data. Nothing in this repo produces it — durable
+/// sleep goes through `/sleep` — and core no longer parses it. The risk that
+/// buys is silence: a client that believes it armed a wake would park forever.
+///
+/// This runs through the real router rather than calling the handler directly,
+/// because the payload only reaches core by way of the endpoint's base64
+/// decode, and that seam is the part a unit test cannot see.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_suspend_event_with_a_sleep_payload_arms_no_wake() {
+    use base64::Engine;
+
+    let pool = test_pool().await;
+    let persistence: Arc<dyn Persistence> = Arc::new(PostgresPersistence::new(pool));
+    let tenant = format!("payload-suspend-{}", Uuid::new_v4());
+    let instance = format!("{tenant}-1");
+    let checkpoint = "sleep-cp-1";
+
+    let (runtime, addr) = start(persistence.clone(), 8).await;
+    assert_eq!(register(addr, &instance, &tenant).await, 200, "register");
+
+    let sleep_shape = json!({
+        "wake_at_ms": (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp_millis(),
+        "state": base64::engine::general_purpose::STANDARD.encode(b"test checkpoint state"),
+    })
+    .to_string();
+
+    let status = reqwest::Client::new()
+        .post(format!("http://{addr}/api/v1/instances/{instance}/events"))
+        .json(&json!({
+            "event_type": "suspended",
+            "checkpoint_id": checkpoint,
+            "payload": base64::engine::general_purpose::STANDARD.encode(&sleep_shape),
+        }))
+        .send()
+        .await
+        .expect("events request")
+        .status()
+        .as_u16();
+    assert_eq!(status, 200, "a payload-bearing suspend is still accepted");
+
+    let record = persistence
+        .get_instance(&instance)
+        .await
+        .expect("get_instance")
+        .expect("instance must exist");
+    assert_eq!(record.status, "suspended", "the instance still parks");
+    assert!(
+        record.sleep_until.is_none(),
+        "no wake may be armed from a payload core no longer parses"
+    );
+    assert_ne!(
+        record.termination_reason.as_deref(),
+        Some("sleeping"),
+        "parking is a plain suspend, not a durable sleep"
+    );
+    assert!(
+        persistence
+            .load_checkpoint(&instance, checkpoint)
+            .await
+            .expect("load_checkpoint")
+            .is_none(),
+        "no checkpoint may be reconstructed out of the payload"
+    );
+
+    runtime.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
Closes [SYN-618](https://linear.app/syncmyordershq/issue/SYN-618/dead-surface-in-runtara-core-never-implemented-error-history-api) (child of SYN-607, `runtara-core` cleanup).

Three pieces of dead surface in `runtara-core`, all pure subtraction — nothing gains behaviour.

## What changed

**1. The structured error-history API, which was born with no callers.**
`Persistence::record_error` / `get_last_error` / `list_errors` plus `ErrorHistoryRecord`. The only backend inherits the no-op defaults. The consumer half is equally dead: `CheckpointResponse.last_error` was hardcoded `None`, and the SDK's `CheckpointResp` has no such field to deserialize into. Because the wire field carried `skip_serializing_if = "Option::is_none"` and was always `None`, **the key has never appeared in a response body — removing it is not a wire break.** The tables behind it were already dropped by core migration `017`.

The in-band feature stays put: `ErrorCategory` / `ErrorSeverity` / `RetryHint` travel with the step result and are read by retry logic. That is precisely why the query-it-later half was never needed.

**2. `parse_sleep_payload`, which was unreachable.**
It sniffed a `{wake_at_ms, state}` shape out of a suspend event's payload. The producer disappeared with the move to HTTP-only transport — every `EventSuspended` construction in the tree now passes an empty payload, and durable sleep goes through the sleep endpoint and `set_instance_sleep` instead. The arm collapses to a plain suspend, keeping a `warn!` when a payload does arrive so a stale out-of-tree client posting to the generic `/events` endpoint is loud rather than silently parking with no wake armed. `base64` was left with no user in the crate and is dropped.

**3. Two `#![allow(dead_code)]` that suppressed nothing** (`error.rs`, `persistence/postgres.rs`).

Item 4 of the ticket (the orphaned 434-line `tests/common/mod.rs`) was already deleted in `10a369942`, so there was nothing left to do there.

## Behaviour note

A payload-bearing suspend that *would* have parsed previously armed a sleep; now it suspends without one. No in-repo producer exists, so this is a no-op in practice — but it is a real change for a hypothetical out-of-tree client, and the `warn!` is what makes that diagnosable instead of silent.

## How it was verified

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean, against a **green baseline captured on the same commit beforehand**, so the "removing both `allow(dead_code)` produces zero new warnings" claim is measured rather than inherited from the ticket.
- New unit test `test_handle_event_suspended_with_payload_arms_no_sleep`: a payload-bearing suspend parks the instance and arms no wake. It asserts the exact negation of the deleted `test_handle_event_suspended_with_sleep` on the same payload, so it is a genuine before/after regression test.
- New integration case `a_suspend_event_with_a_sleep_payload_arms_no_wake` in `core_instance_api.rs`, driving the same payload through the **real router against a real Postgres**. The unit test calls the handler directly and cannot see the endpoint's base64 decode; this covers that seam. All 3 tests in that file pass.
- The `warn!` was observed firing on a live `CoreRuntime` with a subscriber temporarily attached: `Suspend event carried a payload; ignoring it, no wake armed payload_len=67 checkpoint_id=Some("sleep-cp-1")`. The instrumentation was reverted and is not in this diff.
- Durable sleep runs through `handle_sleep` (untouched, 10 tests green), confirming it never depended on the deleted parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)