### PR TITLE
SYN-621: Name the sleep and the timeout when a durable sleep fails

### DIFF
--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -54,10 +54,29 @@ impl HttpSdkConfig {
         let base_url = std::env::var("RUNTARA_HTTP_URL")
             .unwrap_or_else(|_| "http://127.0.0.1:8003".to_string());
 
-        let request_timeout_ms = std::env::var("RUNTARA_REQUEST_TIMEOUT_MS")
+        // A parsed 0 is refused rather than accepted or quietly defaulted. It
+        // reads as the conventional "no limit", but the client builds its
+        // deadline as `now + timeout`, so zero is a deadline already in the past
+        // and EVERY request — sleep, checkpoint, heartbeat, complete — fails
+        // instantly with a timeout. Unparseable values still fall back to the
+        // default: those are typos, and a typo that costs nothing is not worth
+        // refusing to start over. Zero is different — it is a deliberate setting
+        // whose meaning is the opposite of what it looks like.
+        let request_timeout_ms = match std::env::var("RUNTARA_REQUEST_TIMEOUT_MS")
             .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(30_000);
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            Some(0) => {
+                return Err(SdkError::Config(
+                    "RUNTARA_REQUEST_TIMEOUT_MS=0 is not \"no timeout\": it puts every request's \
+                     deadline in the past, so all of them fail instantly. Set a positive number \
+                     of milliseconds, or leave it unset for 30000."
+                        .into(),
+                ));
+            }
+            Some(value) => value,
+            None => 30_000,
+        };
 
         let signal_poll_interval_ms = std::env::var("RUNTARA_SIGNAL_POLL_INTERVAL_MS")
             .ok()
@@ -132,24 +151,34 @@ impl HttpBackend {
     ///
     /// Left to run, the failure names neither sleep nor the ceiling: it reads as
     /// a server that stopped answering. Refusing up front costs milliseconds
-    /// instead of the whole timeout and says which knob moves the ceiling.
+    /// instead of the whole timeout, and names what can actually move it.
     ///
-    /// A zero timeout is left alone deliberately. It is a degenerate
-    /// configuration under which no request of any kind can complete, so
-    /// reporting it against the sleep would blame the sleep for something that
-    /// is not about sleeping at all.
+    /// A zero timeout is passed through rather than reported. Zero is not "no
+    /// limit" — it is a deadline already in the past, so nothing completes,
+    /// sleep or otherwise; blaming the sleep would point at the wrong thing
+    /// entirely. [`HttpSdkConfig::from_env`] refuses it up front, so this only
+    /// covers a config built by hand.
     fn reject_sleep_beyond_request_timeout(&self, duration_ms: u64) -> Result<()> {
         let timeout_ms = self.request_timeout_ms;
         if timeout_ms == 0 || duration_ms < timeout_ms {
             return Ok(());
         }
 
+        // The remedy named first is the one that always works. Raising
+        // RUNTARA_REQUEST_TIMEOUT_MS is real only where the SDK reads its own
+        // process environment: a workflow guest's environment is BUILT for it by
+        // the host (`build_env` in runtara-environment) and carries just the
+        // handful of variables that function forwards, this not among them. An
+        // operator told to raise it there would change nothing and conclude the
+        // diagnosis was wrong — which is the failure this message exists to end.
         Err(SdkError::Sleep(format!(
             "durable sleep of {duration_ms}ms does not fit inside the {timeout_ms}ms client \
              request timeout: this backend holds the sleep request open for the whole duration, \
-             so the client aborts it at {timeout_ms}ms before the server ever answers. Raise \
-             RUNTARA_REQUEST_TIMEOUT_MS above the sleep duration, or run the workflow on the \
-             host-import binding, whose durable sleep issues no request at all."
+             so the client aborts it at {timeout_ms}ms before the server ever answers. A sleep \
+             this long needs the host-import binding, whose durable sleep is a host call and \
+             issues no request at all. Raising RUNTARA_REQUEST_TIMEOUT_MS helps only where this \
+             SDK reads its own process environment — a workflow guest's environment is built by \
+             the host and does not carry it."
         )))
     }
 
@@ -791,6 +820,41 @@ mod config_tests {
         assert_eq!(cfg.base_url, "http://127.0.0.1:8003");
     }
 
+    /// Zero looks like "no timeout" and behaves like the exact opposite: the
+    /// client's deadline lands in the past and every request fails instantly.
+    /// Refused by name rather than accepted, so the setting is diagnosed where
+    /// it is made instead of surfacing later as a fleet of instant timeouts.
+    #[test]
+    fn test_http_sdk_config_refuses_a_zero_request_timeout() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_INSTANCE_ID", "test-instance");
+        guard.set("RUNTARA_TENANT_ID", "test-tenant");
+        guard.set("RUNTARA_REQUEST_TIMEOUT_MS", "0");
+
+        let message = HttpSdkConfig::from_env()
+            .expect_err("a zero request timeout is refused")
+            .to_string();
+
+        assert!(message.contains("RUNTARA_REQUEST_TIMEOUT_MS"), "{message}");
+        assert!(message.contains("30000"), "{message}");
+    }
+
+    /// A value that is not a number stays a fall-back to the default: typos cost
+    /// nothing, so refusing to start over one would be worse than absorbing it.
+    #[test]
+    fn test_http_sdk_config_falls_back_on_an_unparseable_request_timeout() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let mut guard = EnvGuard::new();
+        guard.set("RUNTARA_INSTANCE_ID", "test-instance");
+        guard.set("RUNTARA_TENANT_ID", "test-tenant");
+        guard.set("RUNTARA_REQUEST_TIMEOUT_MS", "not-a-number");
+
+        let cfg = HttpSdkConfig::from_env().expect("a typo falls back to the default");
+
+        assert_eq!(cfg.request_timeout_ms, 30_000);
+    }
+
     #[test]
     fn test_http_sdk_config_uses_http_url() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -863,6 +927,9 @@ mod sleep_ceiling_tests {
         let message = error.to_string();
         assert!(message.contains("35000ms"), "{message}");
         assert!(message.contains("30000ms"), "{message}");
+        // The binding is the remedy that always works; the env var is qualified
+        // rather than offered, because a workflow guest never sees it.
+        assert!(message.contains("host-import binding"), "{message}");
         assert!(message.contains("RUNTARA_REQUEST_TIMEOUT_MS"), "{message}");
     }
 
