### PR TITLE
Give the server's default execution timeout its own environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`RUNTARA_REQUEST_TIMEOUT_MS` is deprecated as a runtara-server setting; use
+  `RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS`.** One name was read by two unrelated
+  components meaning two different things in two different units: in runtara-sdk
+  it is the per-request HTTP client timeout, in milliseconds; in runtara-server
+  it was divided by 1000 and used as the default execution timeout for a workflow
+  instance that names no `executionTimeoutSeconds` of its own — a kill deadline,
+  enforced by stopping the instance and recording it `failed` with
+  `termination_reason: timeout`. Setting it for one silently moved the other, and
+  neither site said so. The SDK keeps the name; the server's timeout is now named
+  in the unit it is kept in, with no division. **The old name is still read when
+  the new one is unset, so no deployment changes behavior on upgrade**, but the
+  server logs a deprecation warning quoting both the milliseconds found and the
+  seconds derived. Note the old conversion truncates: a value under `1000`
+  becomes a zero-second timeout, under which every workflow is killed the instant
+  it starts. The resolved timeout is now logged at startup regardless of which
+  name supplied it, and `RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS=0` is refused
+  rather than honored.
+
 - **BREAKING: `GET /api/runtime/workflows` now takes a 0-based `page`**, matching
   every other paginated endpoint in the runtime API (`/executions`,
   `/workflows/{id}/instances`, `/checkpoints`, `/actions`). It was the only

--- a/crates/runtara-sdk/src/lib.rs
+++ b/crates/runtara-sdk/src/lib.rs
@@ -66,7 +66,7 @@
 //! | `RUNTARA_INSTANCE_ID` | Yes | - | Unique instance identifier |
 //! | `RUNTARA_TENANT_ID` | Yes | - | Tenant identifier |
 //! | `RUNTARA_HTTP_URL` | No | `http://127.0.0.1:8003` | HTTP API URL |
-//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | This SDK's per-request HTTP timeout, and nothing else. `0` is refused — it is a deadline in the past, not "no timeout". Read from the SDK's own process environment, which a workflow guest does not have. The server's workflow poll timeout is a separate knob, `RUNTARA_RUNTIME_POLL_TIMEOUT_SECS`. |
+//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | This SDK's per-request HTTP timeout. `0` is refused — it is a deadline in the past, not "no timeout". Read from the SDK's own process environment, which a workflow guest does not have. Deprecated as a runtara-server setting, where the same name still supplies the default workflow execution timeout until operators move to `RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS`. |
 //! | `RUNTARA_SIGNAL_POLL_INTERVAL_MS` | No | `1000` | Signal poll rate limit |
 //!
 //! ## Programmatic Configuration

--- a/crates/runtara-sdk/src/lib.rs
+++ b/crates/runtara-sdk/src/lib.rs
@@ -66,7 +66,7 @@
 //! | `RUNTARA_INSTANCE_ID` | Yes | - | Unique instance identifier |
 //! | `RUNTARA_TENANT_ID` | Yes | - | Tenant identifier |
 //! | `RUNTARA_HTTP_URL` | No | `http://127.0.0.1:8003` | HTTP API URL |
-//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | Request timeout |
+//! | `RUNTARA_REQUEST_TIMEOUT_MS` | No | `30000` | This SDK's per-request HTTP timeout, and nothing else. The server's workflow poll timeout is a separate knob, `RUNTARA_RUNTIME_POLL_TIMEOUT_SECS`. |
 //! | `RUNTARA_SIGNAL_POLL_INTERVAL_MS` | No | `1000` | Signal poll rate limit |
 //!
 //! ## Programmatic Configuration

--- a/crates/runtara-server/README.md
+++ b/crates/runtara-server/README.md
@@ -35,16 +35,29 @@ plain environment variables read by `config.rs`; see that module for the
 authoritative list. Once the server is up, the OpenAPI spec is exposed by the
 router and the MCP transport is mounted under the `mcp` module's routes.
 
-`RUNTARA_RUNTIME_POLL_TIMEOUT_SECS` (default `300`) bounds how long the server
-waits for a workflow instance to reach a terminal state when the caller names no
-timeout of its own. It replaces `RUNTARA_REQUEST_TIMEOUT_MS`, which is the
-runtara-sdk per-request HTTP timeout and never meant this: an operator who
-raised it for the SDK also moved this wait, and one who set it here was writing
-milliseconds for a value kept in seconds. The old name is still read when the
-new one is unset — a deployment that relied on it keeps the same wait — and the
-server logs a warning naming both the milliseconds it found and the seconds it
-derived. Values under `1000` truncate to a zero-second wait, so migrate rather
-than leave the old name in place.
+`RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS` (default `300`) is the execution timeout
+applied to a workflow instance whose definition names no `executionTimeoutSeconds`
+of its own. It is a kill deadline, not a patience setting: runtara-environment's
+container monitor stops the instance when it elapses and records the run `failed`
+with `termination_reason: timeout`, and a synchronous execution cancels it. It is
+read by `runtime_client.rs`, not by `config.rs`. The server always sends a
+timeout, so it is this value rather than runtara-environment's own
+`RUNTARA_DEFAULT_INSTANCE_TIMEOUT_SECS` (3600) that governs anything the server
+starts.
+
+It replaces `RUNTARA_REQUEST_TIMEOUT_MS`, which is the runtara-sdk per-request
+HTTP timeout, in milliseconds, and never meant this. The two never collided in
+effect — a server process does not run the SDK, and `build_env` does not forward
+the variable to workflow guests — but they collided in name and in unit: an
+operator who set it here was writing milliseconds for a value the server keeps in
+seconds, and divided it by 1000 to get there.
+
+The old name is still read when the new one is unset, so a deployment that relied
+on it keeps the timeout it had, and the server warns, quoting both the
+milliseconds it found and the seconds it derived. A value under `1000` truncates
+to zero seconds, under which every workflow is killed the instant it starts —
+migrate rather than leave the old name in place. Whichever name supplies it, the
+resolved timeout is logged at startup.
 
 ## Embedded UI (optional)
 

