### PR TITLE
Fix Postgres step duration wrapping every 60 seconds

### DIFF
--- a/crates/runtara-core/src/persistence/common/ops/step_summaries.rs
+++ b/crates/runtara-core/src/persistence/common/ops/step_summaries.rs
@@ -8,7 +8,7 @@
 //! `step_debug_end` events. Its SQL lives behind
 //! `Dialect::sql_list_step_summaries` / `sql_count_step_summaries` and
 //! leans on JSONB operators to reach into the payload blob plus
-//! `EXTRACT(MILLISECONDS ...)` for the paired duration.
+//! `Dialect::duration_ms` for the paired duration.
 //!
 //! The outer SELECT emits `inputs`, `outputs`, and `error` as TEXT via
 //! `(jsonb_expr)::text` rather than as JSONB, and the row-marshaling

--- a/crates/runtara-core/src/persistence/dialect/mod.rs
+++ b/crates/runtara-core/src/persistence/dialect/mod.rs
@@ -102,9 +102,13 @@ pub trait Dialect: Send + Sync + 'static {
     fn in_list(col: &str, count: usize, start_idx: usize) -> String;
 
     /// SQL expression returning milliseconds between two timestamp columns
-    /// (`a - b`): `EXTRACT(MILLISECONDS FROM ({a} - {b}))::bigint`. The
+    /// (`a - b`): `(EXTRACT(EPOCH FROM ({a} - {b})) * 1000)::bigint`. The
     /// `::bigint` cast is what makes the column decodable as `i64` —
     /// `EXTRACT` on its own yields `numeric`.
+    ///
+    /// Must measure the *whole* span: `EXTRACT(MILLISECONDS ...)` reads a
+    /// single interval field and therefore wraps every minute, so an
+    /// implementation may not use it.
     fn duration_ms(a: &str, b: &str) -> String;
 
     // --- Whole-SQL (for queries where fragment composition loses value) ----

--- a/crates/runtara-core/src/persistence/dialect/postgres.rs
+++ b/crates/runtara-core/src/persistence/dialect/postgres.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 SyncMyOrders Sp. z o.o.
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Postgres dialect: `$N` placeholders, enum type casts, JSONB operators,
-//! `ILIKE`, `ANY($1)` for batch `IN`, `EXTRACT(MILLISECONDS FROM ...)`.
+//! `ILIKE`, `ANY($1)` for batch `IN`, `EXTRACT(EPOCH FROM ...)`.
 
 use crate::error::CoreError;
 
@@ -63,7 +63,12 @@ impl Dialect for PostgresDialect {
     }
 
     fn duration_ms(a: &str, b: &str) -> String {
-        format!("EXTRACT(MILLISECONDS FROM ({a} - {b}))::bigint")
+        // EPOCH, not MILLISECONDS: on an `interval`, `EXTRACT(MILLISECONDS
+        // ...)` yields only the seconds *field* scaled to ms, so it wraps at
+        // one minute (90s -> 30000, 120s -> 0). EPOCH yields the whole span in
+        // seconds, so scaling it by 1000 is the only form correct for
+        // intervals longer than a minute.
+        format!("(EXTRACT(EPOCH FROM ({a} - {b})) * 1000)::bigint")
     }
 
     fn select_status_col() -> &'static str {
