### PR TITLE
Give the runtime schema its own database in the test-server job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,11 +335,29 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ github.sha }}
 
+      # The service container creates only POSTGRES_DB. The runtime schema needs
+      # a database of its own — see the note on TEST_RUNTARA_DATABASE_URL below.
+      - name: Create the runtime-schema database
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -c 'CREATE DATABASE runtara_runtime_test;'
+
       - name: Run runtara-server tests
         # Explicit features include the Postgres and plaintext-Valkey suites;
         # both fail closed when their required services are unavailable.
         env:
           TEST_RUNTARA_SERVER_DATABASE_URL: postgres://postgres:postgres@localhost:5432/runtara_test
+          # tests/core_instance_api.rs drives CoreRuntime against the *runtime*
+          # schema, not the server one, so it reads this separate variable and
+          # panics without it.
+          #
+          # It must be its own database, not runtara_test. Both schemas track
+          # their state in the same `_sqlx_migrations` table, so a core migrator
+          # pointed at the server's database sees the server's rows as unknown
+          # versions and aborts with VersionMissing(20250101000000). Sharing is
+          # only safe for a consumer that runs no migrations of its own, which
+          # is why object-store can reuse runtara_test below and this cannot.
+          TEST_RUNTARA_DATABASE_URL: postgres://postgres:postgres@localhost:5432/runtara_runtime_test
           TEST_REPORTS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
           VALKEY_HOST: localhost
           VALKEY_PORT: "6379"


### PR DESCRIPTION
## What's broken

The `test-server` job has been failing on `main` since `e2eee0e1` ("Make runtara-core a transport-free library"), which added `crates/runtara-server/tests/core_instance_api.rs`. Both of its tests panic immediately:

```
db-integration-tests requires TEST_RUNTARA_DATABASE_URL: NotPresent
```

That test drives `CoreRuntime` against the **runtime** schema rather than the server one, so it reads `TEST_RUNTARA_DATABASE_URL`. The `test-server` job sets `TEST_RUNTARA_SERVER_DATABASE_URL`, `TEST_REPORTS_DATABASE_URL`, `VALKEY_HOST` and `VALKEY_PORT` — but never that one. The test file and the workflow were simply never connected.

Pre-existing and unrelated to any feature branch: `main` is green at `708f86ae` and red from the `e2eee0e1..45680867` batch onward.

## Why it needs its own database

The obvious one-line fix — pointing `TEST_RUNTARA_DATABASE_URL` at the existing `runtara_test` — does not work, and it fails in a way that only shows up in a full-suite run:

```
required core migrations must succeed: VersionMissing(20250101000000)
```

Both schemas record their state in the same `_sqlx_migrations` table. Once the server tests have migrated `runtara_test`, a core migrator aimed at that database reads the server's rows as unknown versions and aborts. So this PR creates a dedicated `runtara_runtime_test` and points the variable there.

Worth calling out because it is a trap: pointing both at one database **passes** if you run only the `core_instance_api` target, because nothing has applied the server migrations yet. It fails as soon as the job runs its targets in order, which is what CI does. The sharing that object-store does with `runtara_test` further down the same job is safe only because object-store adds no migrations of its own.

## How it was verified

Against a local Postgres, running what the job runs — `cargo test -p runtara-server --features db-integration-tests -- --test-threads=1`:

- **Separate databases (this PR): every target passes, 0 failed**, `core_instance_api` included.
- **One shared database: reproduces `VersionMissing(20250101000000)`.**
- **Neither variable set: reproduces the exact `NotPresent` panic CI reports.**

The workflow YAML parses and the new step lands in the right place in `test-server`.

Not covered locally: the `valkey-integration-tests` half of that job and the TLS-Valkey step, since no Valkey is running here. Those were passing in CI before this change and this PR does not touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)