@@ -894,9 +961,10 @@ mod sleep_ceiling_tests {
         );
     }
 
-    /// Zero is not a ceiling of zero. It is a configuration under which no
-    /// request of any kind completes, so reporting it against the sleep would
-    /// blame the sleep for something that has nothing to do with sleeping.
+    /// Zero is not a ceiling of zero. It is a deadline already in the past, so
+    /// no request of any kind completes and blaming the sleep would point at the
+    /// wrong thing; `from_env` refuses it before it can get this far, and this
+    /// covers the hand-built config that bypasses it.
     #[test]
     fn a_zero_timeout_is_not_treated_as_a_ceiling() {
         assert!(

--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -89,6 +89,10 @@ pub struct HttpBackend {
     tenant_id: String,
     base_url: String,
     client: runtara_http::HttpClient,
+    /// The deadline the client applies to every request, kept alongside the
+    /// client that enforces it because durable sleep has to reason about it —
+    /// see [`HttpBackend::reject_sleep_beyond_request_timeout`].
+    request_timeout_ms: u64,
     connected: AtomicBool,
 }
 
@@ -104,6 +108,7 @@ impl HttpBackend {
             tenant_id: config.tenant_id.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
             client,
+            request_timeout_ms: config.request_timeout_ms,
             connected: AtomicBool::new(false),
         })
     }
@@ -114,6 +119,38 @@ impl HttpBackend {
             "{}/api/v1/instances/{}/{}",
             self.base_url, self.instance_id, path
         )
