### PR TITLE
Stop the dev Postgres reporting healthy during initdb

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -31,10 +31,26 @@ services:
             - postgres_data:/var/lib/postgresql
             - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U smo_worker -d smo_container"]
+            # Probed over TCP, and against a database init-db.sql creates.
+            #
+            # On first boot the entrypoint runs a temporary server with
+            # listen_addresses='' so it can execute the initdb scripts, then
+            # shuts it down and starts the real one. `pg_isready` over the unix
+            # socket answers during that window, so the container reported
+            # healthy while the only server running was about to be stopped -
+            # anything that connected on the strength of that got "connection
+            # reset by peer". Requiring TCP means the probe cannot pass until
+            # the real server is listening, and naming `runtara` means it
+            # cannot pass until the init scripts have actually run.
+            test:
+                [
+                    "CMD-SHELL",
+                    "pg_isready -h 127.0.0.1 -U smo_worker -d runtara",
+                ]
             interval: 2s
             timeout: 5s
-            retries: 10
+            retries: 15
+            start_period: 10s
 
     valkey:
         image: valkey/valkey:8-alpine


### PR DESCRIPTION
## Description

The `v8.7.9` Release run failed in **Smoke Bundle** — the first Release failure since `v8.7.0`. The backend never came up, so the job polled `127.0.0.1:7001` for ~80 seconds and then printed:

```
thread 'main' panicked at crates/runtara-server/src/main.rs:28:10:
Failed to connect to database: Io(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })
```

That is at **connect**, before any migration runs, and all three bundle builds succeeded — so this is not a code regression in the release.

**Cause.** On first boot the Postgres entrypoint starts a *temporary* server with `listen_addresses=''` so it can execute `/docker-entrypoint-initdb.d/*`, then shuts it down and starts the real one. The healthcheck was `pg_isready -U smo_worker -d smo_container` over the unix socket, which **answers during that window**. Compose marked the container healthy, the workflow's wait loop moved on, and the backend connected right as the temporary server was being stopped — "connection reset by peer". It is purely timing, which is why it passed for eight releases and failed on the ninth.

**Fix.** Probe over TCP, against a database `init-db.sql` creates. During init there is no TCP listener, so the probe cannot pass until the real server is up; naming `runtara` means it cannot pass until the init scripts have actually run. Also adds `start_period: 10s` and two more retries so the longer, honest startup is not mistaken for a failure.

## Related Issue

<!-- none -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [ ] I have run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` <!-- no Rust changed; the workspace gate was run on main separately and is clean -->
- [x] I have added tests that prove my fix/feature works <!-- reproduced empirically, below -->
- [x] All new and existing tests pass (`cargo test`)
- [ ] I have updated the documentation if needed
- [x] My changes don't introduce new warnings

## Testing

`docker compose -f dev/docker-compose.yml config` validates.

The race was reproduced against a throwaway `pgvector/pgvector:pg18` container with the same init script, polling both probes every 500 ms from container start:

| probe # | old (socket, `smo_container`) | new (TCP, `runtara`) |
|---|---|---|
| 1–5 | not ready | not ready |
| **6** | **READY** ← temporary init server | not ready |
| 7–9 | not ready ← temp server stopped | not ready |
| 10 | READY | **READY** |

Probe 6 is the false positive. Probes 7–9 are the window in which a client that trusted it gets `connection reset by peer` — precisely the release failure. The new probe never reports ready before the real server is listening.

## Additional Notes

This only touches `dev/docker-compose.yml`, which is used by local development and by the release smoke job. No application code changes.

**The `v8.7.9` release is still blocked** — `Smoke Bundle` failing skipped `Build Docker Image`, `Merge Docker Manifest` and `Create Release`, so no release artifacts were published. Re-running the Release workflow for the tag after this merges should carry it through; I have deliberately not re-run it, since a green run publishes a GitHub release and Docker images.
