### PR TITLE
Deflake the JWKS startup test by asserting the property, not the clock

### DIFF
--- a/crates/runtara-server/src/auth/jwks.rs
+++ b/crates/runtara-server/src/auth/jwks.rs
@@ -22,6 +22,10 @@ pub struct RetryPolicy {
     /// Minimum gap between refreshes triggered from the request path, so a cache miss storm
     /// cannot fan out one upstream fetch per request.
     pub miss_cooldown: Duration,
+    /// Hard bound on a single fetch. Startup makes exactly one, so this is also the whole
+    /// inline startup budget — the longest [`JwksCache::with_policy`] can take before it gives
+    /// up and hands retrying to the background refresher.
+    pub fetch_timeout: Duration,
 }
 
 impl Default for RetryPolicy {
@@ -31,6 +35,7 @@ impl Default for RetryPolicy {
             empty_retry_interval: Duration::from_secs(15),
             refresh_interval: Duration::from_secs(3600),
             miss_cooldown: Duration::from_secs(10),
+            fetch_timeout: Duration::from_secs(10),
         }
     }
 }
@@ -124,7 +129,7 @@ impl JwksCache {
         let response = self
             .client
             .get(&self.jwks_uri)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(self.policy.fetch_timeout)
             .send()
             .await
             .map_err(|e| format!("JWKS fetch failed: {e}"))?;

--- a/crates/runtara-server/tests/jwks_recovery.rs
+++ b/crates/runtara-server/tests/jwks_recovery.rs
@@ -47,6 +47,10 @@ fn fast_policy() -> RetryPolicy {
         empty_retry_interval: Duration::from_secs(300),
         refresh_interval: Duration::from_secs(300),
         miss_cooldown: Duration::from_millis(50),
+        // Well above the deliberate response delays these tests use, so it never truncates a
+        // fetch they expect to complete — but far below the production 10s, so a test that
+        // does hit a hung endpoint fails fast instead of stalling the suite.
+        fetch_timeout: Duration::from_secs(2),
     }
 }
 
@@ -102,19 +106,32 @@ async fn startup_does_not_block_on_an_unreachable_endpoint() {
     )
     .await;
 
-    let started = std::time::Instant::now();
+    let policy = RetryPolicy {
+        // Startup's whole inline budget is one fetch bounded by `fetch_timeout`. At a tenth of
+        // a second there are two orders of magnitude between "handed off" and the 10s ceiling
+        // below, so no amount of CPU contention can blur the two — measured against the
+        // production 10s the margin was 1.5x, and a loaded machine ate it.
+        fetch_timeout: Duration::from_millis(100),
+        // Park the refresher. It is not what this test measures, and its first retry landing
+        // mid-assertion would show up as an extra request in the count below.
+        initial_backoff: Duration::from_secs(60),
+        ..fast_policy()
+    };
+
     let cache = tokio::time::timeout(
-        Duration::from_secs(20),
-        JwksCache::with_policy(uri(&server), fast_policy()),
+        Duration::from_secs(10),
+        JwksCache::with_policy(uri(&server), policy),
     )
     .await
-    .expect("startup must not block on the JWKS endpoint");
+    .expect("startup blocked on the JWKS endpoint instead of handing off to the refresher");
 
     assert!(!cache.is_ready().await, "cache is empty, so report unready");
-    assert!(
-        started.elapsed() < Duration::from_secs(15),
-        "startup took {:?} — it is retrying inline again",
-        started.elapsed()
+    // The property the wall clock used to stand in for. Retrying inline is what stalls the
+    // bind, and it shows up here as extra requests however loaded the machine is.
+    assert_eq!(
+        request_count(&server).await,
+        1,
+        "startup makes exactly one attempt; retrying is the refresher's job"
     );
 }
 


### PR DESCRIPTION
## Description

`startup_does_not_block_on_an_unreachable_endpoint` in `crates/runtara-server/tests/jwks_recovery.rs` failed roughly two runs in three on a moderately loaded machine. Measured on `45680867` with no local modifications: **14.62s pass, 15.81s FAIL, 15.10s FAIL, 11.42s pass** — clustered right at the `started.elapsed() < Duration::from_secs(15)` assertion.

**The cause was not an inline retry loop.** `JwksCache::with_policy` makes exactly one attempt, as designed. It was a hardcoded `.timeout(Duration::from_secs(10))` inside `refresh()` that `RetryPolicy` had no knob for, so `fast_policy()` could not shrink it. That put a fixed **10s floor under a 15s assertion** — a 1.5x margin, which `reqwest::Client` setup plus contention from the sibling tests' RSA-2048 keygen ate routinely.

### What changed

**`src/auth/jwks.rs`** — `fetch_timeout` becomes a `RetryPolicy` field, defaulting to the same `Duration::from_secs(10)` that was hardcoded. Production behaviour is unchanged; the value just becomes reachable, which is what that struct exists for ("Grouped into one struct so tests can shrink every interval at once").

**`tests/jwks_recovery.rs`** — the test now:

- sets `fetch_timeout: 100ms`, putting two orders of magnitude between "handed off" and the outer ceiling (tightened 20s → 10s);
- parks the refresher with `initial_backoff: 60s` so its first retry cannot land mid-assertion and show up in the request count;
- replaces `started.elapsed() < 15s` with `request_count == 1` — the property the wall clock was standing in for. Retrying inline is the regression being guarded against, and it shows up as extra requests however loaded the machine is.

`fast_policy()` gets `fetch_timeout: 2s`: above every deliberate response delay in the file (max 300ms), so the other six tests are untouched, but low enough that no test can stall on a hung endpoint.

## Related Issue

Pre-existing flake, unrelated to any feature work. Found while verifying SYN-618 and deliberately left out of scope there.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

See "Semver note" below — the breaking-change box is ticked for the public-API technicality only; runtime behaviour is unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [x] My changes don't introduce new warnings

## Testing

**20 consecutive suite runs pass** — 11 during development and 9 on the final restored source, split between idle and under 2x-core CPU saturation (36 spinners on an 18-core machine). No drift: every run lands at ~0.8–0.97s.

**Suite wall-clock: 10.05s → 0.8s.** The flaky test was the whole 10s.

**Mutation-tested, so the new assertion is not vacuous.** Reintroducing the exact regression the test guards — a 3-attempt inline retry loop in `with_policy` — fails it deterministically:

```
test startup_does_not_block_on_an_unreachable_endpoint ... FAILED
  left: 3
 right: 1
test result: FAILED. 5 passed; 2 failed; finished in 0.77s
```

It now catches that in 0.77s instead of needing 30s of wall clock to notice, and `permanent_startup_failure_leaves_an_empty_cache_without_panicking` catches it too. Source restored afterwards; `cargo clippy -p runtara-server --all-targets` and `cargo fmt --check` clean.

## Additional Notes

**Semver note for reviewers:** `RetryPolicy` is public API (`runtara_server::auth::jwks::RetryPolicy`) and this crate publishes to crates.io, so adding a field is technically breaking for any downstream code constructing it as a struct literal without `..Default::default()`. There are no such callers in tree — `cargo clippy --all-targets` compiles every test target clean. Flagging it in case it matters for the next version bump.

The request-count assertion is safe against the mock server: wiremock records a request on arrival, *before* applying `set_delay`, so the hung 30s stub still registers its one attempt immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