+    }
+
+    /// Refuse a durable sleep the client deadline cannot outlast.
+    ///
+    /// `POST .../sleep` does not answer until the sleep is over: core holds the
+    /// response open for the whole duration. This backend's client, meanwhile,
+    /// aborts any request that produces no first byte within
+    /// `request_timeout_ms`. A sleep at or beyond that ceiling therefore cannot
+    /// succeed — the abort always lands first, and it lands at the timeout, not
+    /// at the requested duration.
+    ///
+    /// Left to run, the failure names neither sleep nor the ceiling: it reads as
+    /// a server that stopped answering. Refusing up front costs milliseconds
+    /// instead of the whole timeout and says which knob moves the ceiling.
+    ///
+    /// A zero timeout is left alone deliberately. It is a degenerate
+    /// configuration under which no request of any kind can complete, so
+    /// reporting it against the sleep would blame the sleep for something that
+    /// is not about sleeping at all.
+    fn reject_sleep_beyond_request_timeout(&self, duration_ms: u64) -> Result<()> {
+        let timeout_ms = self.request_timeout_ms;
+        if timeout_ms == 0 || duration_ms < timeout_ms {
+            return Ok(());
+        }
+
+        Err(SdkError::Sleep(format!(
+            "durable sleep of {duration_ms}ms does not fit inside the {timeout_ms}ms client \
+             request timeout: this backend holds the sleep request open for the whole duration, \
+             so the client aborts it at {timeout_ms}ms before the server ever answers. Raise \
+             RUNTARA_REQUEST_TIMEOUT_MS above the sleep duration, or run the workflow on the \
+             host-import binding, whose durable sleep issues no request at all."
+        )))
     }
 
     /// POST JSON to an endpoint and deserialize the response.
