### PR TITLE
SYN-619: Park a durable Delay instead of blocking the host for its duration

### DIFF
--- a/crates/runtara-component-host/src/runtime_host.rs
+++ b/crates/runtara-component-host/src/runtime_host.rs
@@ -162,10 +162,21 @@ pub trait RuntimeHost: Send + Sync {
         state: Vec<u8>,
         ms: u64,
     ) -> Result<(), String>;
+    /// Milliseconds since the UNIX epoch, as the guest sees them.
+    ///
+    /// Defaults to the wall clock, which is what every production host uses. It
+    /// is a trait method rather than a free function so a harness standing in
+    /// for the wake scheduler can advance to a park's deadline instead of
+    /// waiting out real time: a resumed durable Delay compares `now-ms` against
+    /// its stored deadline to decide whether to continue or re-park, so without
+    /// a movable clock a park can only ever be observed re-parking.
+    fn now_ms(&self) -> Result<u64, String> {
+        wall_clock_now_ms()
+    }
 }
 
-/// Milliseconds since the UNIX epoch (the `now-ms` implementation).
-fn now_ms() -> Result<u64, String> {
+/// Milliseconds since the UNIX epoch (the default `now-ms` implementation).
+fn wall_clock_now_ms() -> Result<u64, String> {
     let elapsed = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|error| error.to_string())?;
@@ -300,8 +311,9 @@ pub fn add_runtime_to_linker(linker: &mut Linker<WorkflowState>) -> anyhow::Resu
 
     inst.func_wrap_async(
         "now-ms",
-        |_store: StoreContextMut<'_, WorkflowState>, (): ()| {
-            Box::new(async move { Ok((now_ms(),)) })
+        |mut store: StoreContextMut<'_, WorkflowState>, (): ()| {
+            let host = require_host(&mut store);
+            Box::new(async move { Ok((host?.now_ms(),)) })
         },
     )?;
 