@@ -211,6 +216,7 @@ impl Dialect for PostgresDialect {
         // `inputs`/`outputs`/`error` are emitted as TEXT so the shared row
         // mapper can parse them with `serde_json::from_str`; the JSONB->TEXT
         // round-trip produces an equal `serde_json::Value`.
+        let paired_duration_ms = Self::duration_ms("ee.completed_at", "se.started_at");
         format!(
             "WITH se AS MATERIALIZED ( \
                 SELECT \
@@ -261,7 +267,7 @@ impl Dialect for PostgresDialect {
                     END as status, \
                     CASE \
                         WHEN ee.completed_at IS NOT NULL \
-                        THEN EXTRACT(MILLISECONDS FROM (ee.completed_at - se.started_at))::bigint \
+                        THEN {paired_duration_ms} \
                         ELSE NULL \
                     END as duration_ms \
                 FROM se LEFT JOIN ee \
@@ -402,10 +408,23 @@ mod tests {
     }
 
     #[test]
-    fn duration_ms_uses_extract() {
+    fn duration_ms_uses_extract_epoch() {
         assert_eq!(
             PostgresDialect::duration_ms("e.created_at", "s.created_at"),
-            "EXTRACT(MILLISECONDS FROM (e.created_at - s.created_at))::bigint"
+            "(EXTRACT(EPOCH FROM (e.created_at - s.created_at)) * 1000)::bigint"
         );
+    }
+
+    /// The step-summary CTE must derive its `duration_ms` column from the
+    /// helper rather than re-inlining the expression, so the two cannot drift
+    /// apart again.
+    #[test]
+    fn step_summary_sql_derives_duration_from_helper() {
+        let sql = PostgresDialect::sql_list_step_summaries("ASC");
+        assert!(sql.contains(&PostgresDialect::duration_ms(
+            "ee.completed_at",
+            "se.started_at"
+        )));
+        assert!(!sql.contains("EXTRACT(MILLISECONDS"));
     }
 }

--- a/crates/runtara-core/src/persistence/postgres.rs
+++ b/crates/runtara-core/src/persistence/postgres.rs
@@ -2437,10 +2437,10 @@ mod tests {
         assert_eq!(steps[0].status, StepSummaryStatus::Completed);
         assert!(steps[0].completed_at.is_some());
         assert!(steps[0].duration_ms.is_some());
-        // Stronger than a bare `is_some`: the duration is derived with
-        // `EXTRACT(MILLISECONDS FROM (completed_at - started_at))::bigint`, so
-        // assert it actually reflects the >= 20ms gap rather than merely being
-        // present.
+        // Stronger than a bare `is_some`: assert the value actually reflects
+        // the >= 20ms gap rather than merely being present. A sub-minute gap
+        // cannot distinguish a whole-span duration from a single-interval-field
+        // one — `test_list_step_summaries_duration_spans_minutes` covers that.
         assert!(steps[0].duration_ms.unwrap() >= 10);
         // The inputs come back through the JSONB -> TEXT round-trip in the
         // outer SELECT and must still parse to the value that was written.
@@ -2452,6 +2452,87 @@ mod tests {
         // A sequential step's end event carries no launch/settle pair.
         assert_eq!(steps[0].launched_at_ms, None);
         assert_eq!(steps[0].settled_at_ms, None);
+
+        cleanup_step_summary_instance(&pool, &instance_id).await;
+    }
+
+    /// A step longer than a minute must report its whole span.
+    ///
+    /// `EXTRACT(MILLISECONDS FROM interval)` returns only the interval's
+    /// seconds *field* scaled to milliseconds, so it wraps every 60 seconds: a
+    /// 90-second step reported 30000 and an exactly-N-minute step reported 0.
+    /// Sub-minute gaps — which is all the other tests in this family exercise —
+    /// pass under both the wrapping and the correct expression, so this test
+    /// needs a gap over a minute.
+    ///
+    /// `insert_event` persists the caller's `created_at` verbatim, so the gap
+    /// is constructed by backdating the start event rather than by sleeping.
+    #[tokio::test]
+    async fn test_list_step_summaries_duration_spans_minutes() {
+        let pool = test_pool().await;
+        let persistence = PostgresPersistence::new(pool.clone());
+
+        let instance_id = register_step_summary_instance(&persistence, "longdur").await;
+
+        let completed_at = Utc::now();
+        let started_at = completed_at - chrono::Duration::seconds(90);
+
+        persistence
+            .insert_event(&EventRecord {
+                id: None,
+                instance_id: instance_id.clone(),
+                event_type: "custom".to_string(),
+                checkpoint_id: None,
+                payload: Some(
+                    serde_json::to_vec(&serde_json::json!({
+                        "step_id": "slow-step",
+                        "step_type": "DurableSleep",
+                    }))
+                    .unwrap(),
+                ),
+                created_at: started_at,
+                subtype: Some("step_debug_start".to_string()),
+            })
+            .await
+            .unwrap();
+
+        persistence
+            .insert_event(&EventRecord {
+                id: None,
+                instance_id: instance_id.clone(),
+                event_type: "custom".to_string(),
+                checkpoint_id: None,
+                payload: Some(
+                    serde_json::to_vec(&serde_json::json!({
+                        "step_id": "slow-step",
+                        "outputs": {"slept": true},
+                    }))
+                    .unwrap(),
+                ),
+                created_at: completed_at,
+                subtype: Some("step_debug_end".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let filter = step_summary_filter(StepSummarySortOrder::Desc);
+
+        let steps = persistence
+            .list_step_summaries(&instance_id, &filter, 100, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].status, StepSummaryStatus::Completed);
+
+        // 90_000, not the 30_000 the wrapping expression produced. The bound is
+        // loose only to absorb the microsecond truncation in the timestamp
+        // round-trip, not a minute-sized wrap.
+        let duration_ms = steps[0].duration_ms.unwrap();
+        assert!(
+            (89_999..=90_001).contains(&duration_ms),
+            "expected ~90000ms for a 90s step, got {duration_ms}"
+        );
 
         cleanup_step_summary_instance(&pool, &instance_id).await;
     }


### PR DESCRIPTION
## The bug

`Dialect::duration_ms` (and a second, inlined copy inside the step-summary CTE) derived the `duration_ms` column with:

```sql
EXTRACT(MILLISECONDS FROM (completed_at - started_at))::bigint
```

On a Postgres `interval`, `EXTRACT(MILLISECONDS ...)` returns only the interval's seconds **field** scaled to milliseconds — not the total span. So the reported duration wraps every 60 seconds. Verified empirically against Postgres 18:

| interval | reported | correct |
|---|---|---|
| 90s | `30000` | `90000` |
| 120s | `0` | `120000` |
| 5min | `0` | `300000` |

Every step longer than a minute reports a wrapped `duration_ms` in the step-summary and timeline debug views, and a step of exactly N minutes reports `0`. Long-running and durable-sleep steps are hit hardest.

## The fix

`(EXTRACT(EPOCH FROM (a - b)) * 1000)::bigint` — the whole span, and the same form `runtara-environment`'s instance-duration query (`crates/runtara-environment/src/db.rs`) already uses.

The expression was written out twice (the helper, plus an inline copy in `sql_list_step_summaries`), which is how the two could have drifted apart. The CTE now interpolates `Self::duration_ms`, and a dialect unit test pins that it does — including that no `EXTRACT(MILLISECONDS` survives anywhere in the generated SQL.

## On the test

Existing coverage could not have caught this, and a naive test would not either:

- `persistence/postgres.rs` asserted `duration_ms >= 10` over a ~20ms gap — passes under both the broken and the correct expression.
- The dialect test asserted the generated SQL *string*, not its semantics.

A regression test needs a gap longer than 60 seconds. Rather than sleeping, the new test backdates the `step_debug_start` event's `created_at` by 90 seconds — `insert_event` persists the caller's `created_at` verbatim (pinned by the conformance assertion added in #199), so any interval can be constructed instantly — and asserts the reported duration is ~90000.

Confirmed it fails against the pre-fix expression:

```
thread '...::test_list_step_summaries_duration_spans_minutes' panicked:
expected ~90000ms for a 90s step, got 30000
```

## Verification

- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean.
- `cargo test -p runtara-core --features db-integration-tests` against a scratch DB on `runtara-dev-postgres` — 128 passed, 0 failed (scratch DB dropped afterwards).

## Context

Found during review of #199 (SYN-616), which added the `created_at` conformance assertion this test leans on. This duration bug is adjacent but separate and was not fixed there. Cleanup under SYN-607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)