@@ -548,13 +585,22 @@ impl SdkBackend for HttpBackend {
     }
 
     fn durable_sleep(&self, duration: Duration, checkpoint_id: &str, state: &[u8]) -> Result<()> {
+        let duration_ms = duration.as_millis() as u64;
+        self.reject_sleep_beyond_request_timeout(duration_ms)?;
+
         let body = SleepBody {
-            duration_ms: duration.as_millis() as u64,
+            duration_ms,
             checkpoint_id: checkpoint_id.to_string(),
             state: encode_b64(state),
         };
 
-        let resp: SuccessResp = self.post(&self.url("sleep"), &body)?;
+        // Re-label a transport failure as a sleep failure. The generic text is
+        // "HTTP request failed", which for the one request that is *meant* to
+        // take minutes reads as an unrelated network fault; naming the sleep and
+        // its duration is what points a reader at the right thing.
+        let resp: SuccessResp = self.post(&self.url("sleep"), &body).map_err(|error| {
+            SdkError::Sleep(format!("durable sleep of {duration_ms}ms failed: {error}"))
+        })?;
 
         if resp.success {
             Ok(())
@@ -756,5 +802,150 @@ mod config_tests {
         let cfg = HttpSdkConfig::from_env().unwrap();
 
         assert_eq!(cfg.base_url, "http://example.test:1234");
+    }
+}
+
+#[cfg(test)]
+mod sleep_ceiling_tests {
+    use super::{HttpBackend, HttpSdkConfig};
+    use crate::backend::SdkBackend;
+    use crate::error::SdkError;
+    use std::time::Duration;
+
+    fn backend_at(base_url: String, request_timeout_ms: u64) -> HttpBackend {
+        HttpBackend::new(&HttpSdkConfig {
+            instance_id: "test-instance".to_string(),
+            tenant_id: "test-tenant".to_string(),
+            base_url,
+            request_timeout_ms,
+            signal_poll_interval_ms: 1_000,
+            heartbeat_interval_ms: 30_000,
+        })
+        .expect("backend construction is infallible for a well-formed config")
+    }
+
+    /// `base_url` is deliberately a dead port: these assertions are about sleeps
+    /// that never get as far as building a request, so a backend that stopped
+    /// refusing would fail by dialling rather than pass silently.
+    fn backend(request_timeout_ms: u64) -> HttpBackend {
+        backend_at("http://127.0.0.1:1".to_string(), request_timeout_ms)
+    }
+
+    /// A stand-in core that accepts the connection and then answers nothing —
+    /// what a sleep looks like on the wire for its whole duration, since
+    /// `handle_sleep` writes no byte until the deadline passes.
+    ///
+    /// The accept loop runs detached and holds each connection open; it lives
+    /// for the process, which outlasts anything that would notice.
+    fn silent_core() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+        let addr = listener.local_addr().expect("bound address");
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                held.push(stream);
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// The wiring, not just the predicate: `durable_sleep` itself must refuse,
+    /// and the refusal must carry both numbers and the knob that moves the
+    /// ceiling. The failure it replaces named neither — it arrived at the
+    /// timeout, not at the requested duration, and read as a dead server.
+    #[test]
+    fn durable_sleep_refuses_a_duration_the_request_timeout_cannot_outlast() {
+        let error = backend(30_000)
+            .durable_sleep(Duration::from_millis(35_000), "delay", b"")
+            .expect_err("a 35s sleep cannot survive a 30s request timeout");
+
+        assert!(matches!(error, SdkError::Sleep(_)), "got {error:?}");
+        let message = error.to_string();
+        assert!(message.contains("35000ms"), "{message}");
+        assert!(message.contains("30000ms"), "{message}");
+        assert!(message.contains("RUNTARA_REQUEST_TIMEOUT_MS"), "{message}");
+    }
+
+    /// The boundary is inclusive. A sleep of exactly the timeout still loses:
+    /// the response cannot be written until the sleep is over, which is a moment
+    /// after the client has already given up.
+    #[test]
+    fn a_sleep_of_exactly_the_timeout_is_refused_and_one_below_it_is_not() {
+        assert!(
+            backend(30_000)
+                .reject_sleep_beyond_request_timeout(30_000)
+                .is_err()
+        );
+        assert!(
+            backend(30_000)
+                .reject_sleep_beyond_request_timeout(29_999)
+                .is_ok()
+        );
+    }
+
+    /// Raising the timeout raises the ceiling with it, so a deployment
+    /// configured for long sleeps keeps working.
+    #[test]
+    fn a_raised_request_timeout_raises_the_ceiling() {
+        assert!(
+            backend(300_000)
+                .reject_sleep_beyond_request_timeout(35_000)
+                .is_ok()
+        );
+    }
+
+    /// Zero is not a ceiling of zero. It is a configuration under which no
+    /// request of any kind completes, so reporting it against the sleep would
+    /// blame the sleep for something that has nothing to do with sleeping.
+    #[test]
+    fn a_zero_timeout_is_not_treated_as_a_ceiling() {
+        assert!(
+            backend(0)
+                .reject_sleep_beyond_request_timeout(35_000)
+                .is_ok()
+        );
+    }
+
+    /// The refusal is a SHORT-CIRCUIT, not a nicer message on the same wait.
+    /// Against a core that answers nothing, an over-ceiling sleep must come back
+    /// long before the deadline it could never have met — which is the whole
+    /// point: the old failure arrived at the timeout, making a misconfigured
+    /// sleep look like a server that had stopped responding.
+    #[test]
+    fn an_over_ceiling_sleep_is_refused_without_waiting_out_the_timeout() {
+        let backend = backend_at(silent_core(), 1_500);
+
+        let started = std::time::Instant::now();
+        let error = backend
+            .durable_sleep(Duration::from_millis(2_000), "delay", b"")
+            .expect_err("a 2s sleep cannot survive a 1.5s request timeout");
+        let elapsed = started.elapsed();
+
+        assert!(matches!(error, SdkError::Sleep(_)), "got {error:?}");
+        assert!(
+            elapsed < Duration::from_millis(1_000),
+            "the refusal must not wait out the timeout it is predicting; took {elapsed:?}"
+        );
+    }
+
+    /// The other half: a sleep INSIDE the ceiling is still issued, and when the
+    /// request dies anyway the failure names the sleep instead of reading as an
+    /// unrelated transport fault. This is the case the pre-flight cannot catch —
+    /// a duration the client would have tolerated, on a request that overran
+    /// regardless.
+    #[test]
+    fn a_sleep_inside_the_ceiling_is_issued_and_its_failure_names_the_sleep() {
+        let backend = backend_at(silent_core(), 1_000);
+
+        let error = backend
+            .durable_sleep(Duration::from_millis(500), "delay", b"")
+            .expect_err("the stand-in core never answers, so the request times out");
+
+        assert!(matches!(error, SdkError::Sleep(_)), "got {error:?}");
+        let message = error.to_string();
+        assert!(
+            message.contains("durable sleep of 500ms failed"),
+            "{message}"
+        );
     }
 }

--- a/crates/runtara-sdk/src/lib.rs
+++ b/crates/runtara-sdk/src/lib.rs
@@ -66,7 +66,7 @@
 //! | `RUNTARA_INSTANCE_ID` | Yes | - | Unique instance identifier |
 //! | `RUNTARA_TENANT_ID` | Yes | - | Tenant identifier |
 //! | `RUNTARA_HTTP_URL` | No | `http://127.0.0.1:8003` | HTTP API URL |
-//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | Request timeout |
+//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | Request timeout. `0` is refused — it is a deadline in the past, not "no timeout". Read from the SDK's own process environment, which a workflow guest does not have. |
 //! | `RUNTARA_SIGNAL_POLL_INTERVAL_MS` | No | `1000` | Signal poll rate limit |
 //!
 //! ## Programmatic Configuration

--- a/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/delay.rs
@@ -21,9 +21,9 @@
 use wasm_encoder::{BlockType, Function as WasmFunction, Instruction};
 
 use super::abi::{
-    emit_entry_suspend_at, emit_retptr_error_or_step_fail, load_retptr_list,
-    push_i64_load_from_ptr, push_retptr_arg, push_retptr_i64_load, push_segment_args,
-    return_if_retptr_error, store_local_i64_at,
+    emit_entry_suspend_at, emit_fail_if_retptr_error_inplace, emit_retptr_error_or_step_fail,
+    load_retptr_list, push_i64_load_from_ptr, push_retptr_arg, push_retptr_i64_load,
+    push_segment_args, return_if_retptr_error, store_local_i64_at,
 };
 use super::checkpoint::{
     emit_check_signals_and_suspend, emit_checkpoint_lookup, emit_checkpoint_save,
@@ -83,7 +83,15 @@ fn emit_blocking_durable_sleep(body: &mut WasmFunction, indices: &DirectCoreFunc
     body.instruction(&Instruction::LocalGet(DIRECT_DELAY_DURATION_MS_LOCAL));
     push_retptr_arg(body);
     body.instruction(&Instruction::Call(indices.runtime_durable_sleep_checkpoint));
-    return_if_retptr_error(body, indices);
+    // REPORT the failure rather than returning a bare `Err`. Under `wasi:cli/run`
+    // a bare return is an exit code and nothing else — no SDK event, no
+    // diagnostic — so a sleep that fails surfaces to an operator as a process
+    // that died for no stated reason. That is the whole of what they get, and it
+    // names neither the sleep nor its cause. The blocking arm is also the only
+    // one that can fail this way: it is the arm the composed binding takes, where
+    // the sleep is an HTTP request held open for its full duration and so subject
+    // to the client's request deadline.
+    emit_fail_if_retptr_error_inplace(body, indices);
     // The sleep writes no checkpoint on the GUEST side, so it has no
     // `emit_checkpoint_save` to fold signal handling into. Poll explicitly:
     // without this a cancel that arrived mid-sleep is never observed, and a

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -7163,6 +7163,14 @@ struct CheckpointingRuntimeHost {
     /// whose deterministic signal id (workflow-id-scoped) isn't known ahead of
     /// the run.
     any_signal: Mutex<Option<Vec<u8>>>,
+    /// When set, `durable-sleep-checkpoint` reports this message instead of
+    /// returning cleanly — the shape of a sleep whose request the client
+    /// deadline outlasted.
+    sleep_error: Mutex<Option<String>>,
+    /// What the guest reported through `runtime.fail`. `None` after a failed run
+    /// is the defect this captures: an error the lowering returned without ever
+    /// reporting it.
+    failed: Mutex<Option<Vec<u8>>>,
 }
 
 impl CheckpointingRuntimeHost {
@@ -7176,7 +7184,16 @@ impl CheckpointingRuntimeHost {
             clock_offset_ms: Mutex::new(0),
             pinned_clock_ms: Mutex::new(None),
             any_signal: Mutex::new(None),
+            sleep_error: Mutex::new(None),
+            failed: Mutex::new(None),
         }
+    }
+
+    /// Arm every `durable-sleep-checkpoint` to fail with `message`, standing in
+    /// for the composed binding's sleep request being aborted by the client's
+    /// own request deadline before core can answer it.
+    fn fail_sleeps_with(&self, message: &str) {
+        *self.sleep_error.lock().unwrap() = Some(message.to_string());
     }
 
     fn deliver_signal(&self, checkpoint_id: &str, payload: &[u8]) {
@@ -7238,7 +7255,8 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
         *self.completed.lock().unwrap() = Some(output);
         Ok(())
     }
-    async fn fail(&self, _error: Vec<u8>) -> Result<(), String> {
+    async fn fail(&self, error: Vec<u8>) -> Result<(), String> {
+        *self.failed.lock().unwrap() = Some(error);
         Ok(())
     }
     async fn custom_event(&self, _kind: String, _payload: Vec<u8>) -> Result<(), String> {
@@ -7342,6 +7360,12 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
                 .or_insert(state);
         }
         self.sleeps.lock().unwrap().push(checkpoint_id);
+        // Report the failure only AFTER the checkpoint and the key are recorded:
+        // core saves before it sleeps, so a sleep that dies on the client's
+        // deadline dies with its checkpoint already durable.
+        if let Some(message) = self.sleep_error.lock().unwrap().as_ref() {
+            return Err(message.clone());
+        }
         Ok(())
     }
 }
@@ -7686,6 +7710,66 @@ fn direct_wasm_execute_cli_run_abi_blocks_a_long_delay() {
         host.checkpoints.lock().unwrap().get("delay"),
         Some(&Vec::new()),
         "cli-run must record only the blocking sleep's empty checkpoint, never a deadline"
+    );
+}
+
+/// A durable sleep that fails must SAY so.
+///
+/// The blocking arm used to end its `durable-sleep-checkpoint` call with a bare
+/// `Err` return, which under `wasi:cli/run` is an exit code and nothing else: no
+/// `failed` event, no message. All an operator got was that the process had
+/// died — a report naming neither the sleep nor its cause, and pointing squarely
+/// at the wrong problem.
+///
+/// This is the arm where that matters. `cli-run` has no success arm able to
+/// carry a wake, so it can never park and always blocks; under the composed
+/// binding that block is an HTTP request held open for the sleep's whole
+/// duration, which the client's own request deadline outlasts for any sleep
+/// beyond it. Every one of those failures was mute.
+#[test]
+fn direct_wasm_execute_cli_run_reports_a_failed_durable_sleep() {
+    const SLEEP_FAILURE: &str =
+        "durable sleep of 3600000ms does not fit inside the 30000ms client request timeout";
+
+    let components_dir = direct_e2e_components_dir();
+    let graph: ExecutionGraph = serde_json::from_str(&store_freeing_delay_fixture(Some(3_600_000)))
+        .expect("delay fixture parses");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let compiled = compile_direct_workflow_composed_configured(
+        DirectCompilationInput {
+            workflow_id: "delay-cli-run-sleep-failure".to_string(),
+            version: 1,
+            source_checksum: None,
+            execution_graph: graph,
+            child_workflows: vec![],
+            output_dir: temp.path().to_path_buf(),
+            track_events: false,
+            agent_catalog: None,
+            agent_slug: None,
+        },
+        &components_dir,
+        RuntimeBinding::HostImport,
+        runtara_workflows::direct_wasm::WorkflowAbi::CliRunHttp,
+        false,
+    )
+    .expect("cli-run compile+compose succeeds");
+
+    let input = br#"{"value":"cli-run"}"#.to_vec();
+    let host = Arc::new(CheckpointingRuntimeHost::new(&input));
+    host.fail_sleeps_with(SLEEP_FAILURE);
+    let (ok, _stderr, _) = execute_via_embedded(&compiled.wasm_path, &[], Some(host.clone()));
+
+    assert!(
+        !ok,
+        "a workflow whose durable sleep failed must not report success"
+    );
+    let reported = host.failed.lock().unwrap().clone().expect(
+        "the sleep failure must reach the operator through runtime.fail, not just an exit code",
+    );
+    assert!(
+        String::from_utf8_lossy(&reported).contains(SLEEP_FAILURE),
+        "the report must carry the sleep's own diagnosis; got {:?}",
+        String::from_utf8_lossy(&reported)
     );
 }
 


### PR DESCRIPTION
## What

A durable sleep over the SDK's HTTP backend is a request core holds open for the sleep's whole duration — `handle_sleep` writes no byte until the deadline passes. The client applies `RUNTARA_REQUEST_TIMEOUT_MS` (default 30s) to it like any other call, so any sleep at or beyond that ceiling is aborted client-side. The ticket measured it: 5s completes, 35s dies at 30.36s.

The endpoint is deliberately **not** repaired here, per the ticket — it is reachable only from the legacy composed binding (`WorkflowAbi::CliRunHttp`) and goes away with it. What this PR fixes is the diagnosis, which two separate things erased:

**The SDK never named the ceiling**, though it knows both numbers. `HttpBackend::durable_sleep` now refuses a sleep the client deadline cannot outlast *before* issuing the request — in milliseconds instead of the whole timeout — naming the duration, the ceiling, and `RUNTARA_REQUEST_TIMEOUT_MS`. Raising that env var raises the threshold with it, so a deployment configured for long sleeps is unaffected. A sleep request that fails anyway is now reported as a sleep failure rather than a bare "HTTP request failed".

**The Delay lowering then threw the message away.** `emit_blocking_durable_sleep` ended its `runtime.durable-sleep-checkpoint` call with `return_if_retptr_error` — under `wasi:cli/run` a bare `Return(1)`, an exit code and nothing else. It now uses `emit_fail_if_retptr_error_inplace`, reporting through `runtime.fail` like every other step-failure site, so the message becomes a terminal `failed` event carrying the text instead of a silent non-zero exit that surfaces as "Process terminated without SDK event". That blocking arm is the one the composed binding always takes (`cli-run` has no success arm able to carry a wake, so it can never park), which is the only binding whose durable sleep issues this request at all.

## Why it needs both halves

A better SDK message alone changes nothing an operator can see: the lowering discards it at the ABI boundary. The new e2e demonstrates that directly — with the lowering change reverted it fails at `exit=GuestError` with nothing reported at all.

## Verification

- `cargo test -p runtara-sdk` — 6 new tests. Two are socket-backed against a stand-in core that accepts and never answers (what a sleep looks like on the wire), proving the refusal short-circuits rather than waiting out the deadline, and that a genuine timeout inside the ceiling is re-labelled.
- New e2e `direct_wasm_execute_cli_run_reports_a_failed_durable_sleep` — compiles and composes a real `cli-run` artifact, runs it under the embedded executor with a host whose sleep fails, asserts the message reaches `runtime.fail`. Red before the change, green after.
- Full `runtara-workflows` suite: 536 unit + 170 e2e pass. `compression_round_trips_in_guest` and `xlsx_parses_in_guest` fail identically with these changes stashed out — pre-existing, from stale staged agent components, untouched here.
- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Follow-up review

A review of this branch raised three findings. Two are fixed in `7c02e5f8`:

- The error message's headline remedy was unreachable. `RUNTARA_REQUEST_TIMEOUT_MS` is read from the SDK's own process environment, but a workflow guest has none — `build_env` in `runtara-environment` constructs one and forwards only a handful of variables, this not among them. The message now leads with the host-import binding and qualifies the environment variable.
- `RUNTARA_REQUEST_TIMEOUT_MS=0` reads as "no limit" but means the opposite: the client builds its deadline as `now + timeout`, so zero puts it in the past and every request fails instantly. It is now refused at parse, by name. Unparseable values still fall back to the default.

## Two limitations worth stating

**The SDK half needs a component rebuild.** It only takes effect in a real deployment once `runtara_workflow_runtime.wasm` is rebuilt, since the SDK is linked into that composed component. The lowering half reaches recompiled workflows.

**A narrow window just under the park threshold is still not caught.** At `Composed` + `InvokeHostImports`, the durable-delay park threshold is 30 000 ms and the guest's client timeout is also 30 000 ms. A Delay of, say, 29 900 ms is below the threshold (so it blocks rather than parks) *and* below the pre-flight guard (`duration_ms < timeout_ms`, so it is allowed), yet the checkpoint save plus connect overhead can push the round trip past 30 000 ms. Such a run still gets the re-labelled `durable sleep of 29900ms failed: …` rather than a fully anonymous transport error, so it is not the original symptom — but the pre-flight misses it.

Left open deliberately. Closing it means comparing against the timeout minus an overhead budget, and there is no measured basis for that number here; inventing one would trade a known narrow gap for an arbitrary constant in a binding that is scheduled for deletion alongside this endpoint.

**Noted separately, out of scope:** `RUNTARA_REQUEST_TIMEOUT_MS` is also read by `runtara-server`'s `RuntimeClientConfig::from_env` as a *seconds* value (`ms / 1000`), so the one name drives two unrelated timeouts. Pre-existing, and part of why this PR does not tell operators to set it.

[SYN-621](https://linear.app/syncmyordershq/issue/SYN-621/sleep-has-a-hard-30s-ceiling-that-cannot-be-fixed-server-side-and)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