@@ -397,7 +409,7 @@ mod tests {
 
     #[test]
     fn now_ms_is_epoch_scaled() {
-        let value = now_ms().expect("clock after epoch");
+        let value = wall_clock_now_ms().expect("clock after epoch");
         // 2020-01-01 in ms — sanity floor that catches unit mistakes
         // (seconds vs milliseconds) without pinning a wall clock.
         assert!(value > 1_577_836_800_000);

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -273,6 +273,70 @@ fn has_on_signal_wake(wakes: &[runtara_component_host::lifecycle::WorkflowWake])
     wakes.iter().any(|w| matches!(w, WorkflowWake::OnSignal(_)))
 }
 
+/// The checkpoint (signal) ids this park is waiting on, in wake order.
+fn on_signal_checkpoint_ids(
+    wakes: &[runtara_component_host::lifecycle::WorkflowWake],
+) -> Vec<&str> {
+    use runtara_component_host::lifecycle::WorkflowWake;
+    wakes
+        .iter()
+        .filter_map(|wake| match wake {
+            WorkflowWake::OnSignal(wait) => Some(wait.checkpoint_id.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Close the window between the guest's last signal poll and the `suspended`
+/// write above.
+///
+/// A signal delivered in that window is otherwise lost: `handle_send_custom_signal`
+/// inserts the row and calls `wake_suspended_on_signal`, which no-ops unless the
+/// instance is ALREADY `suspended` + `waiting_signal` — and at that moment it is
+/// still `running`. The park then completes, and for a wait with no timeout
+/// `sleep_until` stays NULL with no other wake path, so the instance is stranded
+/// forever with its signal sitting in the table.
+///
+/// Re-reading here, after the row is visible to the waker, closes it: if the
+/// signal is already present we self-wake by stamping `sleep_until = now`, which
+/// is exactly what the waker would have done. The read is non-destructive
+/// (`take_pending_custom_signal` retains the row, despite its name), so the
+/// replayed guest still observes the signal.
+///
+/// Returns true when it woke the instance.
+async fn wake_if_signal_already_arrived(
+    persistence: &dyn Persistence,
+    instance_id: &str,
+    wakes: &[runtara_component_host::lifecycle::WorkflowWake],
+) -> bool {
+    for checkpoint_id in on_signal_checkpoint_ids(wakes) {
+        match persistence
+            .take_pending_custom_signal(instance_id, checkpoint_id)
+            .await
+        {
+            Ok(Some(_)) => {
+                if let Err(e) = persistence
+                    .set_instance_sleep(instance_id, chrono::Utc::now())
+                    .await
+                {
+                    warn!(instance_id, error = %e, "Failed to self-wake after a signal raced the park");
+                    return false;
+                }
+                info!(
+                    instance_id,
+                    checkpoint_id, "Signal arrived while parking; woke the instance immediately"
+                );
+                return true;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(instance_id, error = %e, "Could not re-check for a signal that raced the park")
+            }
+        }
+    }
+    false
+}
+
 /// Park an invoke-shaped instance that returned `outcome::suspended` (the
 /// store-freeing durable-sleep / wait-for-signal paths). Stamps
 /// `status='suspended'`, plus `sleep_until=deadline` when there is a TIMED wake
@@ -388,6 +452,9 @@ async fn park_invoke_suspend(
         Err(e) => {
             warn!(instance_id, error = %e, "Failed to mark instance suspended after invoke suspend");
         }
+    }
+    if wake_if_signal_already_arrived(persistence, instance_id, wakes).await {
+        return;
     }
     let Some(deadline_ms) = deadline_ms else {
         // Deadline-less on-signal: parked as suspended; the waker relaunches it.
@@ -920,6 +987,80 @@ mod tests {
             inst.termination_reason.as_deref(),
             Some(WAITING_SIGNAL_TERMINATION),
             "the waker must be able to distinguish this park from a pause suspend"
+        );
+    }
+
+    #[cfg(feature = "db-integration-tests")]
+    #[tokio::test]
+    async fn park_self_wakes_when_the_signal_beat_the_suspend_write() {
+        // The lost-wakeup window: `handle_send_custom_signal` inserts the row and
+        // calls `wake_suspended_on_signal`, which no-ops while the instance is
+        // still `running` — which it is, right up until the write inside
+        // `park_invoke_suspend`. For a wait with NO timeout there is no other
+        // wake path, so without the re-check the instance would sit suspended
+        // forever with its signal already in the table.
+        let (persistence, instance_id) = running_instance().await;
+        persistence
+            .insert_custom_signal(&instance_id, "raced-sig", b"{}")
+            .await
+            .expect("insert signal");
+
+        park_invoke_suspend(
+            persistence.as_ref(),
+            &instance_id,
+            &[WorkflowWake::OnSignal(SignalWait {
+                checkpoint_id: "raced-sig".into(),
+                deadline_ms: None,
+            })],
+        )
+        .await;
+
+        let inst = persistence
+            .get_instance(&instance_id)
+            .await
+            .expect("get")
+            .expect("instance exists");
+        assert_eq!(inst.status, "suspended");
+        assert!(
+            inst.sleep_until.is_some(),
+            "a signal already present at park time must self-wake the instance, \
+             not strand it waiting for a waker that already ran"
+        );
+        // Non-destructive: the replayed guest still observes the signal.
+        assert!(
+            persistence
+                .take_pending_custom_signal(&instance_id, "raced-sig")
+                .await
+                .expect("read signal")
+                .is_some(),
+            "the self-wake must not consume the signal the replay needs"
+        );
+    }
+
+    #[cfg(feature = "db-integration-tests")]
+    #[tokio::test]
+    async fn park_leaves_sleep_unset_when_no_signal_has_arrived_yet() {
+        // The ordinary case must be untouched by the re-check above.
+        let (persistence, instance_id) = running_instance().await;
+        park_invoke_suspend(
+            persistence.as_ref(),
+            &instance_id,
+            &[WorkflowWake::OnSignal(SignalWait {
+                checkpoint_id: "quiet-sig".into(),
+                deadline_ms: None,
+            })],
+        )
+        .await;
+
+        let inst = persistence
+            .get_instance(&instance_id)
+            .await
+            .expect("get")
+            .expect("instance exists");
+        assert_eq!(inst.status, "suspended");
+        assert!(
+            inst.sleep_until.is_none(),
+            "with no signal present the waker remains the sole wake path"
         );
     }
 

--- a/crates/runtara-server/src/api/services/compilation.rs
+++ b/crates/runtara-server/src/api/services/compilation.rs
@@ -883,10 +883,9 @@ impl CompilationService {
             let mut result = runtara_workflows::direct_wasm::compile_direct_workflow_with_abi(
                 direct_input,
                 runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-                // Blocking durable-sleep (store-freeing suspend stays gated) and
                 // omit-runtime "requested" — the AgentCapabilities arm decides
-                // the effective shape.
-                false,
+                // the effective shape. Durable steps published as an agent block
+                // regardless: the capability invoke has no wake to park on.
                 true,
             )?;
             runtara_workflows::direct_wasm::compose_direct_workflow_with_extra_dirs(

--- a/crates/runtara-workflows/src/direct_wasm/compile.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile.rs
@@ -781,8 +781,7 @@ pub fn compile_direct_workflow_composed_with_binding(
         components_dir,
         binding,
         super::component::WorkflowAbi::CliRunHttp,
-        // Legacy axes keep the blocking durable-sleep path and the runtime import.
-        false,
+        // Legacy axes keep the runtime import.
         false,
     )
 }
@@ -795,7 +794,6 @@ pub fn compile_direct_workflow_composed_configured(
     components_dir: impl AsRef<Path>,
     binding: super::component::RuntimeBinding,
     abi: super::component::WorkflowAbi,
-    store_freeing_sleep: bool,
     omit_runtime: bool,
 ) -> Result<DirectCompilationResult, DirectCompileError> {
     // Mirror the inner path's export-id derivation so the re-emitted world
@@ -811,8 +809,7 @@ pub fn compile_direct_workflow_composed_configured(
         }
         _ => None,
     };
-    let mut result =
-        compile_direct_workflow_with_abi(input, abi, store_freeing_sleep, omit_runtime)?;
+    let mut result = compile_direct_workflow_with_abi(input, abi, omit_runtime)?;
     let agent_ids: Vec<String> = result
         .component_artifacts
         .agent_components
@@ -868,30 +865,7 @@ const DIRECT_COMPILE_STACK_SIZE: usize = 256 * 1024 * 1024;
 pub fn compile_direct_workflow(
     input: DirectCompilationInput,
 ) -> Result<DirectCompilationResult, DirectCompileError> {
-    compile_direct_workflow_with_abi(
-        input,
-        workflow_abi_from_env(),
-        store_freeing_sleep_from_env(),
-        omit_runtime_from_env(),
-    )
-}
-
-/// Store-freeing durable-sleep gate for production compiles, from
-/// `RUNTARA_DIRECT_STORE_FREEING_SLEEP`. Default (unset or anything but a
-/// truthy value): OFF — durable Delay blocks in the host, byte-identical to the
-/// legacy path. Set to `1`/`true` to opt a compile into the exit-and-reschedule
-/// lowering (only takes effect under the invoke export). See
-/// [`super::compile::core_imports::DirectCoreFunctionIndices::store_freeing_sleep`].
-fn store_freeing_sleep_from_env() -> bool {
-    store_freeing_sleep_from_raw(
-        std::env::var("RUNTARA_DIRECT_STORE_FREEING_SLEEP")
-            .ok()
-            .as_deref(),
-    )
-}
-
-fn store_freeing_sleep_from_raw(raw: Option<&str>) -> bool {
-    matches!(raw, Some("1") | Some("true"))
+    compile_direct_workflow_with_abi(input, workflow_abi_from_env(), omit_runtime_from_env())
 }
 
 /// Opt-in to dropping the `runtara:workflow-runtime/runtime` import for a PURE,
@@ -901,7 +875,14 @@ fn store_freeing_sleep_from_raw(raw: Option<&str>) -> bool {
 /// to let eligible workflows compile agent-shaped (zero runtime imports). This
 /// is the compile lever behind workflow-as-agent.
 fn omit_runtime_from_env() -> bool {
-    store_freeing_sleep_from_raw(std::env::var("RUNTARA_DIRECT_OMIT_RUNTIME").ok().as_deref())
+    omit_runtime_from_raw(std::env::var("RUNTARA_DIRECT_OMIT_RUNTIME").ok().as_deref())
+}
+
+/// Truthiness for [`omit_runtime_from_env`]. Deliberately its OWN parser rather
+/// than one shared with a neighbouring lever: a shared parser turns any change
+/// to one gate's semantics into a silent change to the other's.
+fn omit_runtime_from_raw(raw: Option<&str>) -> bool {
+    matches!(raw, Some("1") | Some("true"))
 }
 
 /// Export shape for production compiles, from `RUNTARA_DIRECT_WORKFLOW_ABI` —
@@ -939,7 +920,6 @@ fn workflow_abi_from_raw(raw: Option<&str>) -> super::component::WorkflowAbi {
 pub fn compile_direct_workflow_with_abi(
     input: DirectCompilationInput,
     abi: super::component::WorkflowAbi,
-    store_freeing_sleep: bool,
     omit_runtime: bool,
 ) -> Result<DirectCompilationResult, DirectCompileError> {
     let span = tracing::Span::current();
@@ -948,7 +928,7 @@ pub fn compile_direct_workflow_with_abi(
         .stack_size(DIRECT_COMPILE_STACK_SIZE)
         .spawn(move || {
             let _span = span.entered();
-            compile_direct_workflow_inner(input, abi, store_freeing_sleep, omit_runtime)
+            compile_direct_workflow_inner(input, abi, omit_runtime)
         })
         .map_err(DirectCompileError::Io)?;
     match handle.join() {
@@ -960,7 +940,6 @@ pub fn compile_direct_workflow_with_abi(
 fn compile_direct_workflow_inner(
     input: DirectCompilationInput,
     abi: super::component::WorkflowAbi,
-    store_freeing_sleep: bool,
     omit_runtime_requested: bool,
 ) -> Result<DirectCompilationResult, DirectCompileError> {
     // The agent catalog is supplied by the caller (the server passes the
@@ -1059,7 +1038,6 @@ fn compile_direct_workflow_inner(
         input.track_events,
         &input.workflow_id,
         abi,
-        store_freeing_sleep,
         omit_runtime,
         export_agent_id.as_deref(),
     )?;
@@ -1149,7 +1127,6 @@ fn emit_direct_artifact(
     track_events: bool,
     workflow_id: &str,
     abi: super::component::WorkflowAbi,
-    store_freeing_sleep: bool,
     omit_runtime: bool,
     export_agent_id: Option<&str>,
 ) -> Result<(Vec<u8>, std::collections::BTreeMap<String, u32>), DirectCompileError> {
@@ -1202,7 +1179,6 @@ fn emit_direct_artifact(
         track_events,
         workflow_id,
         abi,
-        store_freeing_sleep,
         omit_runtime,
         export_agent_id,
     )?;
@@ -1228,14 +1204,12 @@ fn emit_direct_component(
     track_events: bool,
     workflow_id: &str,
     abi: super::component::WorkflowAbi,
-    store_freeing_sleep: bool,
     omit_runtime: bool,
     export_agent_id: Option<&str>,
 ) -> Result<(Vec<u8>, std::collections::BTreeMap<String, u32>), DirectCompileError> {
     let core_config =
         DirectCoreConfig::new_with_workflow_id(manifest, manifest_json, track_events, workflow_id)?
             .with_abi(abi)
-            .with_store_freeing_sleep(store_freeing_sleep)
             .with_omit_runtime(omit_runtime);
     // Parallel-split instance pools: each
     // pooled agent contributes phantom world imports (`…-par<n>`) that the wac

--- a/crates/runtara-workflows/src/direct_wasm/compile/core_imports.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/core_imports.rs
@@ -162,7 +162,6 @@ impl DirectCoreImportIndices {
     pub(super) fn require_all(
         self,
         abi: crate::direct_wasm::component::WorkflowAbi,
-        store_freeing_sleep: bool,
         omit_runtime: bool,
         has_connections: bool,
     ) -> Result<DirectCoreFunctionIndices, DirectCompileError> {
@@ -170,7 +169,6 @@ impl DirectCoreImportIndices {
             require_import(self.stdlib_agent_error_info, "stdlib.agent-error-info")?;
         Ok(DirectCoreFunctionIndices {
             abi,
-            store_freeing_sleep,
             omit_runtime,
             connection_resolver_describe: require_connection_resolver(
                 self.connection_resolver_describe,
@@ -636,14 +634,6 @@ pub(super) struct DirectCoreFunctionIndices {
     /// the return convention at fail sites depends on it (tag under
     /// `wasi:cli/run`; result-area pointer under the invoke export).
     pub(super) abi: crate::direct_wasm::component::WorkflowAbi,
-    /// Opt-in gate for the store-freeing durable-sleep lowering. When false
-    /// (the default), a durable Delay blocks in the host on
-    /// `durable-sleep-checkpoint` — byte-identical to the legacy path. When
-    /// true AND `abi == InvokeHostImports`, the Delay checkpoints its deadline
-    /// and exits with `outcome::suspended(at(deadline))` so the host frees the
-    /// Store and reschedules a relaunch. Only meaningful under the invoke
-    /// export (the only shape whose success arm can carry a wake).
-    pub(super) store_freeing_sleep: bool,
     /// When true, the component imports no runtime; the terminal `complete`/
     /// `fail` are NOT lowered and the result travels solely via the invoke
     /// return value. Runtime index fields hold a poison sentinel and must never

--- a/crates/runtara-workflows/src/direct_wasm/compile/core_module.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/core_module.rs
@@ -46,11 +46,6 @@ pub(super) struct DirectCoreConfig {
     /// Top-level export shape (see `component::WorkflowAbi`). Defaults to the
     /// legacy `wasi:cli/run`; set via [`Self::with_abi`].
     pub(super) abi: crate::direct_wasm::component::WorkflowAbi,
-    /// Opt-in gate for the store-freeing durable-sleep lowering (see
-    /// [`DirectCoreFunctionIndices::store_freeing_sleep`]). Defaults to false —
-    /// the blocking, byte-preserved path — and is set via
-    /// [`Self::with_store_freeing_sleep`].
-    pub(super) store_freeing_sleep: bool,
     /// When true, the component imports no `runtara:workflow-runtime/runtime`,
     /// so the emitter must NOT lower any `runtime.*` call — the terminal
     /// `complete`/`fail` are dropped and the result travels solely in-band via
@@ -94,12 +89,6 @@ impl DirectCoreConfig {
         self
     }
 
-    /// Enable the store-freeing durable-sleep lowering (opt-in; default off).
-    pub(super) fn with_store_freeing_sleep(mut self, enabled: bool) -> Self {
-        self.store_freeing_sleep = enabled;
-        self
-    }
-
     /// Compile with no runtime import (agent-shaped; opt-in, default off).
     pub(super) fn with_omit_runtime(mut self, enabled: bool) -> Self {
         self.omit_runtime = enabled;
@@ -115,7 +104,6 @@ impl DirectCoreConfig {
         let variables_json = direct_core_variables_json(&manifest.graph.variables, workflow_id)?;
         Ok(Self {
             abi: crate::direct_wasm::component::WorkflowAbi::default(),
-            store_freeing_sleep: false,
             omit_runtime: false,
             run_plan: direct_run_plan(manifest)?,
             static_data: DirectCoreStaticData::new_with_child_workflows(
@@ -351,7 +339,6 @@ pub(super) fn emit_direct_core_module(
 
     let import_indices = import_indices.require_all(
         config.abi,
-        config.store_freeing_sleep,
         config.omit_runtime,
         config.static_data.has_connections(),
     )?;

--- a/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
@@ -21,8 +21,9 @@
 use wasm_encoder::{BlockType, Function as WasmFunction, Instruction};
 
 use super::abi::{
-    emit_entry_suspend_at, emit_retptr_error_or_step_fail, load_retptr_list, push_retptr_arg,
-    push_retptr_i64_load, push_segment_args, return_if_retptr_error, store_local_i64_at,
+    emit_entry_suspend_at, emit_retptr_error_or_step_fail, load_retptr_list,
+    push_i64_load_from_ptr, push_retptr_arg, push_retptr_i64_load, push_segment_args,
+    return_if_retptr_error, store_local_i64_at,
 };
 use super::checkpoint::{
     emit_check_signals_and_suspend, emit_checkpoint_lookup, emit_checkpoint_save,
@@ -56,6 +57,17 @@ use super::{
 /// it.
 const DIRECT_DURABLE_DELAY_PARK_THRESHOLD_MS: i64 = 30_000;
 
+/// Width of a park's checkpoint state: one `u64` absolute deadline.
+///
+/// A park's state is checked against this before it is trusted, because the
+/// blocking arm's key is the SAME key and core's `handle_sleep` saves a
+/// checkpoint under it with an EMPTY state. `get-checkpoint` reports that as
+/// `some([])` — a HIT — so a delay that blocked on one pass and parks on a
+/// later replay (its `durationMs` is a reference that resolved differently)
+/// would otherwise read the blocking arm's empty state as "already waited" and
+/// skip its wait entirely.
+const DIRECT_DELAY_DEADLINE_STATE_LEN: i32 = 8;
+
 /// Blocking durable sleep: the host holds the wasmtime Store and the tokio task
 /// for the whole duration on `durable-sleep-checkpoint`.
 ///
@@ -81,15 +93,22 @@ fn emit_blocking_durable_sleep(body: &mut WasmFunction, indices: &DirectCoreFunc
 
 /// Store-freeing park: checkpoint an absolute deadline and EXIT with
 /// `suspended(at(deadline))`, so the host tears down the Store and the wake
-/// scheduler relaunches at the deadline. On resume the replay re-reaches this
-/// delay, the checkpoint HITS, and the wait is skipped. The DEADLINE is stored,
-/// not the remaining duration, so a resume never re-sleeps time that already
-/// elapsed.
+/// scheduler relaunches at the deadline. The DEADLINE is stored, not the
+/// remaining duration, so a resume never re-sleeps time that already elapsed.
 ///
-/// The looked-up value (the stored deadline bytes) is DISCARDED on a HIT —
-/// routed into wait-only scratch locals rather than the step output locals, so
-/// the parking and blocking arms leave identical state behind (deadline bytes
-/// must never be observable as a step output, however the delay is followed).
+/// A HIT does NOT mean the wait is over — it means a deadline was recorded. The
+/// guest re-reads it and compares against `now`, because the wake scheduler is
+/// not the only thing that can relaunch a parked instance: `handle_resume_instance`
+/// accepts any row whose status is `suspended`, with no `termination_reason`
+/// filter, so an operator (or the MCP `resume_execution` tool) resuming a
+/// workflow parked on a 24-hour Delay reaches this code early. Treating the
+/// checkpoint's mere existence as "already waited" would make that resume skip
+/// the entire delay.
+///
+/// The deadline bytes are routed into wait-only scratch locals rather than the
+/// step output locals, so the parking and blocking arms leave identical state
+/// behind — the deadline must never be observable as a step output, however the
+/// delay is followed.
 fn emit_park_until_deadline(
     body: &mut WasmFunction,
     indices: &DirectCoreFunctionIndices,
@@ -104,9 +123,56 @@ fn emit_park_until_deadline(
         DIRECT_WAIT_ON_WAIT_VARIABLES_PTR_LOCAL,
         DIRECT_WAIT_ON_WAIT_VARIABLES_LEN_LOCAL,
     );
-    // HIT: the host already waited — fall through, skip the sleep.
+    // A HIT of exactly one u64 is a deadline THIS arm wrote: re-read it and
+    // decide. Any other width is core's `handle_sleep` checkpoint, saved under
+    // this same key with an EMPTY state when the blocking arm ran — which means
+    // the wait was already served on that pass, so falling through is the
+    // correct resume. (It must be a fall-through, not a re-park: `handle_checkpoint`
+    // is get-or-SET, so a save under an occupied key is a no-op and a re-park
+    // would never persist its deadline — it would park again on every relaunch,
+    // forever.)
+    body.instruction(&Instruction::LocalGet(
+        DIRECT_WAIT_ON_WAIT_VARIABLES_LEN_LOCAL,
+    ));
+    body.instruction(&Instruction::I32Const(DIRECT_DELAY_DEADLINE_STATE_LEN));
+    body.instruction(&Instruction::I32Eq);
+    body.instruction(&Instruction::If(BlockType::Empty));
+    push_i64_load_from_ptr(body, DIRECT_WAIT_ON_WAIT_VARIABLES_PTR_LOCAL);
+    body.instruction(&Instruction::LocalSet(DIRECT_WAIT_DEADLINE_MS_LOCAL));
+    push_retptr_arg(body);
+    body.instruction(&Instruction::Call(indices.runtime_now_ms));
+    return_if_retptr_error(body, indices);
+    push_retptr_i64_load(body, DIRECT_RET_U64_OK_OFFSET);
+    body.instruction(&Instruction::LocalGet(DIRECT_WAIT_DEADLINE_MS_LOCAL));
+    // Unsigned: both sides are u64 epoch milliseconds.
+    body.instruction(&Instruction::I64LtU);
+    body.instruction(&Instruction::If(BlockType::Empty));
+    // Woken early — re-park on the SAME absolute deadline. The wait is not
+    // shortened by having been relaunched, and nothing is re-saved: the
+    // deadline is already durable.
+    emit_entry_suspend_at(body, DIRECT_WAIT_DEADLINE_MS_LOCAL);
+    body.instruction(&Instruction::End);
+    body.instruction(&Instruction::End);
+    // The wait is over. Poll before falling through — the same reasoning as the
+    // blocking arm: this replay reached the delay through a checkpoint HIT, so
+    // there is no `emit_checkpoint_save` here to fold signal handling into, and
+    // without an explicit poll a woken chain of delays would run its remaining
+    // steps having never looked for the cancel that arrived while it was parked.
+    emit_check_signals_and_suspend(body, indices);
     body.instruction(&Instruction::Else);
-    // MISS: deadline = now + duration; checkpoint it; suspend.
+    // MISS: first reach of this delay.
+    emit_park_fresh(body, indices, output_ptr_local, output_len_local);
+    body.instruction(&Instruction::End);
+}
+
+/// Compute `now + duration`, checkpoint it as this delay's deadline, and exit
+/// `suspended(at(deadline))`. Never returns to the caller's flow.
+fn emit_park_fresh(
+    body: &mut WasmFunction,
+    indices: &DirectCoreFunctionIndices,
+    output_ptr_local: u32,
+    output_len_local: u32,
+) {
     push_retptr_arg(body);
     body.instruction(&Instruction::Call(indices.runtime_now_ms));
     return_if_retptr_error(body, indices);
@@ -121,7 +187,7 @@ fn emit_park_until_deadline(
     );
     body.instruction(&Instruction::I32Const(DIRECT_WAIT_DEADLINE_SCRATCH_OFFSET));
     body.instruction(&Instruction::LocalSet(output_ptr_local));
-    body.instruction(&Instruction::I32Const(8));
+    body.instruction(&Instruction::I32Const(DIRECT_DELAY_DEADLINE_STATE_LEN));
     body.instruction(&Instruction::LocalSet(output_len_local));
     emit_checkpoint_save(
         body,
@@ -132,7 +198,6 @@ fn emit_park_until_deadline(
         output_len_local,
     );
     emit_entry_suspend_at(body, DIRECT_WAIT_DEADLINE_MS_LOCAL);
-    body.instruction(&Instruction::End);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
@@ -4,12 +4,21 @@
 //!
 //! A thin step whose only real choice is durable vs. blocking sleep. The duration
 //! is computed in the stdlib (`stdlib_delay_duration_ms`) from the resolved
-//! source; a durable delay sleeps via `runtime_durable_sleep_checkpoint` keyed by
-//! step id so a resumed instance skips an already-elapsed sleep, a non-durable one
-//! blocks. Everything else is the usual build-output / rebuild-source /
-//! continue-to-next tail.
+//! source; a non-durable delay always blocks.
+//!
+//! A durable delay under the invoke export PARKS: it checkpoints an absolute
+//! deadline and exits with `outcome::suspended(at(deadline))`, so the host frees
+//! the wasmtime Store and the wake scheduler relaunches at the deadline —
+//! instead of pinning a Store and a tokio task for the whole wait. Short delays
+//! still block, chosen against [`DIRECT_DURABLE_DELAY_PARK_THRESHOLD_MS`] at
+//! RUNTIME rather than compile time, because `durationMs` may be a reference the
+//! emitter cannot resolve. Both arms are therefore emitted into every durable
+//! delay under that export.
+//!
+//! Everything else is the usual build-output / rebuild-source / continue-to-next
+//! tail.
 
-use wasm_encoder::{Function as WasmFunction, Instruction};
+use wasm_encoder::{BlockType, Function as WasmFunction, Instruction};
 
 use super::abi::{
     emit_entry_suspend_at, emit_retptr_error_or_step_fail, load_retptr_list, push_retptr_arg,
@@ -28,6 +37,103 @@ use super::{
     DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL, DirectCoreFunctionIndices, DirectCoreStaticData,
     DirectDataSegment, DirectFailureTarget, DirectHandledTarget, DirectRunPlan, DirectVariables,
 };
+
+/// Durable-delay park threshold, in milliseconds: at or above it a delay frees
+/// the Store and reschedules, below it the delay blocks in the host.
+///
+/// Parking is not free. It costs a checkpoint write, a Store teardown, up to one
+/// wake-scheduler poll interval of lag (5s by default), and a relaunch that
+/// REPLAYS the workflow from its entry step — so every already-completed step
+/// pays a checkpoint lookup to skip itself, making the cost grow with how deep
+/// the delay sits in the graph. Blocking costs one pinned Store for the
+/// duration.
+///
+/// 30s sits comfortably above the poll interval, which is what makes the trade
+/// work: scheduler lag stays a small fraction of the wait rather than dwarfing
+/// it, and a sub-second pause inside a While loop keeps blocking instead of
+/// parking and replaying on every iteration. Delays long enough to matter — the
+/// hours-long business waits that pinned a Store for hours — are all far above
+/// it.
+const DIRECT_DURABLE_DELAY_PARK_THRESHOLD_MS: i64 = 30_000;
+
+/// Blocking durable sleep: the host holds the wasmtime Store and the tokio task
+/// for the whole duration on `durable-sleep-checkpoint`.
+///
+/// The host saves the sleep checkpoint but does NOT look one up, so a replayed
+/// blocking delay sleeps again — bounded by the park threshold, which is why the
+/// threshold has to stay small enough for a re-slept delay to be cheap.
+fn emit_blocking_durable_sleep(body: &mut WasmFunction, indices: &DirectCoreFunctionIndices) {
+    body.instruction(&Instruction::LocalGet(DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL));
+    body.instruction(&Instruction::LocalGet(DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL));
+    body.instruction(&Instruction::I32Const(0));
+    body.instruction(&Instruction::I32Const(0));
+    body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));
+    push_retptr_arg(body);
+    body.instruction(&Instruction::Call(indices.runtime_durable_sleep_checkpoint));
+    return_if_retptr_error(body, indices);
+    // The sleep writes no checkpoint on the GUEST side, so it has no
+    // `emit_checkpoint_save` to fold signal handling into. Poll explicitly:
+    // without this a cancel that arrived mid-sleep is never observed, and a
+    // chain of delays has no poll site at all — the run ignores the cancel and
+    // finishes normally.
+    emit_check_signals_and_suspend(body, indices);
+}
+
+/// Store-freeing park: checkpoint an absolute deadline and EXIT with
+/// `suspended(at(deadline))`, so the host tears down the Store and the wake
+/// scheduler relaunches at the deadline. On resume the replay re-reaches this
+/// delay, the checkpoint HITS, and the wait is skipped. The DEADLINE is stored,
+/// not the remaining duration, so a resume never re-sleeps time that already
+/// elapsed.
+///
+/// The looked-up value (the stored deadline bytes) is DISCARDED on a HIT —
+/// routed into wait-only scratch locals rather than the step output locals, so
+/// the parking and blocking arms leave identical state behind (deadline bytes
+/// must never be observable as a step output, however the delay is followed).
+fn emit_park_until_deadline(
+    body: &mut WasmFunction,
+    indices: &DirectCoreFunctionIndices,
+    output_ptr_local: u32,
+    output_len_local: u32,
+) {
+    emit_checkpoint_lookup(
+        body,
+        indices,
+        DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL,
+        DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL,
+        DIRECT_WAIT_ON_WAIT_VARIABLES_PTR_LOCAL,
+        DIRECT_WAIT_ON_WAIT_VARIABLES_LEN_LOCAL,
+    );
+    // HIT: the host already waited — fall through, skip the sleep.
+    body.instruction(&Instruction::Else);
+    // MISS: deadline = now + duration; checkpoint it; suspend.
+    push_retptr_arg(body);
+    body.instruction(&Instruction::Call(indices.runtime_now_ms));
+    return_if_retptr_error(body, indices);
+    push_retptr_i64_load(body, DIRECT_RET_U64_OK_OFFSET);
+    body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));
+    body.instruction(&Instruction::I64Add);
+    body.instruction(&Instruction::LocalSet(DIRECT_WAIT_DEADLINE_MS_LOCAL));
+    store_local_i64_at(
+        body,
+        DIRECT_WAIT_DEADLINE_SCRATCH_OFFSET,
+        DIRECT_WAIT_DEADLINE_MS_LOCAL,
+    );
+    body.instruction(&Instruction::I32Const(DIRECT_WAIT_DEADLINE_SCRATCH_OFFSET));
+    body.instruction(&Instruction::LocalSet(output_ptr_local));
+    body.instruction(&Instruction::I32Const(8));
+    body.instruction(&Instruction::LocalSet(output_len_local));
+    emit_checkpoint_save(
+        body,
+        indices,
+        DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL,
+        DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL,
+        output_ptr_local,
+        output_len_local,
+    );
+    emit_entry_suspend_at(body, DIRECT_WAIT_DEADLINE_MS_LOCAL);
+    body.instruction(&Instruction::End);
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn emit_delay_plan(
@@ -129,81 +235,35 @@ pub(super) fn emit_delay_plan(
             DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL,
         );
 
-        // Store-freeing suspend is opt-in per the unify plan: the DEFAULT under
-        // both ABIs remains the legacy blocking `durable-sleep-checkpoint`, whose
-        // output is byte-preserved and battery-green. Only when the compile-time
-        // gate is set AND we're on the invoke export (whose `outcome::suspended`
-        // arm can carry a wake) do we exit-and-reschedule instead of blocking.
-        // Blocking is also the right call for short delays — suspend/relaunch
-        // would pessimize them — so a future threshold policy lives behind the
-        // same gate.
-        let store_freeing = indices.store_freeing_sleep
-            && indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
-        if !store_freeing {
-            // Legacy: block in the host on `durable-sleep-checkpoint`.
-            body.instruction(&Instruction::LocalGet(DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL));
-            body.instruction(&Instruction::LocalGet(DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL));
-            body.instruction(&Instruction::I32Const(0));
-            body.instruction(&Instruction::I32Const(0));
+        // Whether this artifact CAN park is a capability question, not a policy
+        // one: only the invoke export has a success arm (`outcome::suspended`)
+        // able to carry a wake. `wasi:cli/run` has none, and a workflow
+        // published as an agent runs its durable steps inside the parent's
+        // capability invoke — both must block.
+        let can_park = indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
+        if can_park {
+            // WHETHER to park is decided at runtime, not here: `durationMs` may
+            // be a reference (a template, an input field) that the emitter
+            // cannot resolve, so the same artifact must be able to block on one
+            // run and park on the next. Both arms are emitted and the guest
+            // picks between them from the resolved duration.
+            //
+            // Both arms key off the SAME sleep key computed above, so the choice
+            // is stable across a replay: the duration is recomputed from the
+            // same replayed data and lands on the same side of the threshold.
             body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));
-            push_retptr_arg(body);
-            body.instruction(&Instruction::Call(indices.runtime_durable_sleep_checkpoint));
-            return_if_retptr_error(body, indices);
-            // The sleep blocks in the host and writes no checkpoint of its own,
-            // so it has no `emit_checkpoint_save` to fold signal handling into.
-            // Poll explicitly: without this a cancel that arrived mid-sleep is
-            // never observed, and a chain of delays has no poll site at all —
-            // the run ignores the cancel and finishes normally.
-            emit_check_signals_and_suspend(body, indices);
-        } else {
-            // Store-freeing suspend: the deadline is a durable checkpoint, and
-            // the run EXITS with `suspended(at(deadline))` so the host tears
-            // down the Store and reschedules a relaunch at the deadline. On
-            // resume the replay re-reaches this delay, the checkpoint HITS, and
-            // we skip. The deadline is stored, not the remaining duration, so a
-            // resume never re-sleeps time that already elapsed.
-            // The looked-up value (the stored deadline bytes) is DISCARDED on
-            // a HIT — route it into wait-only scratch locals instead of the
-            // step output locals so the blocking and store-freeing lowerings
-            // leave identical state (deadline bytes must never be observable
-            // as a step output, however the delay is followed).
-            emit_checkpoint_lookup(
-                body,
-                indices,
-                DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL,
-                DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL,
-                DIRECT_WAIT_ON_WAIT_VARIABLES_PTR_LOCAL,
-                DIRECT_WAIT_ON_WAIT_VARIABLES_LEN_LOCAL,
-            );
-            // HIT: the host already waited — fall through, skip the sleep.
+            body.instruction(&Instruction::I64Const(
+                DIRECT_DURABLE_DELAY_PARK_THRESHOLD_MS,
+            ));
+            // Unsigned: the duration is a u64 carried in an i64 local.
+            body.instruction(&Instruction::I64GeU);
+            body.instruction(&Instruction::If(BlockType::Empty));
+            emit_park_until_deadline(body, indices, output_ptr_local, output_len_local);
             body.instruction(&Instruction::Else);
-            // MISS: deadline = now + duration; checkpoint it; suspend.
-            push_retptr_arg(body);
-            body.instruction(&Instruction::Call(indices.runtime_now_ms));
-            return_if_retptr_error(body, indices);
-            push_retptr_i64_load(body, DIRECT_RET_U64_OK_OFFSET);
-            body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));
-            body.instruction(&Instruction::I64Add);
-            body.instruction(&Instruction::LocalSet(DIRECT_WAIT_DEADLINE_MS_LOCAL));
-            store_local_i64_at(
-                body,
-                DIRECT_WAIT_DEADLINE_SCRATCH_OFFSET,
-                DIRECT_WAIT_DEADLINE_MS_LOCAL,
-            );
-            body.instruction(&Instruction::I32Const(DIRECT_WAIT_DEADLINE_SCRATCH_OFFSET));
-            body.instruction(&Instruction::LocalSet(output_ptr_local));
-            body.instruction(&Instruction::I32Const(8));
-            body.instruction(&Instruction::LocalSet(output_len_local));
-            emit_checkpoint_save(
-                body,
-                indices,
-                DIRECT_WAIT_SIGNAL_ID_PTR_LOCAL,
-                DIRECT_WAIT_SIGNAL_ID_LEN_LOCAL,
-                output_ptr_local,
-                output_len_local,
-            );
-            emit_entry_suspend_at(body, DIRECT_WAIT_DEADLINE_MS_LOCAL);
+            emit_blocking_durable_sleep(body, indices);
             body.instruction(&Instruction::End);
+        } else {
+            emit_blocking_durable_sleep(body, indices);
         }
     } else {
         body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));

--- a/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
@@ -10715,6 +10715,20 @@ fn workflow_abi_env_lever_defaults_invoke() {
 }
 
 #[test]
+fn omit_runtime_env_lever_defaults_off() {
+    // Workflow-as-agent's compile lever: opt-in, truthy-only. This parser used
+    // to be shared with the store-freeing durable-sleep gate, which meant a
+    // change to one gate's semantics silently moved the other; it now stands
+    // alone precisely so that cannot happen again.
+    assert!(!super::omit_runtime_from_raw(None));
+    assert!(!super::omit_runtime_from_raw(Some("")));
+    assert!(!super::omit_runtime_from_raw(Some("0")));
+    assert!(!super::omit_runtime_from_raw(Some("yes")));
+    assert!(super::omit_runtime_from_raw(Some("1")));
+    assert!(super::omit_runtime_from_raw(Some("true")));
+}
+
+#[test]
 fn generated_workflow_slugs_are_wit_valid_packages() {
     // The slug plan allows leading digits (decision 3) on the premise that
     // wit-parser accepts digit-led words in

--- a/crates/runtara-workflows/src/direct_wasm/compile/wait.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/wait.rs
@@ -139,12 +139,14 @@ pub(super) fn emit_ai_wait_tool_arm(
     body.instruction(&Instruction::Call(indices.runtime_heartbeat));
     return_if_retptr_error(body, indices);
 
-    // Store-freeing (gated; invoke export only): a human-in-the-loop AI tool
-    // wait has no timeout, so it suspends on-signal with NO deadline — the
-    // custom-signal waker is the sole wake path. Default stays the blocking
-    // poll loop (byte-preserved).
-    let store_freeing = indices.store_freeing_sleep
-        && indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
+    // Store-freeing, invoke export only: a human-in-the-loop AI tool wait has
+    // no timeout, so it suspends on-signal with NO deadline — the custom-signal
+    // waker is the sole wake path. The remaining condition is a CAPABILITY
+    // check, not a policy: `wasi:cli/run` has no success arm that can carry a
+    // wake, and a workflow published as an agent runs its durable steps inside
+    // the parent's capability invoke, so both must keep the blocking poll loop.
+    let store_freeing =
+        indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
     if store_freeing {
         emit_entry_suspend_on_signal(
             body,
@@ -458,15 +460,18 @@ pub(super) fn emit_wait_for_signal_plan(
         handled_target,
     );
 
-    // Store-freeing Wait (gated; invoke export only): after one poll MISS and
-    // the timeout check, EXIT with `suspended(on-signal{signal-id, deadline})`
+    // Store-freeing Wait, invoke export only: after one poll MISS and the
+    // timeout check, EXIT with `suspended(on-signal{signal-id, deadline})`
     // instead of blocking the Store for the poll interval. The host parks the
     // instance (sleep_until = timeout deadline, or NULL when there is none) and
     // the custom-signal waker relaunches it when the signal arrives; the replay
-    // re-polls the now-present signal and continues. Default stays the blocking
-    // poll loop — byte-preserved.
-    let store_freeing = indices.store_freeing_sleep
-        && indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
+    // re-polls the now-present signal and continues. No duration threshold
+    // applies here, unlike a Delay: a Wait is open-ended by construction — what
+    // would be blocked for is the poll interval, not a known wait — so parking
+    // is right however short that interval is. The ABI condition is a
+    // capability check (see the AI-tool wait above).
+    let store_freeing =
+        indices.abi == crate::direct_wasm::component::WorkflowAbi::InvokeHostImports;
     if store_freeing {
         emit_entry_suspend_on_signal(
             body,

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -1673,6 +1673,26 @@ fn execute_via_cli(wasm_path: &Path, env_pairs: &[(String, String)]) -> (bool, S
 /// spare, and bounds a lowering bug that parks in a loop.
 const INVOKE_MAX_RELAUNCHES: usize = 4;
 
+/// Longest a park's deadline may be from now before this axis refuses to wait it
+/// out. Battery fixtures use millisecond timeouts; anything beyond this is a
+/// fixture the harness cannot honour, and saying so beats stalling the suite.
+const INVOKE_MAX_PARK_WAIT: Duration = Duration::from_secs(5);
+
+/// The earliest wall-clock deadline across a park's wakes, if any is timed.
+fn earliest_timed_deadline_ms(
+    wakes: &[runtara_component_host::lifecycle::WorkflowWake],
+) -> Option<u64> {
+    use runtara_component_host::lifecycle::WorkflowWake;
+    wakes
+        .iter()
+        .filter_map(|wake| match wake {
+            WorkflowWake::At(ms) => Some(*ms),
+            WorkflowWake::OnSignal(wait) => wait.deadline_ms,
+            WorkflowWake::OnResume => None,
+        })
+        .min()
+}
+
 /// Whether the wake scheduler would relaunch a park carrying these wakes.
 ///
 /// Mirrors `park_invoke_suspend` in runtara-environment: a TIMED wake (`at`, or
@@ -1734,14 +1754,34 @@ fn execute_via_embedded_invoke(
                     input.clone(),
                 )
                 .await;
-            let relaunch = matches!(
-                &result.exit,
-                runtara_component_host::InvokeExit::Suspended(wakes)
-                    if scheduler_would_relaunch(wakes)
-            );
-            if !relaunch || attempt == INVOKE_MAX_RELAUNCHES {
+            let runtara_component_host::InvokeExit::Suspended(wakes) = &result.exit else {
+                break result;
+            };
+            if !scheduler_would_relaunch(wakes) {
                 break result;
             }
+            // Wait out the deadline before relaunching, exactly as the scheduler
+            // does. Relaunching early is not a shortcut: a park re-reads its own
+            // deadline and re-parks while it is still in the future, so an
+            // instant relaunch would burn the budget without making progress.
+            // Fixture deadlines are milliseconds, so this costs almost nothing.
+            if let Some(deadline_ms) = earliest_timed_deadline_ms(wakes) {
+                let remaining = deadline_ms.saturating_sub(now_ms());
+                assert!(
+                    remaining <= INVOKE_MAX_PARK_WAIT.as_millis() as u64,
+                    "fixture parked {remaining}ms out, past the {}ms this axis will wait — \
+                     the battery has no way to fast-forward that far",
+                    INVOKE_MAX_PARK_WAIT.as_millis()
+                );
+                if remaining > 0 {
+                    tokio::time::sleep(Duration::from_millis(remaining)).await;
+                }
+            }
+            assert!(
+                attempt < INVOKE_MAX_RELAUNCHES,
+                "run still parked after {INVOKE_MAX_RELAUNCHES} relaunches — a lowering \
+                 that parks in a loop must fail the suite, not read as a clean suspend"
+            );
             attempt += 1;
         }
     });
@@ -7109,6 +7149,12 @@ struct CheckpointingRuntimeHost {
     /// the wake-scheduler-side signal store. `poll_custom_signal` reads it
     /// non-destructively (a replayed wait re-reads the same signal).
     custom_signals: Mutex<HashMap<String, Vec<u8>>>,
+    /// Milliseconds added to the wall clock for every `now-ms` the guest asks
+    /// for. The wake-scheduler stand-in advances this to a park's deadline so a
+    /// 1-hour Delay can be woken without waiting an hour: a resumed park
+    /// compares `now-ms` against its stored deadline, so a stand-in that cannot
+    /// move the clock can only ever observe a re-park.
+    clock_offset_ms: Mutex<u64>,
     /// Fallback payload returned for ANY polled id — for the blocking control,
     /// whose deterministic signal id (workflow-id-scoped) isn't known ahead of
     /// the run.
@@ -7123,6 +7169,7 @@ impl CheckpointingRuntimeHost {
             completed: Mutex::new(None),
             sleeps: Mutex::new(Vec::new()),
             custom_signals: Mutex::new(HashMap::new()),
+            clock_offset_ms: Mutex::new(0),
             any_signal: Mutex::new(None),
         }
     }
@@ -7132,6 +7179,15 @@ impl CheckpointingRuntimeHost {
             .lock()
             .unwrap()
             .insert(checkpoint_id.to_string(), payload.to_vec());
+    }
+
+    /// Move the guest's clock far enough forward that `deadline_ms` has passed —
+    /// what the wake scheduler achieves by simply not relaunching until then.
+    fn advance_clock_past(&self, deadline_ms: u64) {
+        let wall = now_ms();
+        let mut offset = self.clock_offset_ms.lock().unwrap();
+        // +1 so the guest sees `now > deadline`, not `now == deadline`.
+        *offset = (*offset).max(deadline_ms.saturating_sub(wall).saturating_add(1));
     }
 
     /// Whether a custom signal is armed for `checkpoint_id` — what the
@@ -7231,6 +7287,9 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
     async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
         Ok(false)
     }
+    fn now_ms(&self) -> Result<u64, String> {
+        Ok(now_ms() + *self.clock_offset_ms.lock().unwrap())
+    }
     async fn record_retry_attempt(
         &self,
         _checkpoint_id: String,
@@ -7245,9 +7304,13 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
         state: Vec<u8>,
         _ms: u64,
     ) -> Result<(), String> {
-        // Blocking path: record the key (and persist the checkpoint like core's
-        // handle_sleep) but never actually sleep — keeps the 1h fixture fast.
-        if !state.is_empty() {
+        // Blocking path: record the key and persist the checkpoint exactly as
+        // core's `handle_sleep` does — which saves whenever the checkpoint id is
+        // non-empty, EMPTY STATE INCLUDED. Skipping the empty case (as this mock
+        // used to) hid the fact that the blocking arm leaves a `some([])` behind
+        // under the very key the park arm looks up. Only the sleep itself is
+        // skipped here, which is what keeps the 1h fixture fast.
+        {
             self.checkpoints
                 .lock()
                 .unwrap()
@@ -7316,13 +7379,12 @@ enum ParkLeg {
 /// It honours both wake shapes the host supports, refusing to relaunch a park
 /// that production would leave parked:
 ///
-/// - `at(deadline)` — a timed park. The scheduler relaunches when the deadline
-///   passes; the GUEST never re-checks it (its checkpoint HIT is what skips the
-///   sleep), so the deadline is purely host-side bookkeeping and a relaunch is
-///   always safe to issue here. Time is not virtualisable in this harness —
-///   `now-ms` is a free function in the host crate, not a `RuntimeHost` method —
-///   so the loop relaunches immediately rather than burning the wall clock, and
-///   callers assert the deadline VALUE separately.
+/// - `at(deadline)` — a timed park. The scheduler relaunches once the deadline
+///   passes, and the GUEST enforces that: a resumed park re-reads its stored
+///   deadline and re-parks if it is still in the future, so relaunching early
+///   does NOT run the delay out. The loop therefore advances the host's virtual
+///   clock past the deadline before relaunching — honouring it exactly, without
+///   burning the wall clock on an hour-long fixture.
 /// - `on-signal{deadline}` — a signal park. Relaunching is only legitimate once
 ///   `deliver` has armed the awaited signal or a timeout deadline exists; a park
 ///   with neither would sit forever in production, so the loop stops rather than
@@ -7351,6 +7413,19 @@ fn drive_wake_scheduler(
             return legs;
         };
         deliver(relaunch, host.as_ref(), &wakes);
+        // Honour every timed wake by moving the clock to it, the way the
+        // scheduler honours it by waiting.
+        for wake in &wakes {
+            match wake {
+                WorkflowWake::At(ms) => host.advance_clock_past(*ms),
+                WorkflowWake::OnSignal(wait) => {
+                    if let Some(ms) = wait.deadline_ms {
+                        host.advance_clock_past(ms);
+                    }
+                }
+                WorkflowWake::OnResume => {}
+            }
+        }
         let wakeable = wakes.iter().any(|wake| match wake {
             WorkflowWake::At(_) => true,
             WorkflowWake::OnSignal(wait) => {
@@ -7505,9 +7580,13 @@ fn direct_wasm_execute_invoke_delay_threshold_is_decided_at_runtime() {
         &["delay".to_string()],
         "a below-threshold duration must go through durable-sleep-checkpoint"
     );
-    assert!(
-        short_host.checkpoints.lock().unwrap().is_empty(),
-        "the blocking arm writes no guest-side deadline checkpoint"
+    // The blocking arm writes no guest-side deadline, but core's `handle_sleep`
+    // still saves a checkpoint under the sleep key with an EMPTY state — which
+    // is exactly why the park arm cannot treat a bare HIT as "already waited".
+    assert_eq!(
+        short_host.checkpoints.lock().unwrap().get("delay"),
+        Some(&Vec::new()),
+        "the blocking arm must leave the host's empty sleep checkpoint under the delay key"
     );
 
     // Same wasm, long duration: parks on a timed wake instead.
@@ -7577,9 +7656,117 @@ fn direct_wasm_execute_cli_run_abi_blocks_a_long_delay() {
         &["delay".to_string()],
         "under cli-run even an hours-long Delay must block on durable-sleep-checkpoint"
     );
+    // The blocking sleep leaves core's empty checkpoint behind, but never an
+    // 8-byte deadline: cli-run has no wake that could carry one.
+    assert_eq!(
+        host.checkpoints.lock().unwrap().get("delay"),
+        Some(&Vec::new()),
+        "cli-run must record only the blocking sleep's empty checkpoint, never a deadline"
+    );
+}
+
+/// Relaunching a parked Delay BEFORE its deadline must not skip the wait: the
+/// guest re-reads the stored deadline and re-parks on the same absolute value.
+///
+/// The wake scheduler is not the only relauncher — `handle_resume_instance`
+/// accepts any instance whose status is `suspended`, with no `termination_reason`
+/// filter, so an operator resuming a workflow parked on a long Delay lands here
+/// early. A HIT means "a deadline was recorded", never "the wait is over".
+#[test]
+fn direct_wasm_execute_invoke_early_relaunch_reparks_instead_of_skipping_the_delay() {
+    let components_dir = direct_e2e_components_dir();
+    let input = br#"{"value":"early"}"#.to_vec();
+    let duration_ms = 3_600_000u64;
+    let artifact = compile_invoke_abi_artifact(
+        &components_dir,
+        "delay-early-relaunch",
+        &store_freeing_delay_fixture(Some(duration_ms)),
+    );
+    let host = Arc::new(CheckpointingRuntimeHost::new(&input));
+
+    let first = run_invoke_once(&artifact.wasm_path, host.clone(), input.clone());
+    let first_deadline = match &first {
+        runtara_component_host::InvokeExit::Suspended(wakes) => match &wakes[0] {
+            runtara_component_host::lifecycle::WorkflowWake::At(ms) => *ms,
+            other => panic!("expected a timed wake, got {other:?}"),
+        },
+        other => panic!("first invoke must park, got {other:?}"),
+    };
+
+    // Relaunch immediately — an hour before the deadline, exactly as a manual
+    // resume would. It must park again, not complete.
+    let second = run_invoke_once(&artifact.wasm_path, host.clone(), input.clone());
+    let second_deadline = match &second {
+        runtara_component_host::InvokeExit::Suspended(wakes) => match &wakes[0] {
+            runtara_component_host::lifecycle::WorkflowWake::At(ms) => *ms,
+            other => panic!("expected a timed wake, got {other:?}"),
+        },
+        other => panic!("an early relaunch must re-park, not run the delay out; got {other:?}"),
+    };
+    assert_eq!(
+        first_deadline, second_deadline,
+        "a re-park must carry the SAME absolute deadline — the wait is not \
+         shortened by having been relaunched"
+    );
     assert!(
-        host.checkpoints.lock().unwrap().is_empty(),
-        "cli-run has no wake to carry a deadline, so it must write no deadline checkpoint"
+        host.completed.lock().unwrap().is_none(),
+        "an early relaunch must not complete the run"
+    );
+    assert!(
+        host.sleeps.lock().unwrap().is_empty(),
+        "re-parking must not fall back to a blocking sleep"
+    );
+}
+
+/// The blocking arm and the park arm share one checkpoint key, and core's
+/// `handle_sleep` saves an EMPTY state under it. The park arm must tell that
+/// apart from its own 8-byte deadline — and having done so, treat it as a
+/// SERVED wait and continue.
+///
+/// That is the correct resume, not a shortcut: the only writer of empty state
+/// under this key is `handle_sleep`, so its presence means the blocking arm
+/// already slept this delay on an earlier pass. Re-parking instead would hang
+/// the run outright — `handle_checkpoint` is get-or-set, so the park's deadline
+/// could never overwrite the empty state and every relaunch would park again.
+#[test]
+fn direct_wasm_execute_invoke_blocking_sleep_checkpoint_reads_as_a_served_wait() {
+    let components_dir = direct_e2e_components_dir();
+    let input = br#"{"value":"aliased"}"#.to_vec();
+    let artifact = compile_invoke_abi_artifact(
+        &components_dir,
+        "delay-key-aliasing",
+        &store_freeing_delay_fixture(Some(3_600_000)),
+    );
+    let host = Arc::new(CheckpointingRuntimeHost::new(&input));
+    // Seed the key exactly as a prior BLOCKING pass through this step would
+    // have, via core's handle_sleep.
+    host.checkpoints
+        .lock()
+        .unwrap()
+        .insert("delay".to_string(), Vec::new());
+
+    let exit = run_invoke_once(&artifact.wasm_path, host.clone(), input.clone());
+    let output = match exit {
+        runtara_component_host::InvokeExit::Completed(output) => output,
+        other => panic!(
+            "a served blocking-sleep checkpoint must let the run continue, not park \
+             (a re-park here could never persist its deadline and would hang); got {other:?}"
+        ),
+    };
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output).expect("output is JSON"),
+        serde_json::json!({ "echo": "aliased" }),
+    );
+    assert!(
+        host.sleeps.lock().unwrap().is_empty(),
+        "the served wait must not be slept again"
+    );
+    // The empty state is left exactly as it was: nothing overwrote it, which is
+    // precisely why the length check has to happen before the deadline read.
+    assert_eq!(
+        host.checkpoints.lock().unwrap().get("delay"),
+        Some(&Vec::new()),
+        "a get-or-set checkpoint store leaves the blocking arm's empty state in place"
     );
 }
 

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -784,7 +784,7 @@ fn route(
                 );
             }
             ("POST", "sleep") => {
-                capture_sleep(body, sink);
+                capture_sleep(body, sink, server_state);
                 return (200, serde_json::json!({"success": true}));
             }
             ("POST", "failed") => {
@@ -896,7 +896,10 @@ fn capture_event(body: &[u8], sink: &mpsc::Sender<CapturedMessage>) {
     }
 }
 
-fn capture_sleep(body: &[u8], sink: &mpsc::Sender<CapturedMessage>) {
+/// Mirror production `handle_sleep`: persist the checkpoint, then (here) skip
+/// the sleep itself. See [`CapturingRuntimeHost::durable_sleep_checkpoint`] for
+/// why the save has to happen even though the wait does not.
+fn capture_sleep(body: &[u8], sink: &mpsc::Sender<CapturedMessage>, server_state: &ServerState) {
     if let Ok(parsed) = serde_json::from_slice::<Value>(body)
         && let Some(checkpoint_id) = parsed.get("checkpoint_id").and_then(Value::as_str)
     {
@@ -909,6 +912,11 @@ fn capture_sleep(body: &[u8], sink: &mpsc::Sender<CapturedMessage>) {
             .and_then(Value::as_str)
             .and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
             .unwrap_or_default();
+        server_state
+            .checkpoints
+            .lock()
+            .expect("checkpoint state lock")
+            .insert(checkpoint_id.to_string(), state.clone());
         let _ = sink.send(CapturedMessage::Sleep(SleepRequest {
             checkpoint_id: checkpoint_id.to_string(),
             duration_ms,
@@ -1268,9 +1276,6 @@ fn run_direct_workflow_capture_attempt(
         components_dir,
         binding,
         abi,
-        // The battery axis exercises the blocking durable-sleep path; the
-        // store-freeing lowering has its own dedicated suspend/resume test.
-        false,
         // Runtime import kept — omit-runtime has its own dedicated test.
         false,
     )
@@ -1611,8 +1616,17 @@ impl runtara_component_host::runtime_host::RuntimeHost for CapturingRuntimeHost 
         state: Vec<u8>,
         ms: u64,
     ) -> Result<(), String> {
-        // Mirror POST /sleep: capture only — the mock neither persists the
-        // checkpoint nor sleeps, keeping delay-heavy fixtures fast.
+        // Mirror POST /sleep, which mirrors production `handle_sleep`: SAVE the
+        // checkpoint, then sleep. The save is not optional the way it reads —
+        // it moves the instance's current checkpoint — so a mock that skipped it
+        // diverged from production on every durable Delay. The sleep itself is
+        // still skipped, which is what keeps delay-heavy fixtures fast; that is
+        // a timing shortcut, not a persistence one.
+        self.state
+            .checkpoints
+            .lock()
+            .expect("checkpoint state lock")
+            .insert(checkpoint_id.clone(), state.clone());
         self.send(CapturedMessage::Sleep(SleepRequest {
             checkpoint_id,
             duration_ms: ms,
@@ -1654,6 +1668,29 @@ fn execute_via_cli(wasm_path: &Path, env_pairs: &[(String, String)]) -> (bool, S
 /// keep flowing through the additive complete/fail recordings the
 /// CapturingRuntimeHost already mirrors — the CapturedRun shape is identical
 /// across all three execution paths.
+/// Relaunch budget for a parked run on the invoke axis. A fixture parks at most
+/// once per durable step; four covers every fixture in the battery with room to
+/// spare, and bounds a lowering bug that parks in a loop.
+const INVOKE_MAX_RELAUNCHES: usize = 4;
+
+/// Whether the wake scheduler would relaunch a park carrying these wakes.
+///
+/// Mirrors `park_invoke_suspend` in runtara-environment: a TIMED wake (`at`, or
+/// `on-signal` with a timeout) gets `sleep_until` stamped and is relaunched at
+/// the deadline, while a park whose only wake is `on-resume` — a cancel ack, a
+/// breakpoint, a drain pause — is deliberately left alone. Relaunching one of
+/// those would resurrect a run the host just stopped, so this is what keeps the
+/// loop below from turning a cancel into a completion.
+fn scheduler_would_relaunch(wakes: &[runtara_component_host::lifecycle::WorkflowWake]) -> bool {
+    use runtara_component_host::lifecycle::WorkflowWake;
+    !wakes.is_empty()
+        && wakes.iter().all(|wake| match wake {
+            WorkflowWake::At(_) => true,
+            WorkflowWake::OnSignal(wait) => wait.deadline_ms.is_some(),
+            WorkflowWake::OnResume => false,
+        })
+}
+
 fn execute_via_embedded_invoke(
     wasm_path: &Path,
     env_pairs: &[(String, String)],
@@ -1670,25 +1707,43 @@ fn execute_via_embedded_invoke(
         limits.max_memory_bytes = max;
     }
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    // Stand in for the wake scheduler: a parked run is not a finished run, so
+    // relaunch it (replaying against the same mock state, exactly as a
+    // relaunched instance replays against the same durable store) until it
+    // reaches a terminal outcome. Without this the harness sees only the park —
+    // which is fine while nothing parks, and wrong the moment a durable Delay
+    // or a Wait timeout does.
     let result = runtime.block_on(async {
         let pre = executor
             .load_instance_pre(wasm_path)
             .await
             .expect("load invoke-shaped workflow component");
-        executor
-            .execute_invoke(
-                &pre,
-                runtara_component_host::WorkflowRunSpec {
-                    env: env_pairs.iter().cloned().collect(),
-                    stderr: None,
-                    timeout: Duration::from_secs(300),
-                    cancel: None,
-                    limits,
-                    runtime: Some(runtime_host),
-                },
-                input,
-            )
-            .await
+        let mut attempt = 0;
+        loop {
+            let result = executor
+                .execute_invoke(
+                    &pre,
+                    runtara_component_host::WorkflowRunSpec {
+                        env: env_pairs.iter().cloned().collect(),
+                        stderr: None,
+                        timeout: Duration::from_secs(300),
+                        cancel: None,
+                        limits: limits.clone(),
+                        runtime: Some(runtime_host.clone()),
+                    },
+                    input.clone(),
+                )
+                .await;
+            let relaunch = matches!(
+                &result.exit,
+                runtara_component_host::InvokeExit::Suspended(wakes)
+                    if scheduler_would_relaunch(wakes)
+            );
+            if !relaunch || attempt == INVOKE_MAX_RELAUNCHES {
+                break result;
+            }
+            attempt += 1;
+        }
     });
     let peak = Some(result.memory_peak_bytes);
     match result.exit {
@@ -2270,7 +2325,6 @@ fn direct_wasm_execute_host_import_runtime_runs_without_http() {
             agent_slug: None,
         },
         WorkflowAbi::CliRunHttp,
-        false,
         false,
     )
     .expect("direct emit succeeds");
@@ -4652,6 +4706,11 @@ fn direct_wasm_execute_durable_delay_reports_sleep_and_completion() {
     assert_eq!(sleep.checkpoint_id, "delay");
     assert_eq!(sleep.duration_ms, 0);
     assert!(sleep.state.is_empty());
+    // No GUEST-side `checkpoint` call: a blocking delay reaches persistence only
+    // through the sleep. The checkpoint itself is still written — production
+    // `handle_sleep` saves one before sleeping, and the mock now does too — so
+    // this asserts the shape of the call the guest made, not that the sleep left
+    // nothing behind.
     assert!(result.checkpoints.is_empty());
 }
 
@@ -6393,29 +6452,13 @@ fn compile_invoke_abi_artifact(
     workflow_id: &str,
     graph_json: &str,
 ) -> runtara_workflows::direct_wasm::DirectCompilationResult {
-    compile_invoke_abi_artifact_configured(components_dir, workflow_id, graph_json, false)
-}
-
-fn compile_invoke_abi_artifact_configured(
-    components_dir: &Path,
-    workflow_id: &str,
-    graph_json: &str,
-    store_freeing_sleep: bool,
-) -> runtara_workflows::direct_wasm::DirectCompilationResult {
-    compile_invoke_abi_artifact_full(
-        components_dir,
-        workflow_id,
-        graph_json,
-        store_freeing_sleep,
-        false,
-    )
+    compile_invoke_abi_artifact_full(components_dir, workflow_id, graph_json, false)
 }
 
 fn compile_invoke_abi_artifact_full(
     components_dir: &Path,
     workflow_id: &str,
     graph_json: &str,
-    store_freeing_sleep: bool,
     omit_runtime: bool,
 ) -> runtara_workflows::direct_wasm::DirectCompilationResult {
     let graph: ExecutionGraph = serde_json::from_str(graph_json).expect("fixture parses");
@@ -6437,7 +6480,6 @@ fn compile_invoke_abi_artifact_full(
         components_dir,
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        store_freeing_sleep,
         omit_runtime,
     )
     .expect("invoke-abi compile+compose succeeds");
@@ -6478,7 +6520,6 @@ fn direct_wasm_execute_invoke_omit_runtime_pure_workflow_runs_with_no_runtime_ho
         &components_dir,
         "omit-runtime-pure",
         PURE_PASSTHROUGH,
-        false,
         true,
     );
 
@@ -6539,7 +6580,6 @@ fn direct_wasm_execute_invoke_omit_runtime_pure_workflow_runs_with_no_runtime_ho
         "omit-runtime-off",
         PURE_PASSTHROUGH,
         false,
-        false,
     );
     assert!(!kept.omit_runtime);
     assert!(
@@ -6555,7 +6595,6 @@ fn direct_wasm_execute_invoke_omit_runtime_pure_workflow_runs_with_no_runtime_ho
         &components_dir,
         "omit-runtime-guarded",
         AGENT_CACHED_REPLAY,
-        false,
         true,
     );
     assert!(
@@ -6592,7 +6631,6 @@ fn compile_agent_capabilities_artifact(
         components_dir,
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-        false,
         // omit_runtime is forced true for AgentCapabilities by the compiler.
         false,
     )
@@ -6663,8 +6701,8 @@ fn direct_wasm_execute_agent_capabilities_workflow_invocable_as_agent() {
 #[test]
 fn direct_wasm_execute_agent_capabilities_keeps_runtime_for_durable_workflow() {
     let components_dir = direct_e2e_components_dir();
-    let graph: ExecutionGraph =
-        serde_json::from_str(STORE_FREEING_DELAY).expect("delay fixture parses");
+    let graph: ExecutionGraph = serde_json::from_str(&store_freeing_delay_fixture(Some(3_600_000)))
+        .expect("delay fixture parses");
     let temp = tempfile::tempdir().expect("tempdir");
     let compiled = compile_direct_workflow_composed_configured(
         DirectCompilationInput {
@@ -6681,7 +6719,6 @@ fn direct_wasm_execute_agent_capabilities_keeps_runtime_for_durable_workflow() {
         &components_dir,
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-        false,
         false,
     )
     .expect("a durable workflow now compiles as an agent");
@@ -6738,7 +6775,6 @@ fn direct_wasm_execute_agent_capabilities_keeps_runtime_for_durable_workflow() {
             &components_dir,
             RuntimeBinding::HostImport,
             runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-            false,
             false,
         )
         .expect("agent compile succeeds")
@@ -7015,30 +7051,48 @@ fn direct_wasm_execute_split_durable_delay_keys_are_per_iteration() {
 /// A single durable Delay whose only job downstream is to echo the input, so
 /// the store-freeing (suspend/relaunch) and blocking (in-host sleep) lowerings
 /// are trivially comparable at the output.
-const STORE_FREEING_DELAY: &str = r#"{
+/// A single durable Delay then a Finish echoing the input. `duration` is the
+/// literal `durationMs` when `Some`, and a REFERENCE to `data.waitMs` when
+/// `None` — the reference form is what makes the park/block choice unresolvable
+/// at compile time, so one artifact has to decide it at runtime.
+fn store_freeing_delay_fixture(duration_ms: Option<u64>) -> String {
+    let (duration, extra_input) = match duration_ms {
+        Some(ms) => (
+            format!(r#"{{ "valueType": "immediate", "value": {ms} }}"#),
+            String::new(),
+        ),
+        None => (
+            r#"{ "valueType": "reference", "value": "data.waitMs" }"#.to_string(),
+            r#", "waitMs": { "type": "number", "required": true }"#.to_string(),
+        ),
+    };
+    format!(
+        r#"{{
   "name": "Store Freeing Delay",
   "durable": true,
-  "steps": {
-    "delay": {
+  "steps": {{
+    "delay": {{
       "stepType": "Delay",
       "id": "delay",
       "name": "Wait",
-      "durationMs": { "valueType": "immediate", "value": 3600000 }
-    },
-    "finish": {
+      "durationMs": {duration}
+    }},
+    "finish": {{
       "stepType": "Finish",
       "id": "finish",
-      "inputMapping": {
-        "echo": { "valueType": "reference", "value": "data.value" }
-      }
-    }
-  },
+      "inputMapping": {{
+        "echo": {{ "valueType": "reference", "value": "data.value" }}
+      }}
+    }}
+  }},
   "entryPoint": "delay",
-  "executionPlan": [ { "fromStep": "delay", "toStep": "finish" } ],
-  "variables": {},
-  "inputSchema": { "value": { "type": "string", "required": true } },
-  "outputSchema": {}
-}"#;
+  "executionPlan": [ {{ "fromStep": "delay", "toStep": "finish" }} ],
+  "variables": {{}},
+  "inputSchema": {{ "value": {{ "type": "string", "required": true }}{extra_input} }},
+  "outputSchema": {{}}
+}}"#
+    )
+}
 
 /// Checkpoint-persisting runtime host: unlike [`RecordingRuntimeHost`] its
 /// checkpoint map survives across `execute_invoke` calls (share one `Arc`), so
@@ -7078,6 +7132,16 @@ impl CheckpointingRuntimeHost {
             .lock()
             .unwrap()
             .insert(checkpoint_id.to_string(), payload.to_vec());
+    }
+
+    /// Whether a custom signal is armed for `checkpoint_id` — what the
+    /// wake-scheduler stand-in consults before relaunching an on-signal park.
+    fn has_signal(&self, checkpoint_id: &str) -> bool {
+        self.custom_signals
+            .lock()
+            .unwrap()
+            .contains_key(checkpoint_id)
+            || self.any_signal.lock().unwrap().is_some()
     }
 
     fn deliver_signal_any(&self, payload: &[u8]) {
@@ -7233,40 +7297,132 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-/// Store-freeing Slice 2: with the gate ON, a durable Delay under the invoke
-/// export EXITS with `suspended(at(deadline))` on first reach (freeing the
-/// Store) and, on relaunch, HITS the deadline checkpoint and skips the sleep —
-/// completing with output byte-identical to the blocking lowering. This is the
-/// in-process stand-in for the wake scheduler: the two invokes share one
-/// checkpoint-persisting host, exactly as a relaunched instance shares the
-/// durable checkpoint store.
+/// What a parked run did on one leg of a [`drive_wake_scheduler`] loop.
+#[derive(Debug)]
+enum ParkLeg {
+    /// The run exited `suspended`, carrying these wakes.
+    Parked(Vec<runtara_component_host::lifecycle::WorkflowWake>),
+    /// The run reached a terminal outcome and the loop stopped.
+    Finished(runtara_component_host::InvokeExit),
+}
+
+/// In-process stand-in for the wake scheduler: relaunch a parked run until it
+/// reaches a terminal outcome, returning every leg in order.
+///
+/// The harness previously invoked exactly once, which cannot be right once a
+/// delay parks — a single invoke sees the suspend and nothing after it. This
+/// drives the real production shape: park, decide, relaunch, replay.
+///
+/// It honours both wake shapes the host supports, refusing to relaunch a park
+/// that production would leave parked:
+///
+/// - `at(deadline)` — a timed park. The scheduler relaunches when the deadline
+///   passes; the GUEST never re-checks it (its checkpoint HIT is what skips the
+///   sleep), so the deadline is purely host-side bookkeeping and a relaunch is
+///   always safe to issue here. Time is not virtualisable in this harness —
+///   `now-ms` is a free function in the host crate, not a `RuntimeHost` method —
+///   so the loop relaunches immediately rather than burning the wall clock, and
+///   callers assert the deadline VALUE separately.
+/// - `on-signal{deadline}` — a signal park. Relaunching is only legitimate once
+///   `deliver` has armed the awaited signal or a timeout deadline exists; a park
+///   with neither would sit forever in production, so the loop stops rather than
+///   spinning and hiding that.
+///
+/// `deliver` is the custom-signal waker: it runs on each park and may deliver a
+/// signal for the id the wake reported.
+fn drive_wake_scheduler(
+    wasm_path: &Path,
+    host: Arc<CheckpointingRuntimeHost>,
+    input: Vec<u8>,
+    max_relaunches: usize,
+    mut deliver: impl FnMut(
+        usize,
+        &CheckpointingRuntimeHost,
+        &[runtara_component_host::lifecycle::WorkflowWake],
+    ),
+) -> Vec<ParkLeg> {
+    use runtara_component_host::lifecycle::WorkflowWake;
+
+    let mut legs = Vec::new();
+    for relaunch in 0..=max_relaunches {
+        let exit = run_invoke_once(wasm_path, host.clone(), input.clone());
+        let runtara_component_host::InvokeExit::Suspended(wakes) = exit else {
+            legs.push(ParkLeg::Finished(exit));
+            return legs;
+        };
+        deliver(relaunch, host.as_ref(), &wakes);
+        let wakeable = wakes.iter().any(|wake| match wake {
+            WorkflowWake::At(_) => true,
+            WorkflowWake::OnSignal(wait) => {
+                wait.deadline_ms.is_some() || host.has_signal(&wait.checkpoint_id)
+            }
+            WorkflowWake::OnResume => false,
+        });
+        legs.push(ParkLeg::Parked(wakes));
+        assert!(
+            wakeable,
+            "leg {relaunch} parked with no wake the scheduler could act on; \
+             production would leave this instance parked forever"
+        );
+    }
+    panic!("run did not finish within {max_relaunches} relaunches");
+}
+
+impl ParkLeg {
+    fn wakes(&self) -> &[runtara_component_host::lifecycle::WorkflowWake] {
+        match self {
+            ParkLeg::Parked(wakes) => wakes,
+            ParkLeg::Finished(exit) => panic!("expected a park, got {exit:?}"),
+        }
+    }
+
+    fn output(&self) -> &[u8] {
+        match self {
+            ParkLeg::Finished(runtara_component_host::InvokeExit::Completed(output)) => output,
+            other => panic!("expected a completed run, got {other:?}"),
+        }
+    }
+}
+
+/// A durable Delay at or above the park threshold under the invoke export
+/// EXITS with `suspended(at(deadline))` on first reach — freeing the Store —
+/// and, on relaunch, HITS the deadline checkpoint and skips the sleep,
+/// completing with output byte-identical to the blocking arm a SHORT delay
+/// takes. The two invokes share one checkpoint-persisting host, exactly as a
+/// relaunched instance shares the durable checkpoint store.
+///
+/// This is the behaviour that used to sit behind `RUNTARA_DIRECT_STORE_FREEING_SLEEP`,
+/// set nowhere; the gate is gone and duration alone decides.
 #[test]
-fn direct_wasm_execute_invoke_store_freeing_delay_suspends_then_resumes() {
+fn direct_wasm_execute_invoke_long_delay_parks_then_resumes() {
     let components_dir = direct_e2e_components_dir();
     let input = br#"{"value":"resume-me"}"#.to_vec();
     let duration_ms = 3_600_000u64;
 
-    // --- Store-freeing lowering (gate ON): suspend, then resume. ---
-    let store_freeing = compile_invoke_abi_artifact_configured(
+    // --- At/above the threshold: park, then resume. ---
+    let parking = compile_invoke_abi_artifact(
         &components_dir,
-        "store-freeing-delay-on",
-        STORE_FREEING_DELAY,
-        true,
+        "delay-park-long",
+        &store_freeing_delay_fixture(Some(duration_ms)),
     );
     let host = Arc::new(CheckpointingRuntimeHost::new(&input));
 
     let before = now_ms();
-    let first = run_invoke_once(&store_freeing.wasm_path, host.clone(), input.clone());
+    let legs = drive_wake_scheduler(
+        &parking.wasm_path,
+        host.clone(),
+        input.clone(),
+        1,
+        |_, _, _| {},
+    );
     let after = now_ms();
 
-    let wakes = match first {
-        runtara_component_host::InvokeExit::Suspended(wakes) => wakes,
-        other => panic!("first invoke must suspend, got {other:?}"),
-    };
+    assert_eq!(legs.len(), 2, "one park then one completing relaunch");
+    let wakes = legs[0].wakes();
     assert_eq!(wakes.len(), 1, "sequential lowering emits one wake");
     let deadline = match &wakes[0] {
         runtara_component_host::lifecycle::WorkflowWake::At(ms) => *ms,
-        other => panic!("durable Delay must suspend on a timed wake, got {other:?}"),
+        other => panic!("a long durable Delay must park on a timed wake, got {other:?}"),
     };
     // deadline == now_ms(at suspend) + duration, and the suspend happened
     // between `before` and `after`.
@@ -7280,60 +7436,150 @@ fn direct_wasm_execute_invoke_store_freeing_delay_suspends_then_resumes() {
     // sleep fired.
     assert!(
         host.checkpoints.lock().unwrap().contains_key("delay"),
-        "store-freeing suspend must checkpoint its deadline under the delay key"
+        "a park must checkpoint its deadline under the delay key"
     );
     assert!(
         host.sleeps.lock().unwrap().is_empty(),
-        "store-freeing lowering must not call the blocking durable-sleep host fn"
+        "a parked delay must not call the blocking durable-sleep host fn — \
+         not on the park, and not on the resume whose checkpoint HIT skips it"
     );
-    assert!(
-        host.completed.lock().unwrap().is_none(),
-        "a suspended run has not completed yet"
-    );
+    let resumed_output = legs[1].output().to_vec();
 
-    // Relaunch: same host (checkpoint survives), replay from the start. The
-    // deadline checkpoint HITS, the sleep is skipped, and the run completes.
-    let second = run_invoke_once(&store_freeing.wasm_path, host.clone(), input.clone());
-    let resumed_output = match second {
-        runtara_component_host::InvokeExit::Completed(output) => output,
-        other => panic!("relaunch must complete, got {other:?}"),
-    };
-    assert!(
-        host.sleeps.lock().unwrap().is_empty(),
-        "resume must not block either — the checkpoint HIT skips the sleep"
-    );
-
-    // --- Blocking lowering (gate OFF): completes in ONE invoke. ---
-    let blocking = compile_invoke_abi_artifact_configured(
+    // --- Below the threshold: blocks, completing in ONE invoke. ---
+    let blocking = compile_invoke_abi_artifact(
         &components_dir,
-        "store-freeing-delay-off",
-        STORE_FREEING_DELAY,
-        false,
+        "delay-park-short",
+        &store_freeing_delay_fixture(Some(25)),
     );
     let blocking_host = Arc::new(CheckpointingRuntimeHost::new(&input));
     let blocking_exit = run_invoke_once(&blocking.wasm_path, blocking_host.clone(), input.clone());
     let blocking_output = match blocking_exit {
         runtara_component_host::InvokeExit::Completed(output) => output,
-        other => panic!("blocking Delay must complete in one invoke, got {other:?}"),
+        other => panic!("a short Delay must block and complete in one invoke, got {other:?}"),
     };
-    // The blocking path DID call the durable-sleep host fn (its whole point),
-    // proving the two lowerings diverge internally...
+    // The blocking arm DID call the durable-sleep host fn (its whole point),
+    // proving the two arms diverge internally...
     assert_eq!(
         blocking_host.sleeps.lock().unwrap().as_slice(),
         &["delay".to_string()],
-        "blocking lowering must go through durable-sleep-checkpoint"
+        "the blocking arm must go through durable-sleep-checkpoint"
     );
 
-    // ...yet converge on byte-identical observable output. This is the
-    // "semantics == legacy blocking, byte-preserved" guarantee.
+    // ...yet converge on byte-identical observable output. Which arm a delay
+    // takes must not be visible to the workflow.
     assert_eq!(
         resumed_output, blocking_output,
-        "store-freeing resume output must byte-match the blocking output"
+        "a resumed park's output must byte-match the blocking arm's"
     );
     let expected: Value = serde_json::json!({ "echo": "resume-me" });
     assert_eq!(
         serde_json::from_slice::<Value>(&resumed_output).expect("output is JSON"),
         expected
+    );
+}
+
+/// The park/block choice is made at RUNTIME, not compile time: ONE artifact,
+/// whose `durationMs` is a reference the emitter cannot resolve, blocks on a
+/// short input and parks on a long one. Both arms are therefore emitted into
+/// every durable delay under the invoke export — which is the whole reason the
+/// threshold could not be a compile-time decision.
+#[test]
+fn direct_wasm_execute_invoke_delay_threshold_is_decided_at_runtime() {
+    let components_dir = direct_e2e_components_dir();
+    let artifact = compile_invoke_abi_artifact(
+        &components_dir,
+        "delay-threshold-runtime",
+        &store_freeing_delay_fixture(None),
+    );
+
+    // Same wasm, short duration: blocks through to completion in one invoke.
+    let short_input = br#"{"value":"short","waitMs":25}"#.to_vec();
+    let short_host = Arc::new(CheckpointingRuntimeHost::new(&short_input));
+    let short_exit = run_invoke_once(&artifact.wasm_path, short_host.clone(), short_input.clone());
+    assert!(
+        matches!(short_exit, runtara_component_host::InvokeExit::Completed(_)),
+        "a below-threshold duration must block, got {short_exit:?}"
+    );
+    assert_eq!(
+        short_host.sleeps.lock().unwrap().as_slice(),
+        &["delay".to_string()],
+        "a below-threshold duration must go through durable-sleep-checkpoint"
+    );
+    assert!(
+        short_host.checkpoints.lock().unwrap().is_empty(),
+        "the blocking arm writes no guest-side deadline checkpoint"
+    );
+
+    // Same wasm, long duration: parks on a timed wake instead.
+    let long_input = br#"{"value":"long","waitMs":3600000}"#.to_vec();
+    let long_host = Arc::new(CheckpointingRuntimeHost::new(&long_input));
+    let long_legs = drive_wake_scheduler(
+        &artifact.wasm_path,
+        long_host.clone(),
+        long_input.clone(),
+        1,
+        |_, _, _| {},
+    );
+    assert!(
+        matches!(
+            long_legs[0].wakes().first(),
+            Some(runtara_component_host::lifecycle::WorkflowWake::At(_))
+        ),
+        "an at-or-above-threshold duration must park on a timed wake, got {:?}",
+        long_legs[0]
+    );
+    assert!(
+        long_host.sleeps.lock().unwrap().is_empty(),
+        "a parked delay must not block"
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(long_legs[1].output()).expect("output is JSON"),
+        serde_json::json!({ "echo": "long" }),
+    );
+}
+
+/// The `wasi:cli/run` export blocks a long Delay even though the invoke export
+/// parks the identical graph. What survived the gate's deletion is a CAPABILITY
+/// check, not a policy one: `cli-run` has no success arm that can carry a wake,
+/// so it has nowhere to put a deadline and must block.
+#[test]
+fn direct_wasm_execute_cli_run_abi_blocks_a_long_delay() {
+    let components_dir = direct_e2e_components_dir();
+    let graph: ExecutionGraph = serde_json::from_str(&store_freeing_delay_fixture(Some(3_600_000)))
+        .expect("delay fixture parses");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let compiled = compile_direct_workflow_composed_configured(
+        DirectCompilationInput {
+            workflow_id: "delay-cli-run-blocks".to_string(),
+            version: 1,
+            source_checksum: None,
+            execution_graph: graph,
+            child_workflows: vec![],
+            output_dir: temp.path().to_path_buf(),
+            track_events: false,
+            agent_catalog: None,
+            agent_slug: None,
+        },
+        &components_dir,
+        RuntimeBinding::HostImport,
+        runtara_workflows::direct_wasm::WorkflowAbi::CliRunHttp,
+        false,
+    )
+    .expect("cli-run compile+compose succeeds");
+
+    let input = br#"{"value":"cli-run"}"#.to_vec();
+    let host = Arc::new(CheckpointingRuntimeHost::new(&input));
+    let (ok, stderr, _) = execute_via_embedded(&compiled.wasm_path, &[], Some(host.clone()));
+    assert!(ok, "cli-run artifact must run to completion: {stderr}");
+
+    assert_eq!(
+        host.sleeps.lock().unwrap().as_slice(),
+        &["delay".to_string()],
+        "under cli-run even an hours-long Delay must block on durable-sleep-checkpoint"
+    );
+    assert!(
+        host.checkpoints.lock().unwrap().is_empty(),
+        "cli-run has no wake to carry a deadline, so it must write no deadline checkpoint"
     );
 }
 
@@ -7363,39 +7609,48 @@ const STORE_FREEING_WAIT: &str = r#"{
   "outputSchema": {}
 }"#;
 
-/// Store-freeing Slice 2 (on-signal waker half): with the gate ON, a durable
-/// WaitForSignal under the invoke export EXITS with
-/// `suspended(on-signal{signal-id, deadline})` on the first poll MISS (freeing
-/// the Store) instead of blocking the poll loop. On relaunch — the in-process
-/// stand-in for the custom-signal waker delivering the signal then the wake
-/// scheduler relaunching — the wait re-polls the now-present signal and
-/// completes. A no-timeout wait carries NO deadline (the waker is the sole wake
-/// path); the blocking lowering (gate OFF) reaches the same output.
+/// A durable WaitForSignal under the invoke export EXITS with
+/// `suspended(on-signal{signal-id, deadline})` on the first poll MISS — freeing
+/// the Store — instead of blocking the poll loop. The wake-scheduler stand-in
+/// then plays the custom-signal waker: it delivers the signal for the id the
+/// wake reported and relaunches, and the replayed wait re-polls the now-present
+/// signal and completes.
+///
+/// A no-timeout wait carries NO deadline (the waker is the sole wake path),
+/// which is exactly the shape the stand-in refuses to relaunch until a signal
+/// is armed. Unlike a Delay, no duration threshold applies: a Wait is
+/// open-ended by construction.
 #[test]
-fn direct_wasm_execute_invoke_store_freeing_wait_suspends_on_signal_then_resumes() {
+fn direct_wasm_execute_invoke_wait_parks_on_signal_then_resumes() {
     let components_dir = direct_e2e_components_dir();
     let input = br#"{}"#.to_vec();
 
-    let artifact = compile_invoke_abi_artifact_configured(
-        &components_dir,
-        "store-freeing-wait-on",
-        STORE_FREEING_WAIT,
-        true,
-    );
+    let artifact = compile_invoke_abi_artifact(&components_dir, "wait-park", STORE_FREEING_WAIT);
     let host = Arc::new(CheckpointingRuntimeHost::new(&input));
 
-    // Invoke #1: the signal is absent, so the wait suspends on-signal.
-    let first = run_invoke_once(&artifact.wasm_path, host.clone(), input.clone());
-    let wakes = match first {
-        runtara_component_host::InvokeExit::Suspended(wakes) => wakes,
-        other => panic!("first invoke must suspend, got {other:?}"),
-    };
+    let legs = drive_wake_scheduler(
+        &artifact.wasm_path,
+        host.clone(),
+        input.clone(),
+        1,
+        |_, host, wakes| {
+            // The custom-signal waker: arm the signal the park is waiting on.
+            for wake in wakes {
+                if let runtara_component_host::lifecycle::WorkflowWake::OnSignal(wait) = wake {
+                    host.deliver_signal(&wait.checkpoint_id, br#"{"approved": true}"#);
+                }
+            }
+        },
+    );
+
+    assert_eq!(legs.len(), 2, "one park then one completing relaunch");
+    let wakes = legs[0].wakes();
     assert_eq!(wakes.len(), 1, "sequential lowering emits one wake");
     let (checkpoint_id, deadline) = match &wakes[0] {
         runtara_component_host::lifecycle::WorkflowWake::OnSignal(wait) => {
             (wait.checkpoint_id.clone(), wait.deadline_ms)
         }
-        other => panic!("a WaitForSignal must suspend on-signal, got {other:?}"),
+        other => panic!("a WaitForSignal must park on-signal, got {other:?}"),
     };
     assert!(
         !checkpoint_id.is_empty(),
@@ -7403,49 +7658,35 @@ fn direct_wasm_execute_invoke_store_freeing_wait_suspends_on_signal_then_resumes
     );
     assert_eq!(
         deadline, None,
-        "a no-timeout wait suspends without a deadline (waker is the sole wake path)"
+        "a no-timeout wait parks without a deadline (waker is the sole wake path)"
     );
     assert!(
         host.sleeps.lock().unwrap().is_empty(),
-        "store-freeing wait must not block on the poll interval"
+        "a parked wait must not block on the poll interval"
     );
-    assert!(host.completed.lock().unwrap().is_none());
-
-    // Deliver the signal for the id the wake reported (the waker stand-in),
-    // then relaunch (same host: the signal store + any checkpoints survive).
-    host.deliver_signal(&checkpoint_id, br#"{"approved": true}"#);
-    let second = run_invoke_once(&artifact.wasm_path, host.clone(), input.clone());
-    let output = match second {
-        runtara_component_host::InvokeExit::Completed(output) => output,
-        other => panic!("relaunch after signal must complete, got {other:?}"),
-    };
+    let output = legs[1].output().to_vec();
     assert_eq!(
         serde_json::from_slice::<Value>(&output).expect("output is JSON"),
         serde_json::json!({ "approved": true }),
         "the resumed wait must surface the delivered signal payload"
     );
 
-    // Control: the blocking lowering (gate OFF) reaches the same output when the
-    // signal is already present (its poll loop finds it on the first pass).
-    let blocking = compile_invoke_abi_artifact_configured(
-        &components_dir,
-        "store-freeing-wait-off",
-        STORE_FREEING_WAIT,
-        false,
-    );
-    let blocking_host = Arc::new(CheckpointingRuntimeHost::new(&input));
-    // The blocking artifact's deterministic signal id is workflow-id-scoped and
-    // differs from the store-freeing one, so pre-deliver for ANY polled id — its
-    // first poll then finds the signal and the loop exits.
-    blocking_host.deliver_signal_any(br#"{"approved": true}"#);
-    let blocking_exit = run_invoke_once(&blocking.wasm_path, blocking_host.clone(), input.clone());
-    let blocking_output = match blocking_exit {
+    // Control: a wait whose signal is ALREADY present never parks — its first
+    // poll finds the signal — and reaches the same output.
+    let present =
+        compile_invoke_abi_artifact(&components_dir, "wait-signal-present", STORE_FREEING_WAIT);
+    let present_host = Arc::new(CheckpointingRuntimeHost::new(&input));
+    // The deterministic signal id is workflow-id-scoped, so pre-deliver for ANY
+    // polled id.
+    present_host.deliver_signal_any(br#"{"approved": true}"#);
+    let present_exit = run_invoke_once(&present.wasm_path, present_host.clone(), input.clone());
+    let present_output = match present_exit {
         runtara_component_host::InvokeExit::Completed(output) => output,
-        other => panic!("blocking wait with a present signal must complete, got {other:?}"),
+        other => panic!("a wait with a present signal must complete, got {other:?}"),
     };
     assert_eq!(
-        blocking_output, output,
-        "store-freeing wait output must byte-match the blocking output"
+        present_output, output,
+        "a resumed park's output must byte-match the never-parked run's"
     );
 }
 
@@ -7497,7 +7738,6 @@ fn parent_workflow_composes_and_invokes_published_workflow_agent() {
         &components_dir,
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-        false,
         false,
     )
     .expect("child agent compile+compose succeeds");
@@ -7577,7 +7817,6 @@ fn parent_workflow_composes_and_invokes_published_workflow_agent() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -7675,7 +7914,6 @@ fn parent_workflow_invokes_published_durable_workflow_agent() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("durable child publishes as an agent");
     assert!(
@@ -7742,7 +7980,6 @@ fn parent_workflow_invokes_published_durable_workflow_agent() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -7850,7 +8087,6 @@ fn composed_durable_child_checkpoints_are_namespaced_per_invocation_site() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("durable child publishes as an agent");
     assert!(
@@ -7935,7 +8171,6 @@ fn composed_durable_child_checkpoints_are_namespaced_per_invocation_site() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -8076,7 +8311,6 @@ fn nested_composed_workflow_agents_chain_checkpoint_namespaces() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("grandchild publishes as an agent");
 
@@ -8141,7 +8375,6 @@ fn nested_composed_workflow_agents_chain_checkpoint_namespaces() {
         },
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("mid compiles as an agent");
     runtara_workflows::direct_wasm::compose_direct_workflow_with_extra_dirs(
@@ -8203,7 +8436,6 @@ fn nested_composed_workflow_agents_chain_checkpoint_namespaces() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("top compile succeeds");
@@ -8312,7 +8544,6 @@ fn stale_durable_workflow_agent_artifact_fails_compose() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("durable child compiles as an agent");
     assert!(
@@ -8390,7 +8621,6 @@ fn stale_durable_workflow_agent_artifact_fails_compose() {
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
         false,
-        false,
     )
     .expect("parent compile itself succeeds");
     let error = runtara_workflows::direct_wasm::compose_direct_workflow_with_extra_dirs(
@@ -8464,7 +8694,6 @@ fn stale_pure_workflow_agent_artifact_composes_freely() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("pure child compiles as an agent");
     assert!(child.omit_runtime, "pure child must not import the runtime");
@@ -8536,7 +8765,6 @@ fn stale_pure_workflow_agent_artifact_composes_freely() {
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
         false,
-        false,
     )
     .expect("parent compile succeeds");
     runtara_workflows::direct_wasm::compose_direct_workflow_with_extra_dirs(
@@ -8599,7 +8827,6 @@ fn composed_children_waiting_on_same_step_get_per_site_signal_ids() {
         &components_dir,
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
-        false,
         false,
     )
     .expect("waiting child publishes as an agent");
@@ -8677,7 +8904,6 @@ fn composed_children_waiting_on_same_step_get_per_site_signal_ids() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -8841,7 +9067,6 @@ fn embedded_children_waiting_on_same_step_get_per_site_signal_ids() {
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
         false,
-        false,
     )
     .expect("embed parent compiles");
     runtara_workflows::direct_wasm::compose_direct_workflow(&mut parent, &components_dir)
@@ -8960,7 +9185,6 @@ fn scoped_signal_wait_survives_drain_and_resume() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("waiting child publishes as an agent");
 
@@ -9023,7 +9247,6 @@ fn scoped_signal_wait_survives_drain_and_resume() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -9155,7 +9378,6 @@ fn pause_during_composed_child_wait_suspends_and_resumes() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("waiting child publishes as an agent");
 
@@ -9218,7 +9440,6 @@ fn pause_during_composed_child_wait_suspends_and_resumes() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -9369,7 +9590,6 @@ fn pause_inside_nested_composed_agents_chains_the_suspend() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("grandchild publishes as an agent");
 
@@ -9433,7 +9653,6 @@ fn pause_inside_nested_composed_agents_chains_the_suspend() {
         },
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("mid compiles as an agent");
     runtara_workflows::direct_wasm::compose_direct_workflow_with_extra_dirs(
@@ -9495,7 +9714,6 @@ fn pause_inside_nested_composed_agents_chains_the_suspend() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("top compile succeeds");
@@ -9614,7 +9832,6 @@ fn workflow_agent_tool_calls_get_per_call_checkpoint_scopes() {
         RuntimeBinding::HostImport,
         runtara_workflows::direct_wasm::WorkflowAbi::AgentCapabilities,
         false,
-        false,
     )
     .expect("durable tool child publishes as an agent");
     assert!(!child.omit_runtime, "durable tool child keeps the runtime");
@@ -9679,7 +9896,6 @@ fn workflow_agent_tool_calls_get_per_call_checkpoint_scopes() {
             agent_slug: None,
         },
         runtara_workflows::direct_wasm::WorkflowAbi::InvokeHostImports,
-        false,
         false,
     )
     .expect("parent compile succeeds");
@@ -11664,7 +11880,6 @@ fn direct_wasm_execute_delay_observes_cancel_and_suspends() {
             agent_slug: None,
         },
         WorkflowAbi::CliRunHttp,
-        false,
         false,
     )
     .expect("direct emit succeeds");

--- a/e2e/test_durable_delay_parks_and_wakes.sh
+++ b/e2e/test_durable_delay_parks_and_wakes.sh
@@ -237,6 +237,31 @@ AHEAD=$(psql_quiet -d "${TEST_DB_RUNTIME}" -c \
 echo "  sleep_until is ${AHEAD}s ahead of now (delay was $((LONG_DELAY_MS / 1000))s)"
 [ "${AHEAD}" -gt 5 ] || { print_error "sleep_until is only ${AHEAD}s out — the deadline was not computed from the duration"; exit 1; }
 
+# A manual resume is NOT the wake scheduler: `handle_resume_instance` accepts any
+# `suspended` row with no termination_reason filter, so it reaches a parked Delay
+# an hour early. The guest must re-read its stored deadline and re-park rather
+# than treat the checkpoint HIT as "already waited" and skip the whole delay.
+print_step "Resuming early — the parked Delay must re-park, not skip..."
+BEFORE_SLEEP_UNTIL="${P_SLEEP_UNTIL}"
+api_post "/workflows/instances/${INST_LONG}/resume" '{}' >/dev/null || true
+REPARKED=""
+for _ in {1..30}; do
+    ROW=$(instance_row "${INST_LONG}")
+    ST=$(instance_status "${INST_LONG}")
+    if [ "${ST}" = "completed" ]; then
+        print_error "An early resume ran the Delay out — the deadline was not re-checked"; exit 1
+    fi
+    if [ "${ROW%%|*}" = "suspended" ] && [ -n "${ROW##*|}" ]; then REPARKED="${ROW}"; fi
+    sleep 1
+    # Give the relaunch a moment, then confirm it parked again rather than finishing.
+    [ -n "${REPARKED}" ] && break
+done
+[ -n "${REPARKED}" ] || { print_error "Instance did not re-park after an early resume (row: $(instance_row "${INST_LONG}"))"; exit 1; }
+AFTER_SLEEP_UNTIL="${REPARKED##*|}"
+echo "  re-parked, sleep_until ${BEFORE_SLEEP_UNTIL} -> ${AFTER_SLEEP_UNTIL}"
+[ "${BEFORE_SLEEP_UNTIL}" = "${AFTER_SLEEP_UNTIL}" ] || print_warn "sleep_until moved across the re-park (expected the same absolute deadline)"
+print_success "Early resume re-parked on the same deadline, wait not skipped ✓"
+
 print_step "Waiting for the wake scheduler to relaunch it..."
 WOKE=""
 DEADLINE=$(( $(date +%s) + LONG_DELAY_MS / 1000 + 60 ))

--- a/e2e/test_durable_delay_parks_and_wakes.sh
+++ b/e2e/test_durable_delay_parks_and_wakes.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# E2E Test: a durable Delay frees the Store and is relaunched by the wake scheduler.
+#
+# A durable Delay used to sleep out its whole duration in-process, pinning a
+# wasmtime Store and a tokio task for the entire wait — a 24-hour Delay held a
+# Store for 24 hours. The Delay lowering now checkpoints an absolute deadline
+# and exits with `outcome::suspended(at(deadline))`; the host frees the Store,
+# stamps `sleep_until`, and the wake scheduler relaunches at the deadline.
+#
+# Parking is only worth it for a wait long enough to pay for the round trip
+# (checkpoint write, Store teardown, up to one 5s scheduler poll of lag, and a
+# replay from the entry step), so the choice is made at RUNTIME against a 30s
+# threshold. This test asserts both sides of it:
+#
+#   LONG  (>= threshold) -> status=suspended, termination_reason='sleeping',
+#                           sleep_until ~ now+duration, container registry row
+#                           gone (the Store really was freed), then the wake
+#                           scheduler relaunches it and it completes.
+#   SHORT (<  threshold) -> never suspends; blocks in-process and completes,
+#                           with no sleep_until ever stamped.
+#
+# The short case is the one a threshold-free promotion would get wrong: it would
+# park for 2s and wait up to 5s for a poll, turning a sub-second pause inside a
+# loop into a multi-second one plus a replay per iteration.
+#
+# Usage:  ./e2e/test_durable_delay_parks_and_wakes.sh
+#
+# Prereqs: Postgres + docker (isolated Valkey) and prebuilt components in
+# target/wasm32-wasip2/release (scripts/build-agent-components.sh).
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+print_step()    { echo -e "${GREEN}[STEP]${NC} $1"; }
+print_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Must straddle the 30s park threshold in the Delay lowering.
+LONG_DELAY_MS="${LONG_DELAY_MS:-45000}"
+SHORT_DELAY_MS="${SHORT_DELAY_MS:-2000}"
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-smo_worker}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-GueUkDKea0CjKP4Rn5Bk0FDV}"
+
+TEST_DB_SERVER="delay_e2e_server_$$"
+TEST_DB_RUNTIME="delay_e2e_runtime_$$"
+TEST_PORT_PUBLIC="${TEST_PORT_PUBLIC:-17720}"
+TEST_PORT_INTERNAL="${TEST_PORT_INTERNAL:-17721}"
+TEST_CORE_PORT="${TEST_CORE_PORT:-18721}"
+TEST_ENV_PORT="${TEST_ENV_PORT:-18722}"
+TEST_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT:-18723}"
+TEST_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT:-18724}"
+TEST_VALKEY_PORT="${TEST_VALKEY_PORT:-16392}"
+TEST_DATA_DIR="$(mktemp -d -t runtara_delay_e2e_XXXXXX)"
+TEST_LOG="${TEST_DATA_DIR}/server.log"
+SERVER_PID=""
+VALKEY_CONTAINER=""
+TENANT="delay_e2e"
+
+RUNTARA_SERVER_BIN="${RUNTARA_SERVER_BIN:-${PROJECT_ROOT}/target/debug/runtara-server}"
+COMPONENTS_DIR="${RUNTARA_AGENT_COMPONENTS_DIR:-${PROJECT_ROOT}/target/wasm32-wasip2/release}"
+SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
+SERVER_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_SERVER}"
+RUNTIME_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_RUNTIME}"
+API="http://127.0.0.1:${TEST_PORT_PUBLIC}/api/runtime"
+
+# `psql` is not always on PATH on a dev box where Postgres runs in a container;
+# fall back to running it inside that container. Either way the server itself
+# reaches Postgres over the published port on the host.
+PG_CONTAINER="${PG_CONTAINER:-runtara-dev-postgres}"
+if command -v psql >/dev/null 2>&1; then
+    psql_quiet() {
+        PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA "$@"
+    }
+else
+    psql_quiet() {
+        docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" -i "${PG_CONTAINER}" \
+            psql -U "${POSTGRES_USER}" -tA "$@"
+    }
+fi
+api_post() {
+    curl -sS --max-time "${3:-60}" -X POST -H "Content-Type: application/json" -d "$2" "${API}$1"
+}
+
+cleanup() {
+    local code=$?
+    [ -n "${SERVER_PID}" ] && kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+    [ -n "${VALKEY_CONTAINER}" ] && docker rm -f "${VALKEY_CONTAINER}" >/dev/null 2>&1 || true
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_SERVER} WITH (FORCE)" >/dev/null 2>&1 || true
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_RUNTIME} WITH (FORCE)" >/dev/null 2>&1 || true
+    [ ${code} -ne 0 ] && [ -f "${TEST_LOG}" ] && { echo "--- server log tail ---"; tail -40 "${TEST_LOG}"; }
+    rm -rf "${TEST_DATA_DIR}"
+    exit ${code}
+}
+trap cleanup EXIT
+
+start_server() {
+    RUNTARA_SERVER_DATABASE_URL="${SERVER_DB_URL}" \
+    OBJECT_MODEL_DATABASE_URL="${SERVER_DB_URL}" \
+    RUNTARA_DATABASE_URL="${RUNTIME_DB_URL}" \
+    TENANT_ID="${TENANT}" \
+    SERVER_HOST=127.0.0.1 \
+    SERVER_PORT="${TEST_PORT_PUBLIC}" \
+    INTERNAL_PORT="${TEST_PORT_INTERNAL}" \
+    RUNTARA_CORE_PORT="${TEST_CORE_PORT}" \
+    RUNTARA_ENVIRONMENT_PORT="${TEST_ENV_PORT}" \
+    RUNTARA_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT}" \
+    RUNTARA_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT}" \
+    RUNTARA_AGENT_COMPONENTS_DIR="${COMPONENTS_DIR}" \
+    DATA_DIR="${TEST_DATA_DIR}" \
+    RUNTARA_DEV_MODE=false \
+    RUST_LOG="${RUST_LOG_OVERRIDE:-warn,runtara_server=info,runtara_environment=info,runtara_core=info}" \
+    AUTH_PROVIDER=local \
+    SESSION_TOKEN_SECRET=8efacf953eb244e07346edb64d1a8adca5bdf92049611737ce09e2c6388cb5f2 \
+    VALKEY_HOST=127.0.0.1 \
+    VALKEY_PORT="${TEST_VALKEY_PORT}" \
+    OTEL_SDK_DISABLED=true \
+    RUNTARA_SDK_BACKEND=http \
+    SQLX_OFFLINE="${SQLX_OFFLINE}" \
+    "${RUNTARA_SERVER_BIN}" >>"${TEST_LOG}" 2>&1 &
+    SERVER_PID=$!
+
+    for _ in {1..60}; do
+        if curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${TEST_PORT_PUBLIC}/health" 2>/dev/null | grep -q "^2"; then
+            return 0
+        fi
+        sleep 1
+        if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            print_error "Server exited during boot."; exit 1
+        fi
+    done
+    print_error "Server did not become healthy."; exit 1
+}
+
+instance_status() {
+    curl -sS "${API}/workflows/instances/$1" | jq -r '.data.status // .status // empty'
+}
+# Runtime-DB truth for the park: the wake bookkeeping the guest never sees.
+instance_row() {
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c \
+        "SELECT COALESCE(status::text,''), COALESCE(termination_reason::text,''), COALESCE(sleep_until::text,'') FROM instances WHERE instance_id = '$1'"
+}
+registry_rows() {
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c \
+        "SELECT COUNT(*) FROM container_registry WHERE instance_id = '$1'" | tr -d '[:space:]'
+}
+
+# Create + compile + deploy a single-Delay workflow, echo its id.
+make_delay_workflow() {
+    local name="$1" duration_ms="$2" resp wf_id definition version
+    resp=$(api_post /workflows/create "{\"name\": \"${name}\", \"description\": \"single durable Delay\"}")
+    wf_id=$(echo "${resp}" | jq -r '.data.id // empty')
+    [ -n "${wf_id}" ] || { print_error "Workflow create failed: ${resp}"; exit 1; }
+
+    definition=$(jq -n --argjson ms "${duration_ms}" '{
+      name: "delay-park-harness",
+      durable: true,
+      entryPoint: "delay",
+      steps: {
+        delay: { stepType: "Delay", id: "delay", name: "Wait", durationMs: { valueType: "immediate", value: $ms } },
+        finish: { stepType: "Finish", id: "finish",
+                  inputMapping: { waited: { valueType: "immediate", value: true } } }
+      },
+      executionPlan: [ { fromStep: "delay", toStep: "finish" } ],
+      variables: {}, inputSchema: {}, outputSchema: {}
+    }')
+    resp=$(api_post "/workflows/${wf_id}/update" "{\"executionGraph\": ${definition}}")
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Update failed: ${resp}"; exit 1; }
+    version=$(curl -sS "${API}/workflows/${wf_id}/versions" | jq -r '[.data[]?.version // .data[]?.versionNumber // empty] | max // 1')
+    resp=$(api_post "/workflows/${wf_id}/versions/${version}/compile" '{}' 900)
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Compile failed: ${resp}"; exit 1; }
+    echo "${wf_id}"
+}
+
+echo "==============================================================="
+echo "E2E: durable Delay parks and is woken  (long=${LONG_DELAY_MS}ms, short=${SHORT_DELAY_MS}ms)"
+echo "==============================================================="
+
+[ -x "${RUNTARA_SERVER_BIN}" ] || { print_error "Missing server bin ${RUNTARA_SERVER_BIN} (cargo build -p runtara-server --bin runtara-server)"; exit 1; }
+[ -f "${COMPONENTS_DIR}/runtara_workflow_stdlib.wasm" ] || { print_error "Missing runtara_workflow_stdlib.wasm — run scripts/build-agent-components.sh"; exit 1; }
+psql_quiet -d postgres -c "SELECT 1" >/dev/null 2>&1 || { print_error "Cannot reach Postgres (psql on PATH, or container '${PG_CONTAINER}')"; exit 1; }
+docker info >/dev/null 2>&1 || { print_error "docker required (isolated Valkey)"; exit 1; }
+
+print_step "Starting isolated Valkey on :${TEST_VALKEY_PORT}..."
+VALKEY_CONTAINER=$(docker run -d --rm -p "${TEST_VALKEY_PORT}:6379" valkey/valkey:8-alpine)
+for _ in {1..20}; do (echo > /dev/tcp/127.0.0.1/${TEST_VALKEY_PORT}) 2>/dev/null && break; sleep 0.5; done
+
+print_step "Creating databases..."
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_SERVER}" >/dev/null
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_RUNTIME}" >/dev/null
+
+print_step "Starting runtara-server on :${TEST_PORT_PUBLIC}..."
+start_server
+echo "  Server up (PID ${SERVER_PID})"
+
+# ---------------------------------------------------------------------------
+# Case 1 — LONG delay: must park, free the Store, and be woken.
+# ---------------------------------------------------------------------------
+print_step "Case 1: ${LONG_DELAY_MS}ms Delay (at/above threshold) must PARK..."
+WF_LONG=$(make_delay_workflow "delay-park-long" "${LONG_DELAY_MS}")
+RESP=$(api_post "/workflows/${WF_LONG}/execute" '{"inputs": {"data": {}}}')
+INST_LONG=$(echo "${RESP}" | jq -r '.data.instanceId // empty')
+[ -n "${INST_LONG}" ] || { print_error "Execute failed: ${RESP}"; exit 1; }
+echo "  Instance ${INST_LONG}"
+
+PARKED=""
+for _ in {1..30}; do
+    ROW=$(instance_row "${INST_LONG}")
+    if [ "${ROW%%|*}" = "suspended" ]; then PARKED="${ROW}"; break; fi
+    sleep 1
+done
+[ -n "${PARKED}" ] || { print_error "Instance never parked (row: $(instance_row "${INST_LONG}"), status: $(instance_status "${INST_LONG}"))"; exit 1; }
+
+IFS='|' read -r P_STATUS P_REASON P_SLEEP_UNTIL <<< "${PARKED}"
+echo "  status=${P_STATUS} termination_reason=${P_REASON} sleep_until=${P_SLEEP_UNTIL}"
+[ "${P_STATUS}" = "suspended" ] || { print_error "expected status=suspended, got '${P_STATUS}'"; exit 1; }
+[ "${P_REASON}" = "sleeping" ] || { print_error "expected termination_reason=sleeping, got '${P_REASON}'"; exit 1; }
+[ -n "${P_SLEEP_UNTIL}" ] || { print_error "sleep_until was not stamped — the wake scheduler has nothing to act on"; exit 1; }
+
+# The Store really was freed: no live container registered for this instance.
+REG=$(registry_rows "${INST_LONG}")
+[ "${REG}" = "0" ] || print_warn "container_registry still has ${REG} row(s) for the parked instance"
+print_success "Parked with a timed wake — Store freed, sleep_until stamped ✓"
+
+# sleep_until must be ~now+duration, not now: the deadline is absolute, so a
+# resume never re-sleeps time that already elapsed.
+AHEAD=$(psql_quiet -d "${TEST_DB_RUNTIME}" -c \
+    "SELECT EXTRACT(EPOCH FROM (sleep_until - NOW()))::int FROM instances WHERE instance_id = '${INST_LONG}'" | tr -d '[:space:]')
+echo "  sleep_until is ${AHEAD}s ahead of now (delay was $((LONG_DELAY_MS / 1000))s)"
+[ "${AHEAD}" -gt 5 ] || { print_error "sleep_until is only ${AHEAD}s out — the deadline was not computed from the duration"; exit 1; }
+
+print_step "Waiting for the wake scheduler to relaunch it..."
+WOKE=""
+DEADLINE=$(( $(date +%s) + LONG_DELAY_MS / 1000 + 60 ))
+while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+    ST=$(instance_status "${INST_LONG}")
+    if [ "${ST}" = "completed" ]; then WOKE="yes"; break; fi
+    if [ "${ST}" = "failed" ] || [ "${ST}" = "cancelled" ]; then
+        print_error "Instance ended ${ST} instead of completing after its wake"; exit 1
+    fi
+    sleep 2
+done
+[ -n "${WOKE}" ] || { print_error "Instance never woke (status: $(instance_status "${INST_LONG}"))"; exit 1; }
+print_success "Woken at its deadline and completed ✓"
+
+# ---------------------------------------------------------------------------
+# Case 2 — SHORT delay: must block, never park.
+# ---------------------------------------------------------------------------
+print_step "Case 2: ${SHORT_DELAY_MS}ms Delay (below threshold) must BLOCK..."
+WF_SHORT=$(make_delay_workflow "delay-park-short" "${SHORT_DELAY_MS}")
+RESP=$(api_post "/workflows/${WF_SHORT}/execute" '{"inputs": {"data": {}}}')
+INST_SHORT=$(echo "${RESP}" | jq -r '.data.instanceId // empty')
+[ -n "${INST_SHORT}" ] || { print_error "Execute failed: ${RESP}"; exit 1; }
+echo "  Instance ${INST_SHORT}"
+
+SAW_SUSPENDED=""
+SHORT_DONE=""
+DEADLINE=$(( $(date +%s) + 60 ))
+while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+    ROW=$(instance_row "${INST_SHORT}")
+    [ "${ROW%%|*}" = "suspended" ] && SAW_SUSPENDED="yes"
+    ST=$(instance_status "${INST_SHORT}")
+    if [ "${ST}" = "completed" ]; then SHORT_DONE="yes"; break; fi
+    if [ "${ST}" = "failed" ] || [ "${ST}" = "cancelled" ]; then
+        print_error "Short-delay instance ended ${ST}"; exit 1
+    fi
+    sleep 0.5
+done
+[ -n "${SHORT_DONE}" ] || { print_error "Short-delay instance never completed (status: $(instance_status "${INST_SHORT}"))"; exit 1; }
+[ -z "${SAW_SUSPENDED}" ] || { print_error "A below-threshold Delay parked; it must block in-process"; exit 1; }
+
+FINAL_SLEEP=$(psql_quiet -d "${TEST_DB_RUNTIME}" -c \
+    "SELECT COALESCE(sleep_until::text,'') FROM instances WHERE instance_id = '${INST_SHORT}'" | tr -d '[:space:]')
+[ -z "${FINAL_SLEEP}" ] || { print_error "A blocking Delay stamped sleep_until='${FINAL_SLEEP}'"; exit 1; }
+print_success "Blocked in-process and completed, never parked ✓"
+
+echo
+print_success "SYN-619 verified: long Delay parks and is woken; short Delay blocks."


### PR DESCRIPTION
Closes [SYN-619](https://linear.app/syncmyordershq/issue/SYN-619/durable-delay-blocks-the-host-for-its-full-duration-promote-store).

## What changed

A durable Delay slept out its whole duration in-process, pinning a wasmtime Store and a tokio task for the entire wait — a 24-hour Delay held a Store for 24 hours. The store-freeing lowering that fixes this already existed but sat behind `RUNTARA_DIRECT_STORE_FREEING_SLEEP`, **set nowhere in the repo**.

- **The gate is deleted, not inverted.** What remains in `delay.rs` / `wait.rs` is a *capability* check, not a policy one: only the invoke export has a success arm (`outcome::suspended`) able to carry a wake, so `wasi:cli/run` and a workflow published as an agent still block. The `store_freeing_sleep` parameter is threaded out of the whole compile chain, including `DirectCoreConfig` and `DirectCoreFunctionIndices`.
- **`RUNTARA_DIRECT_OMIT_RUNTIME` gets its own parser first**, with a test pinning it. It shared the deleted gate's parser, and a shared parser turns any change to one gate's semantics into a silent change to an unrelated lever's.
- **A 30s park threshold, evaluated at runtime.** `durationMs` may be a reference the emitter cannot resolve, so both arms are emitted and the guest picks with an `i64.ge_u`.

## Why 30s

Parking costs a checkpoint write, a Store teardown, up to one wake-scheduler poll of lag (**5s** by default), and a relaunch that replays from the entry step — every already-completed step pays a checkpoint lookup to skip itself, so the cost grows with how deep the delay sits. Blocking costs one pinned Store for the duration.

30s keeps scheduler lag a small fraction of the wait (~17% rather than dwarfing it) and keeps a sub-second pause inside a `While` loop blocking rather than parking and replaying on every iteration. The waits that motivated the ticket — hours-long business delays — are all far above it.

Worth noting: the ticket's own examples imply a threshold in (25ms, 300ms]. I went higher deliberately, and two of the ticket's premises are stale against current `main` — consequence 2 (any Delay over ~2 minutes reaped as `failed`) and the cancel-during-sleep miss were both fixed when SYN-606 merged, so `handle_sleep` now heartbeats each tick and wakes early on cancel. The remaining bug is purely the pinned Store, which is a memory-vs-latency trade, and that argues for parking only where the memory actually matters.

## Harness fidelity

Both gaps the ticket flagged, fixed rather than papered over:

- The mocks did not persist a blocking sleep's checkpoint ("keeping fixtures fast"), diverging from production `handle_sleep`, which saves one. Both now save. **One correction to the ticket:** the consequence it attributed to this doesn't hold — production doesn't serve a replayed blocking sleep from cache either, because `handle_sleep` saves a checkpoint but never looks one up (the resume-remaining math was deliberately not ported; see `runtime_host.rs` module docs).
- The harness only ever invoked once, which cannot be right once a step parks. The invoke axis now stands in for the wake scheduler, relaunching a parked run against the same mock state until it is terminal, and mirroring `park_invoke_suspend` by relaunching **only timed wakes** — never an `on-resume` park, which is a cancel ack or drain pause the host deliberately leaves alone.

Only **one** existing test changed behaviour, not the five the ticket predicted (the higher threshold leaves the smoke fixtures blocking): a Wait timeout, which now parks on an on-signal wake and reaches its `onError` route after the relaunch. It still asserts `WAIT_TIMEOUT` routes to `onError` exactly as before.

## How it was verified

- Full CI clippy gate (`--workspace --all-targets` with `GATE_FEATURES`, `-D warnings`) and `cargo fmt --check`: clean.
- `direct_wasm_execute`: **163/165**. The 2 failures are `compression_round_trips_in_guest` and `xlsx_parses_in_guest`, which fail identically on unmodified `main` (verified by stashing) — stale staged agent components, out of scope.
- Mutation check: forcing the threshold to 1ms makes both new threshold tests fail, so they genuinely exercise the emitted wasm.
- **New `e2e/test_durable_delay_parks_and_wakes.sh`**, run against a local server — this is the host-side wiring (`park_invoke_suspend` → `sleep_until` → `WakeScheduler`) that no unit test executes:
  - 45s Delay → `status=suspended`, `termination_reason=sleeping`, `sleep_until` = now+44s, container registry row gone, then relaunched by the wake scheduler and completed.
  - 2s Delay → blocked in-process, completed, never suspended, `sleep_until` never stamped.

## Out of scope

Deleting `/sleep` and the blocking lowering outright, per the ticket — blocked on retiring the legacy `composed` / `cli-run` shapes. The blocking arm is still reachable below the threshold and under both legacy ABIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)