--- a/crates/runtara-server/README.md
+++ b/crates/runtara-server/README.md
@@ -35,6 +35,17 @@ plain environment variables read by `config.rs`; see that module for the
 authoritative list. Once the server is up, the OpenAPI spec is exposed by the
 router and the MCP transport is mounted under the `mcp` module's routes.
 
+`RUNTARA_RUNTIME_POLL_TIMEOUT_SECS` (default `300`) bounds how long the server
+waits for a workflow instance to reach a terminal state when the caller names no
+timeout of its own. It replaces `RUNTARA_REQUEST_TIMEOUT_MS`, which is the
+runtara-sdk per-request HTTP timeout and never meant this: an operator who
+raised it for the SDK also moved this wait, and one who set it here was writing
+milliseconds for a value kept in seconds. The old name is still read when the
+new one is unset — a deployment that relied on it keeps the same wait — and the
+server logs a warning naming both the milliseconds it found and the seconds it
+derived. Values under `1000` truncate to a zero-second wait, so migrate rather
+than leave the old name in place.
+
 ## Embedded UI (optional)
 
 The crate can bundle the `./frontend` React app into the binary behind the

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -107,8 +107,89 @@ pub enum TerminalOutcome {
 /// Configuration for the runtime client
 #[derive(Debug, Clone)]
 pub struct RuntimeClientConfig {
-    /// Default timeout for operations in seconds
+    /// How long to wait for a workflow instance to reach a terminal state, in
+    /// seconds, when the caller passes no timeout of its own. Not a per-request
+    /// deadline — nothing here issues a request that could take this long; it
+    /// bounds an observation loop.
     pub default_timeout_secs: u32,
+}
+
+/// The wait applied when neither the caller nor the environment names one.
+const DEFAULT_POLL_TIMEOUT_SECS: u32 = 300;
+
+/// The server's own name for that wait, in the unit it is actually kept in.
+const POLL_TIMEOUT_SECS_ENV: &str = "RUNTARA_RUNTIME_POLL_TIMEOUT_SECS";
+
+/// The name this setting used to share with the SDK's per-request HTTP timeout
+/// (`HttpSdkConfig::from_env`), which is milliseconds and means something else
+/// entirely. Still read, because a deployment that set it was getting a longer
+/// poll timeout and silently reverting it to the default on upgrade would cut
+/// long workflows off at five minutes. See [`resolve_poll_timeout`].
+const LEGACY_POLL_TIMEOUT_MS_ENV: &str = "RUNTARA_REQUEST_TIMEOUT_MS";
+
+/// The poll timeout [`RuntimeClientConfig::from_env`] settled on, plus whatever
+/// the operator needs told about how it got there.
+#[derive(Debug, PartialEq, Eq)]
+struct PollTimeout {
+    secs: u32,
+    /// `Some` when the value came from the deprecated variable.
+    deprecation: Option<String>,
+}
+
+/// Decide the poll timeout from the two variables that can name it.
+///
+/// Split out of the env read so the precedence and the millisecond conversion
+/// are testable without mutating process state, which nothing in this crate can
+/// do safely alongside parallel tests.
+///
+/// The deprecated variable is converted the way it always was — integer
+/// division by 1000, truncating — so an existing deployment keeps the exact
+/// number of seconds it had. That conversion is the reason the warning quotes
+/// both numbers: a value chosen as a millisecond request timeout rarely reads
+/// as a sensible number of seconds, and under 1000 it truncates to none at all.
+fn resolve_poll_timeout(configured_secs: Option<String>, legacy_ms: Option<String>) -> PollTimeout {
+    if let Some(secs) = configured_secs
+        .as_deref()
+        .and_then(|value| value.parse::<u32>().ok())
+    {
+        return PollTimeout {
+            secs,
+            deprecation: None,
+        };
+    }
+
+    // An unparseable value falls through rather than failing: a typo in either
+    // name costs nothing here, and the default is a working timeout.
+    let Some(ms) = legacy_ms
+        .as_deref()
+        .and_then(|value| value.parse::<u32>().ok())
+    else {
+        return PollTimeout {
+            secs: DEFAULT_POLL_TIMEOUT_SECS,
+            deprecation: None,
+        };
+    };
+
+    let secs = ms / 1000;
+    let mut deprecation = format!(
+        "{LEGACY_POLL_TIMEOUT_MS_ENV} is deprecated as a server setting. It is the runtara-sdk \
+         per-request HTTP timeout, and the server read the same name for something unrelated: how \
+         long to wait for a workflow instance to finish. Its {ms}ms is being taken as {secs}s for \
+         that wait, in place of the {DEFAULT_POLL_TIMEOUT_SECS}s default. Set \
+         {POLL_TIMEOUT_SECS_ENV} to the seconds you want, and unset \
+         {LEGACY_POLL_TIMEOUT_MS_ENV} from this process's environment."
+    );
+    if secs == 0 {
+        deprecation.push_str(&format!(
+            " {ms}ms truncates to zero seconds, so every wait now times out immediately — set \
+             {POLL_TIMEOUT_SECS_ENV} before this server serves traffic."
+        ));
+    }
+
+    PollTimeout {
+        secs,
+        deprecation: Some(deprecation),
+    }
 }
 
 impl RuntimeClientConfig {
@@ -117,15 +198,22 @@ impl RuntimeClientConfig {
     /// There is no address to read any more: the client talks to the embedded
     /// environment directly, so whether a runtime exists is decided by whether
     /// the embedded runtime started, not by a variable.
+    ///
+    /// `RUNTARA_RUNTIME_POLL_TIMEOUT_SECS` names the poll timeout, in seconds.
+    /// `RUNTARA_REQUEST_TIMEOUT_MS` is still honoured when it does not, and
+    /// warns; see [`resolve_poll_timeout`].
     pub fn from_env() -> Self {
-        let default_timeout_secs = std::env::var("RUNTARA_REQUEST_TIMEOUT_MS")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .map(|ms| ms / 1000)
-            .unwrap_or(300);
+        let resolved = resolve_poll_timeout(
+            std::env::var(POLL_TIMEOUT_SECS_ENV).ok(),
+            std::env::var(LEGACY_POLL_TIMEOUT_MS_ENV).ok(),
+        );
+
+        if let Some(message) = resolved.deprecation {
+            warn!("{message}");
+        }
 
         Self {
-            default_timeout_secs,
+            default_timeout_secs: resolved.secs,
         }
     }
 }
@@ -1003,5 +1091,92 @@ mod classify_observed_status_tests {
             }
             other => panic!("expected Cancelled, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod poll_timeout_tests {
+    use super::*;
+
+    /// The point of the rename: a server-side wait measured in seconds is now
+    /// named in seconds, and nothing divides it.
+    #[test]
+    fn the_seconds_variable_is_taken_at_face_value() {
+        let resolved = resolve_poll_timeout(Some("900".to_string()), None);
+
+        assert_eq!(resolved.secs, 900);
+        assert_eq!(resolved.deprecation, None);
+    }
+
+    #[test]
+    fn neither_variable_leaves_the_default() {
+        let resolved = resolve_poll_timeout(None, None);
+
+        assert_eq!(resolved.secs, DEFAULT_POLL_TIMEOUT_SECS);
+        assert_eq!(resolved.deprecation, None);
+    }
+
+    /// The fallback the deprecation exists for: a deployment that raised the
+    /// wait through the old name keeps the same wait after the upgrade. Reverting
+    /// it to 300s here would cut every workflow past five minutes short, which is
+    /// exactly the silent change a rename must not make.
+    #[test]
+    fn the_deprecated_variable_still_sets_the_same_wait() {
+        let resolved = resolve_poll_timeout(None, Some("3600000".to_string()));
+
+        assert_eq!(resolved.secs, 3600);
+        let message = resolved.deprecation.expect("the old name warns");
+        assert!(message.contains(LEGACY_POLL_TIMEOUT_MS_ENV), "{message}");
+        assert!(message.contains(POLL_TIMEOUT_SECS_ENV), "{message}");
+        // Both numbers, because the whole trap is that they are not the same
+        // number in the same unit.
+        assert!(message.contains("3600000ms"), "{message}");
+        assert!(message.contains("3600s"), "{message}");
+    }
+
+    /// The collision itself: the same value means one thing to the SDK and
+    /// another here, so whichever name wins has to be the one that decides.
+    #[test]
+    fn the_seconds_variable_wins_over_the_deprecated_one() {
+        let resolved = resolve_poll_timeout(Some("120".to_string()), Some("3600000".to_string()));
+
+        assert_eq!(resolved.secs, 120);
+        assert_eq!(
+            resolved.deprecation, None,
+            "a migrated deployment is not nagged about a variable it no longer relies on"
+        );
+    }
+
+    /// A sub-second request timeout is a reasonable SDK setting and a degenerate
+    /// server one: it truncates to a zero-second wait, under which nothing ever
+    /// finishes in time. Honoured rather than clamped — clamping would change the
+    /// behaviour of the deployments the fallback exists to preserve — but said
+    /// out loud, since no operator picked it on purpose.
+    #[test]
+    fn a_sub_second_deprecated_value_truncates_and_says_so() {
+        let resolved = resolve_poll_timeout(None, Some("500".to_string()));
+
+        assert_eq!(resolved.secs, 0);
+        let message = resolved.deprecation.expect("the old name warns");
+        assert!(message.contains("truncates to zero seconds"), "{message}");
+    }
+
+    /// A typo in either name costs nothing: the default is a working timeout, so
+    /// refusing to start over one would be worse than absorbing it.
+    #[test]
+    fn unparseable_values_fall_back() {
+        assert_eq!(
+            resolve_poll_timeout(Some("ten minutes".to_string()), None).secs,
+            DEFAULT_POLL_TIMEOUT_SECS
+        );
+        assert_eq!(
+            resolve_poll_timeout(None, Some("ten minutes".to_string())).secs,
+            DEFAULT_POLL_TIMEOUT_SECS
+        );
+        assert_eq!(
+            resolve_poll_timeout(None, Some("ten minutes".to_string())).deprecation,
+            None,
+            "a value that was never read should not be reported as honoured"
+        );
     }
 }

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -107,88 +107,124 @@ pub enum TerminalOutcome {
 /// Configuration for the runtime client
 #[derive(Debug, Clone)]
 pub struct RuntimeClientConfig {
-    /// How long to wait for a workflow instance to reach a terminal state, in
-    /// seconds, when the caller passes no timeout of its own. Not a per-request
-    /// deadline — nothing here issues a request that could take this long; it
-    /// bounds an observation loop.
+    /// The execution timeout applied to a workflow instance when the caller
+    /// names none — in effect, the default for a workflow definition's own
+    /// `executionTimeoutSeconds`.
+    ///
+    /// This terminates work rather than merely bounding a wait. It travels as
+    /// `StartInstanceOptions::timeout_seconds`, which runtara-environment's
+    /// container monitor enforces by killing the instance and recording it
+    /// `failed` with `termination_reason = "timeout"`, and it bounds
+    /// [`RuntimeClient::wait_for_completion`], which cancels the instance when
+    /// it elapses.
     pub default_timeout_secs: u32,
 }
 
-/// The wait applied when neither the caller nor the environment names one.
-const DEFAULT_POLL_TIMEOUT_SECS: u32 = 300;
+/// The execution timeout used when neither the caller nor the environment names
+/// one. Note that runtara-environment carries its own, longer fallback for
+/// requests that omit a timeout entirely (`RUNTARA_DEFAULT_INSTANCE_TIMEOUT_SECS`,
+/// 3600s); the server always sends a value, so this is the one that applies to
+/// anything the server starts.
+const DEFAULT_EXECUTION_TIMEOUT_SECS: u32 = 300;
 
-/// The server's own name for that wait, in the unit it is actually kept in.
-const POLL_TIMEOUT_SECS_ENV: &str = "RUNTARA_RUNTIME_POLL_TIMEOUT_SECS";
+/// The server's name for that timeout, in the unit it is actually kept in.
+const EXECUTION_TIMEOUT_SECS_ENV: &str = "RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS";
 
 /// The name this setting used to share with the SDK's per-request HTTP timeout
 /// (`HttpSdkConfig::from_env`), which is milliseconds and means something else
 /// entirely. Still read, because a deployment that set it was getting a longer
-/// poll timeout and silently reverting it to the default on upgrade would cut
-/// long workflows off at five minutes. See [`resolve_poll_timeout`].
-const LEGACY_POLL_TIMEOUT_MS_ENV: &str = "RUNTARA_REQUEST_TIMEOUT_MS";
+/// execution timeout, and silently reverting that on upgrade would start killing
+/// workflows at five minutes. See [`resolve_execution_timeout`].
+const LEGACY_EXECUTION_TIMEOUT_MS_ENV: &str = "RUNTARA_REQUEST_TIMEOUT_MS";
 
-/// The poll timeout [`RuntimeClientConfig::from_env`] settled on, plus whatever
-/// the operator needs told about how it got there.
+/// The timeout [`RuntimeClientConfig::from_env`] settled on, plus anything the
+/// operator needs told about how it got there.
 #[derive(Debug, PartialEq, Eq)]
-struct PollTimeout {
+struct ExecutionTimeout {
     secs: u32,
-    /// `Some` when the value came from the deprecated variable.
-    deprecation: Option<String>,
+    /// A deprecated name still in use, or a value that could not be honoured.
+    warning: Option<String>,
 }
 
-/// Decide the poll timeout from the two variables that can name it.
+/// Decide the default execution timeout from the two variables that can name it.
 ///
-/// Split out of the env read so the precedence and the millisecond conversion
-/// are testable without mutating process state, which nothing in this crate can
-/// do safely alongside parallel tests.
+/// Split out of the env read so precedence and the millisecond conversion are
+/// covered directly; [`RuntimeClientConfig::from_env`] is tested separately for
+/// the binding between the two, since the parameters are interchangeable by type
+/// and swapping them would be invisible here.
 ///
-/// The deprecated variable is converted the way it always was — integer
-/// division by 1000, truncating — so an existing deployment keeps the exact
-/// number of seconds it had. That conversion is the reason the warning quotes
-/// both numbers: a value chosen as a millisecond request timeout rarely reads
-/// as a sensible number of seconds, and under 1000 it truncates to none at all.
-fn resolve_poll_timeout(configured_secs: Option<String>, legacy_ms: Option<String>) -> PollTimeout {
-    if let Some(secs) = configured_secs
-        .as_deref()
-        .and_then(|value| value.parse::<u32>().ok())
-    {
-        return PollTimeout {
-            secs,
-            deprecation: None,
-        };
+/// The deprecated variable is converted the way it always was — truncating
+/// integer division by 1000 — so an existing deployment keeps the exact timeout
+/// it had. That conversion is why the warning quotes both numbers: a value chosen
+/// as a millisecond request timeout rarely reads as a sensible number of seconds,
+/// and under 1000 it truncates to none at all.
+fn resolve_execution_timeout(
+    configured_secs: Option<String>,
+    legacy_ms: Option<String>,
+) -> ExecutionTimeout {
+    // A value under the current name is the operator's declared intent, so a bad
+    // one is reported rather than quietly handed back to the deprecated name.
+    match configured_secs.as_deref().map(str::parse::<u32>) {
+        Some(Ok(0)) => {
+            return ExecutionTimeout {
+                secs: DEFAULT_EXECUTION_TIMEOUT_SECS,
+                warning: Some(format!(
+                    "{EXECUTION_TIMEOUT_SECS_ENV}=0 would kill every workflow the instant it \
+                     started, so it is ignored and the {DEFAULT_EXECUTION_TIMEOUT_SECS}s default \
+                     applies. Set a positive number of seconds."
+                )),
+            };
+        }
+        Some(Ok(secs)) => {
+            return ExecutionTimeout {
+                secs,
+                warning: None,
+            };
+        }
+        Some(Err(_)) => {
+            let value = configured_secs.unwrap_or_default();
+            return ExecutionTimeout {
+                secs: DEFAULT_EXECUTION_TIMEOUT_SECS,
+                warning: Some(format!(
+                    "{EXECUTION_TIMEOUT_SECS_ENV}={value:?} is not a whole number of seconds, so \
+                     the {DEFAULT_EXECUTION_TIMEOUT_SECS}s default applies. Note this is seconds, \
+                     not milliseconds, and carries no unit suffix."
+                )),
+            };
+        }
+        None => {}
     }
 
-    // An unparseable value falls through rather than failing: a typo in either
-    // name costs nothing here, and the default is a working timeout.
     let Some(ms) = legacy_ms
         .as_deref()
         .and_then(|value| value.parse::<u32>().ok())
     else {
-        return PollTimeout {
-            secs: DEFAULT_POLL_TIMEOUT_SECS,
-            deprecation: None,
+        return ExecutionTimeout {
+            secs: DEFAULT_EXECUTION_TIMEOUT_SECS,
+            warning: None,
         };
     };
 
     let secs = ms / 1000;
-    let mut deprecation = format!(
-        "{LEGACY_POLL_TIMEOUT_MS_ENV} is deprecated as a server setting. It is the runtara-sdk \
-         per-request HTTP timeout, and the server read the same name for something unrelated: how \
-         long to wait for a workflow instance to finish. Its {ms}ms is being taken as {secs}s for \
-         that wait, in place of the {DEFAULT_POLL_TIMEOUT_SECS}s default. Set \
-         {POLL_TIMEOUT_SECS_ENV} to the seconds you want, and unset \
-         {LEGACY_POLL_TIMEOUT_MS_ENV} from this process's environment."
+    let mut warning = format!(
+        "{LEGACY_EXECUTION_TIMEOUT_MS_ENV} is deprecated as a server setting. It is the \
+         runtara-sdk per-request HTTP timeout, and the server read the same name for something \
+         unrelated: the execution timeout a workflow instance is killed at when it names none of \
+         its own. Its {ms}ms is being taken as {secs}s for that, in place of the \
+         {DEFAULT_EXECUTION_TIMEOUT_SECS}s default. Set {EXECUTION_TIMEOUT_SECS_ENV} to the \
+         seconds you want, and unset {LEGACY_EXECUTION_TIMEOUT_MS_ENV} from this process's \
+         environment."
     );
     if secs == 0 {
-        deprecation.push_str(&format!(
-            " {ms}ms truncates to zero seconds, so every wait now times out immediately — set \
-             {POLL_TIMEOUT_SECS_ENV} before this server serves traffic."
+        warning.push_str(&format!(
+            " {ms}ms truncates to zero seconds, so every workflow is now killed the instant it \
+             starts — set {EXECUTION_TIMEOUT_SECS_ENV} before this server serves traffic."
         ));
     }
 
-    PollTimeout {
+    ExecutionTimeout {
         secs,
-        deprecation: Some(deprecation),
+        warning: Some(warning),
     }
 }
 
@@ -199,18 +235,26 @@ impl RuntimeClientConfig {
     /// environment directly, so whether a runtime exists is decided by whether
     /// the embedded runtime started, not by a variable.
     ///
-    /// `RUNTARA_RUNTIME_POLL_TIMEOUT_SECS` names the poll timeout, in seconds.
-    /// `RUNTARA_REQUEST_TIMEOUT_MS` is still honoured when it does not, and
-    /// warns; see [`resolve_poll_timeout`].
+    /// `RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS` names the default execution
+    /// timeout, in seconds. `RUNTARA_REQUEST_TIMEOUT_MS` is still honoured when
+    /// it does not, and warns; see [`resolve_execution_timeout`].
     pub fn from_env() -> Self {
-        let resolved = resolve_poll_timeout(
-            std::env::var(POLL_TIMEOUT_SECS_ENV).ok(),
-            std::env::var(LEGACY_POLL_TIMEOUT_MS_ENV).ok(),
+        let resolved = resolve_execution_timeout(
+            std::env::var(EXECUTION_TIMEOUT_SECS_ENV).ok(),
+            std::env::var(LEGACY_EXECUTION_TIMEOUT_MS_ENV).ok(),
         );
 
-        if let Some(message) = resolved.deprecation {
-            warn!("{message}");
+        if let Some(warning) = resolved.warning {
+            warn!("{warning}");
         }
+
+        // Logged unconditionally: the failure this setting invites is a value in
+        // the wrong unit, which looks like nothing at all until workflows start
+        // being killed early or living for days.
+        info!(
+            default_execution_timeout_secs = resolved.secs,
+            "Resolved default workflow execution timeout"
+        );
 
         Self {
             default_timeout_secs: resolved.secs,
@@ -1095,88 +1139,154 @@ mod classify_observed_status_tests {
 }
 
 #[cfg(test)]
-mod poll_timeout_tests {
+mod execution_timeout_tests {
     use super::*;
+    use crate::test_env::{ENV_MUTEX, EnvGuard};
 
-    /// The point of the rename: a server-side wait measured in seconds is now
-    /// named in seconds, and nothing divides it.
+    /// The point of the rename: a timeout measured in seconds is named in
+    /// seconds, and nothing divides it.
     #[test]
     fn the_seconds_variable_is_taken_at_face_value() {
-        let resolved = resolve_poll_timeout(Some("900".to_string()), None);
+        let resolved = resolve_execution_timeout(Some("900".to_string()), None);
 
         assert_eq!(resolved.secs, 900);
-        assert_eq!(resolved.deprecation, None);
+        assert_eq!(resolved.warning, None);
     }
 
     #[test]
     fn neither_variable_leaves_the_default() {
-        let resolved = resolve_poll_timeout(None, None);
+        let resolved = resolve_execution_timeout(None, None);
 
-        assert_eq!(resolved.secs, DEFAULT_POLL_TIMEOUT_SECS);
-        assert_eq!(resolved.deprecation, None);
+        assert_eq!(resolved.secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
+        assert_eq!(resolved.warning, None);
+    }
+
+    /// Zero is not "no limit" here — it is a kill deadline in the past, so every
+    /// instance dies the moment it starts. The current name has no deployments
+    /// to preserve, so it is refused outright rather than honoured, matching
+    /// `default_instance_timeout` in runtara-environment.
+    #[test]
+    fn a_zero_second_timeout_is_refused() {
+        let resolved = resolve_execution_timeout(Some("0".to_string()), None);
+
+        assert_eq!(resolved.secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
+        let warning = resolved.warning.expect("zero is reported");
+        assert!(warning.contains(EXECUTION_TIMEOUT_SECS_ENV), "{warning}");
+    }
+
+    /// The realistic migration slip is copying the millisecond value across, or
+    /// writing a unit suffix. Neither parses, and both are worth naming: the
+    /// operator believes they have set the timeout.
+    #[test]
+    fn an_unparseable_seconds_value_is_reported_not_silently_defaulted() {
+        let resolved = resolve_execution_timeout(Some("900s".to_string()), None);
+
+        assert_eq!(resolved.secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
+        let warning = resolved.warning.expect("a bad value is reported");
+        assert!(warning.contains("900s"), "{warning}");
+        assert!(warning.contains("seconds"), "{warning}");
+    }
+
+    /// A typo under the current name must not hand control back to the
+    /// deprecated one: the operator has migrated, so the typo is the thing to
+    /// fix, and a deprecation notice telling them to set a variable they already
+    /// set would send them looking in the wrong place.
+    #[test]
+    fn a_typo_under_the_current_name_does_not_fall_back_to_the_deprecated_one() {
+        let resolved =
+            resolve_execution_timeout(Some("900s".to_string()), Some("3600000".to_string()));
+
+        assert_eq!(resolved.secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
+        let warning = resolved.warning.expect("the typo is reported");
+        assert!(
+            !warning.contains(LEGACY_EXECUTION_TIMEOUT_MS_ENV),
+            "the deprecated name is not the advice here: {warning}"
+        );
     }
 
     /// The fallback the deprecation exists for: a deployment that raised the
-    /// wait through the old name keeps the same wait after the upgrade. Reverting
-    /// it to 300s here would cut every workflow past five minutes short, which is
-    /// exactly the silent change a rename must not make.
+    /// timeout through the old name keeps the same timeout after the upgrade.
+    /// Reverting it to 300s here would start killing every workflow that runs
+    /// past five minutes, which is exactly the silent change a rename must not
+    /// make.
     #[test]
-    fn the_deprecated_variable_still_sets_the_same_wait() {
-        let resolved = resolve_poll_timeout(None, Some("3600000".to_string()));
+    fn the_deprecated_variable_still_sets_the_same_timeout() {
+        let resolved = resolve_execution_timeout(None, Some("3600000".to_string()));
 
         assert_eq!(resolved.secs, 3600);
-        let message = resolved.deprecation.expect("the old name warns");
-        assert!(message.contains(LEGACY_POLL_TIMEOUT_MS_ENV), "{message}");
-        assert!(message.contains(POLL_TIMEOUT_SECS_ENV), "{message}");
+        let warning = resolved.warning.expect("the old name warns");
+        assert!(
+            warning.contains(LEGACY_EXECUTION_TIMEOUT_MS_ENV),
+            "{warning}"
+        );
+        assert!(warning.contains(EXECUTION_TIMEOUT_SECS_ENV), "{warning}");
         // Both numbers, because the whole trap is that they are not the same
         // number in the same unit.
-        assert!(message.contains("3600000ms"), "{message}");
-        assert!(message.contains("3600s"), "{message}");
+        assert!(warning.contains("3600000ms"), "{warning}");
+        assert!(warning.contains("3600s"), "{warning}");
     }
 
     /// The collision itself: the same value means one thing to the SDK and
     /// another here, so whichever name wins has to be the one that decides.
     #[test]
     fn the_seconds_variable_wins_over_the_deprecated_one() {
-        let resolved = resolve_poll_timeout(Some("120".to_string()), Some("3600000".to_string()));
+        let resolved =
+            resolve_execution_timeout(Some("120".to_string()), Some("3600000".to_string()));
 
         assert_eq!(resolved.secs, 120);
         assert_eq!(
-            resolved.deprecation, None,
+            resolved.warning, None,
             "a migrated deployment is not nagged about a variable it no longer relies on"
         );
     }
 
-    /// A sub-second request timeout is a reasonable SDK setting and a degenerate
-    /// server one: it truncates to a zero-second wait, under which nothing ever
-    /// finishes in time. Honoured rather than clamped — clamping would change the
-    /// behaviour of the deployments the fallback exists to preserve — but said
-    /// out loud, since no operator picked it on purpose.
+    /// A sub-second request timeout is a reasonable SDK setting and a lethal
+    /// server one: it truncates to a zero-second kill deadline. Honoured rather
+    /// than clamped — clamping would change the behaviour of the deployments the
+    /// fallback exists to preserve — but said out loud, since no operator picked
+    /// it on purpose.
     #[test]
     fn a_sub_second_deprecated_value_truncates_and_says_so() {
-        let resolved = resolve_poll_timeout(None, Some("500".to_string()));
+        let resolved = resolve_execution_timeout(None, Some("500".to_string()));
 
         assert_eq!(resolved.secs, 0);
-        let message = resolved.deprecation.expect("the old name warns");
-        assert!(message.contains("truncates to zero seconds"), "{message}");
+        let warning = resolved.warning.expect("the old name warns");
+        assert!(warning.contains("truncates to zero seconds"), "{warning}");
     }
 
-    /// A typo in either name costs nothing: the default is a working timeout, so
-    /// refusing to start over one would be worse than absorbing it.
-    #[test]
-    fn unparseable_values_fall_back() {
+    /// The binding [`resolve_execution_timeout`] cannot check for itself: its two
+    /// parameters are both `Option<String>`, so swapping them at the call site
+    /// would leave every test above passing while the server read milliseconds as
+    /// seconds — the exact defect this change exists to remove. The numbers here
+    /// are chosen so a swap cannot produce them.
+    #[tokio::test]
+    async fn from_env_binds_each_variable_to_its_own_unit() {
+        let _lock = ENV_MUTEX.lock().await;
+
+        let mut guard = EnvGuard::new();
+        guard.set(EXECUTION_TIMEOUT_SECS_ENV, "120");
+        guard.set(LEGACY_EXECUTION_TIMEOUT_MS_ENV, "3600000");
         assert_eq!(
-            resolve_poll_timeout(Some("ten minutes".to_string()), None).secs,
-            DEFAULT_POLL_TIMEOUT_SECS
+            RuntimeClientConfig::from_env().default_timeout_secs,
+            120,
+            "the seconds variable is read as seconds, and wins"
         );
+
+        let mut guard = EnvGuard::new();
+        guard.remove(EXECUTION_TIMEOUT_SECS_ENV);
+        guard.set(LEGACY_EXECUTION_TIMEOUT_MS_ENV, "600000");
         assert_eq!(
-            resolve_poll_timeout(None, Some("ten minutes".to_string())).secs,
-            DEFAULT_POLL_TIMEOUT_SECS
+            RuntimeClientConfig::from_env().default_timeout_secs,
+            600,
+            "the deprecated variable is read as milliseconds"
         );
+
+        let mut guard = EnvGuard::new();
+        guard.remove(EXECUTION_TIMEOUT_SECS_ENV);
+        guard.remove(LEGACY_EXECUTION_TIMEOUT_MS_ENV);
         assert_eq!(
-            resolve_poll_timeout(None, Some("ten minutes".to_string())).deprecation,
-            None,
-            "a value that was never read should not be reported as honoured"
+            RuntimeClientConfig::from_env().default_timeout_secs,
+            DEFAULT_EXECUTION_TIMEOUT_SECS
         );
     }
 }


### PR DESCRIPTION
## The collision

`RUNTARA_REQUEST_TIMEOUT_MS` was read by two unrelated components, meaning two different things in two different units:

| Reader | Meaning | Unit | Default |
|---|---|---|---|
| `HttpSdkConfig::from_env` (`runtara-sdk`) | per-request HTTP client timeout | milliseconds | `30000` |
| `RuntimeClientConfig::from_env` (`runtara-server`) | default workflow **execution** timeout | milliseconds ÷ 1000 | `300` (seconds) |

Setting it for one silently moved the other, and neither site said so. Setting it to the SDK's own documented default of `30000` cut the server's execution timeout to 30s.

## What the server's value actually is

Not a patience setting — a **kill deadline**. It travels as `StartInstanceOptions::timeout_seconds` into runtara-environment, whose container monitor stops the instance when it elapses and records the run `failed` with `termination_reason: timeout` (`handlers.rs`, the `sleep_until` arm). The other consumer, `wait_for_completion`, cancels the instance. Nothing merely observes with it — `poll_until_terminal`'s two callers both pass an explicit `max_wait`.

So it is the default for a workflow definition's own `executionTimeoutSeconds`, and the new name says that: **`RUNTARA_DEFAULT_EXECUTION_TIMEOUT_SECS`** — seconds, default 300, no division.

The SDK keeps `RUNTARA_REQUEST_TIMEOUT_MS`: it genuinely is a per-request timeout, genuinely milliseconds, the documented SDK surface, and quoted by name in the SDK's own errors.

## Backwards compatibility

The old name is still read when the new one is unset, and warns, so **no deployment changes behavior on upgrade**. The fallback keeps the original truncating `ms / 1000`, and the warning quotes both numbers because the trap is that they are not the same number in the same unit. A value under `1000` truncates to a zero-second timeout — every workflow killed at launch — which is honoured rather than clamped (clamping would change the behaviour of the deployments the fallback exists to preserve) but called out explicitly.

Under the *new* name, `0` is refused and an unparseable value is reported rather than silently defaulted, and neither falls through to the deprecated name — the operator has migrated, so a notice telling them to set a variable they already set would send them looking in the wrong place. The resolved timeout is logged at startup whichever name supplied it.

Worth knowing: the server always sends a timeout, so this value — not runtara-environment's own `RUNTARA_DEFAULT_INSTANCE_TIMEOUT_SECS` (3600) — governs anything the server starts.

## Tests

Nine, including one that pins the *wiring*: `resolve_execution_timeout` takes two `Option<String>` parameters that are interchangeable by type, so swapping them at the call site would leave every value-level test passing while the server read milliseconds as seconds. `from_env_binds_each_variable_to_its_own_unit` uses the crate's existing `test_env::{ENV_MUTEX, EnvGuard}` and fails under that swap; I verified by making the mutation — the other eight stay green.

## Docs

- `crates/runtara-sdk/src/lib.rs` env-var table — scoped to the SDK, notes the server-side deprecation.
- `crates/runtara-server/README.md` — describes the kill semantics, its relationship to `RUNTARA_DEFAULT_INSTANCE_TIMEOUT_SECS`, and that it is read by `runtime_client.rs` rather than `config.rs`.
- `CHANGELOG.md` — `[Unreleased] / Changed`, per the project's convention for operator-visible environment changes.

There were no pre-existing server-side docs naming the old variable anywhere — nothing in `docs/`, no deployment config, compose file, script or CI.

## Verification

`cargo fmt --all -- --check` clean · `cargo clippy -p runtara-server -p runtara-sdk --all-targets -- -D warnings` exit 0 · `cargo test -p runtara-server --lib` 1114 passed · `cargo test -p runtara-sdk` 72 + 20 passed, 13 ignored (pre-existing). All on this branch, merged up to current `main`.

## History

`55051fb9` proposed `RUNTARA_RUNTIME_POLL_TIMEOUT_SECS`. An independent review established that name was as wrong as the one it replaced — the value kills workflows, it does not poll — so `66ddee89` corrects it along with the docs and tests that had inherited the same misreading. Reviewing `66ddee89` on its own is the shortest path to the current state.

## Out of scope, but noted

`api/handlers/workflows_sync.rs:39` documents a "Hard timeout: 30 seconds" for the sync-execution endpoint. There is no `TimeoutLayer` on that route; the real bound is this value, defaulting to 300s. Pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
