### PR TITLE
Show execution pipeline occupancy in System analytics

### DIFF
--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
 use runtara_component_host::{
@@ -38,7 +38,7 @@ use runtara_core::persistence::Persistence;
 use super::common::{self, WorkflowRunnerConfig};
 use super::traits::{
     CancelToken, ContainerMetrics, LaunchOptions, LaunchResult, Result, Runner, RunnerError,
-    RunnerHandle,
+    RunnerHandle, RunnerOccupancy,
 };
 
 /// Mark a run `running`, clearing what a previous stop left behind.
@@ -88,9 +88,78 @@ pub struct EmbeddedWasmRunner {
     /// A serial caller used to hide this by never asking for more than one at a
     /// time; that is not a limit anything should rely on.
     run_permits: Arc<tokio::sync::Semaphore>,
+    /// The bound `run_permits` was built with.
+    ///
+    /// A `Semaphore` reports what is *available*, never what it started with,
+    /// so the total has to be kept alongside it to turn that into occupancy.
+    run_limit: usize,
+    /// When each currently-held run permit was taken.
+    ///
+    /// Exists so a full runner can be told apart from a stuck one — see
+    /// [`RunnerOccupancy`]. Bounded by `run_limit` (cores x 4 by default), so
+    /// it needs no eviction policy; entries are removed by [`RunSlot`]'s drop,
+    /// which runs on the success, error and panic paths alike.
+    run_slots: RunSlotRegistry,
     /// Shared handler state for per-run [`PersistenceRuntimeHost`]s — the
     /// native runtime interface for HostImport-composed artifacts.
     handler_state: Arc<runtara_core::instance_handlers::InstanceHandlerState>,
+}
+
+/// Acquisition times of the run permits currently held, keyed by instance.
+type RunSlotRegistry = Arc<Mutex<HashMap<String, Instant>>>;
+
+/// A held run permit, tied to the moment it was taken.
+///
+/// The permit alone would bound concurrency perfectly well; this wrapper exists
+/// only so that releasing it also retires the acquisition time. Pairing them in
+/// one value is what makes the two impossible to drift apart — there is no path
+/// that returns a permit without also dropping this.
+struct RunSlot {
+    /// Dropped with the struct; that release is the whole point of the field.
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    instance_id: String,
+    registry: RunSlotRegistry,
+}
+
+/// Turn a semaphore reading plus the slot map into an occupancy report.
+///
+/// Split out from [`Runner::occupancy`] so the decisions it makes are testable
+/// without standing up a runner (which needs a live persistence layer): that
+/// `held` is read from the semaphore rather than counted from the map, and that
+/// the reported age belongs to the *oldest* holder rather than any other.
+fn compute_occupancy(
+    limit: usize,
+    available: usize,
+    slots: &HashMap<String, Instant>,
+    now: Instant,
+) -> RunnerOccupancy {
+    // Deliberately not `slots.len()`. A permit is taken before its acquisition
+    // time is recorded, so during that window the map under-reports; the
+    // semaphore never does. The map's only job is answering "how old is the
+    // oldest", where a momentarily missing entry costs nothing.
+    let held = limit.saturating_sub(available);
+    let oldest = slots.iter().min_by_key(|(_, taken)| **taken);
+    RunnerOccupancy {
+        limit: limit as u64,
+        held: held as u64,
+        oldest_held_ms: oldest
+            .map(|(_, taken)| now.saturating_duration_since(*taken).as_millis() as u64),
+        oldest_instance_id: oldest.map(|(id, _)| id.clone()),
+    }
+}
+
+impl Drop for RunSlot {
+    fn drop(&mut self) {
+        // Recover from poisoning rather than propagate it. This runs while the
+        // task may already be unwinding, so panicking here would abort the
+        // process; and a poisoned occupancy map is not a reason to refuse to
+        // give a permit back.
+        let mut slots = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        slots.remove(&self.instance_id);
+    }
 }
 
 impl EmbeddedWasmRunner {
@@ -104,14 +173,14 @@ impl EmbeddedWasmRunner {
         let handler_state = Arc::new(runtara_core::instance_handlers::InstanceHandlerState::new(
             Arc::clone(&persistence),
         ));
+        let run_limit = max_concurrent_runs();
+        warn_if_run_bound_exceeds_memory(run_limit);
         Ok(Self {
             config,
             limits: limits_from_env(),
-            run_permits: Arc::new(tokio::sync::Semaphore::new({
-                let permits = max_concurrent_runs();
-                warn_if_run_bound_exceeds_memory(permits);
-                permits
-            })),
+            run_permits: Arc::new(tokio::sync::Semaphore::new(run_limit)),
+            run_limit,
+            run_slots: Arc::new(Mutex::new(HashMap::new())),
             persistence,
             executor: Arc::new(executor),
             tasks: Arc::new(Mutex::new(HashMap::new())),
@@ -598,6 +667,19 @@ impl Runner for EmbeddedWasmRunner {
         "wasm-embedded"
     }
 
+    fn occupancy(&self) -> Option<RunnerOccupancy> {
+        let slots = self
+            .run_slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Some(compute_occupancy(
+            self.run_limit,
+            self.run_permits.available_permits(),
+            &slots,
+            Instant::now(),
+        ))
+    }
+
     async fn run(
         &self,
         options: &LaunchOptions,
@@ -790,10 +872,22 @@ impl Runner for EmbeddedWasmRunner {
         // durable, so this delays the run rather than losing it, and it gives
         // the wake scheduler and trigger worker the backpressure their own
         // concurrency limits are supposed to express.
-        let run_slot = Arc::clone(&self.run_permits)
+        let permit = Arc::clone(&self.run_permits)
             .acquire_owned()
             .await
             .expect("run semaphore closed");
+        // Stamp the acquisition before the task is spawned, so the age covers
+        // the whole time the permit is held rather than starting once the task
+        // happens to be scheduled.
+        self.run_slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(options.instance_id.clone(), Instant::now());
+        let run_slot = RunSlot {
+            _permit: permit,
+            instance_id: options.instance_id.clone(),
+            registry: Arc::clone(&self.run_slots),
+        };
         tokio::spawn(async move {
             let _run_slot = run_slot;
             match executor.load_instance_pre(&wasm_path).await {
@@ -1009,6 +1103,155 @@ impl Runner for EmbeddedWasmRunner {
 
 #[cfg(test)]
 mod tests {
+    use super::{RunSlot, compute_occupancy};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    /// Nothing running must be reported as "nothing running", not as "unknown".
+    ///
+    /// The distinction matters downstream: a consumer renders an absent
+    /// occupancy as "not measured" and a present-but-zero one as idle, and
+    /// collapsing the two invents an idle system that is actually unobserved.
+    #[test]
+    fn idle_runner_reports_zero_held_and_no_age() {
+        let occ = compute_occupancy(16, 16, &HashMap::new(), Instant::now());
+        assert_eq!(occ.limit, 16);
+        assert_eq!(occ.held, 0);
+        assert_eq!(occ.oldest_held_ms, None);
+        assert_eq!(occ.oldest_instance_id, None);
+    }
+
+    /// `held` must follow the semaphore, not the bookkeeping map.
+    ///
+    /// A permit is taken before its acquisition time is recorded, so the map
+    /// lags by that window. Were `held` counted from the map, a runner at its
+    /// bound would briefly report headroom it does not have.
+    #[test]
+    fn held_comes_from_the_semaphore_not_the_slot_map() {
+        let now = Instant::now();
+        let mut slots = HashMap::new();
+        slots.insert("only-one-recorded".to_string(), now);
+
+        // Eight permits gone, but only one has been stamped yet.
+        let occ = compute_occupancy(8, 0, &slots, now);
+        assert_eq!(occ.held, 8, "occupancy must not lag behind the semaphore");
+        assert_eq!(
+            occ.oldest_instance_id.as_deref(),
+            Some("only-one-recorded"),
+            "the age still comes from whatever has been recorded"
+        );
+    }
+
+    /// The reported age must belong to the longest-held permit.
+    ///
+    /// This is the signal that separates a runner turning work over from one
+    /// holding work that never leaves, so picking any other holder — the first
+    /// inserted, or whatever the map happens to yield first — would report a
+    /// stalled runner as healthy.
+    #[test]
+    fn age_belongs_to_the_oldest_holder() {
+        let now = Instant::now();
+        let mut slots = HashMap::new();
+        slots.insert("recent".to_string(), now - Duration::from_secs(2));
+        slots.insert("ancient".to_string(), now - Duration::from_secs(2880));
+        slots.insert("middling".to_string(), now - Duration::from_secs(45));
+
+        let occ = compute_occupancy(8, 5, &slots, now);
+        assert_eq!(occ.held, 3);
+        assert_eq!(occ.oldest_instance_id.as_deref(), Some("ancient"));
+        assert_eq!(
+            occ.oldest_held_ms,
+            Some(2_880_000),
+            "48 minutes held is exactly the case this exists to surface"
+        );
+    }
+
+    /// An over-subscribed reading must clamp rather than wrap.
+    ///
+    /// `held` is `limit - available` on unsigned values; a stale or racing read
+    /// where available exceeds the limit would otherwise underflow into an
+    /// enormous occupancy and paint a healthy runner as catastrophically full.
+    #[test]
+    fn available_above_limit_clamps_to_zero() {
+        let occ = compute_occupancy(4, 9, &HashMap::new(), Instant::now());
+        assert_eq!(occ.held, 0, "must saturate, never wrap");
+    }
+
+    /// Dropping the slot must release the permit *and* retire its timestamp.
+    ///
+    /// The pairing is the invariant: a permit returned without its entry
+    /// removed leaves a timestamp that never ages out, and the runner would
+    /// report a permanently stuck holder that finished long ago.
+    #[tokio::test]
+    async fn dropping_a_slot_releases_the_permit_and_forgets_its_age() {
+        let permits = Arc::new(tokio::sync::Semaphore::new(2));
+        let registry: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        {
+            let permit = Arc::clone(&permits).acquire_owned().await.expect("acquire");
+            registry
+                .lock()
+                .expect("registry")
+                .insert("inst-1".to_string(), Instant::now());
+            let _slot = RunSlot {
+                _permit: permit,
+                instance_id: "inst-1".to_string(),
+                registry: Arc::clone(&registry),
+            };
+
+            assert_eq!(permits.available_permits(), 1);
+            assert_eq!(registry.lock().expect("registry").len(), 1);
+        }
+
+        assert_eq!(
+            permits.available_permits(),
+            2,
+            "the permit must return on drop"
+        );
+        assert!(
+            registry.lock().expect("registry").is_empty(),
+            "the acquisition time must retire with the permit"
+        );
+    }
+
+    /// A panicking run must not leave a phantom holder behind.
+    ///
+    /// Unwinding is exactly when bookkeeping is most likely to be skipped, and
+    /// a leaked entry here is worse than none: it ages forever and would make
+    /// every later reading report a stall that is not happening.
+    #[tokio::test]
+    async fn a_panicking_run_still_retires_its_slot() {
+        let permits = Arc::new(tokio::sync::Semaphore::new(1));
+        let registry: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        let permit = Arc::clone(&permits).acquire_owned().await.expect("acquire");
+        registry
+            .lock()
+            .expect("registry")
+            .insert("doomed".to_string(), Instant::now());
+        let slot = RunSlot {
+            _permit: permit,
+            instance_id: "doomed".to_string(),
+            registry: Arc::clone(&registry),
+        };
+
+        let handle = tokio::spawn(async move {
+            let _slot = slot;
+            panic!("the guest blew up");
+        });
+        assert!(handle.await.is_err(), "the task must have panicked");
+
+        assert_eq!(permits.available_permits(), 1);
+        assert!(
+            registry
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty(),
+            "drop runs while unwinding, so the entry must still be retired"
+        );
+    }
+
     /// The advisory bound check must fire only when the setting cannot fit.
     ///
     /// It exists because raising `RUNTARA_MAX_CONCURRENT_RUNS` for throughput

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -21,7 +21,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
@@ -100,6 +100,10 @@ pub struct EmbeddedWasmRunner {
     /// it needs no eviction policy; entries are removed by [`RunSlot`]'s drop,
     /// which runs on the success, error and panic paths alike.
     run_slots: RunSlotRegistry,
+    /// Runs begun since process start.
+    runs_started: Arc<AtomicU64>,
+    /// Runs finished since process start, incremented as each permit returns.
+    runs_finished: Arc<AtomicU64>,
     /// Shared handler state for per-run [`PersistenceRuntimeHost`]s — the
     /// native runtime interface for HostImport-composed artifacts.
     handler_state: Arc<runtara_core::instance_handlers::InstanceHandlerState>,
@@ -119,6 +123,9 @@ struct RunSlot {
     _permit: tokio::sync::OwnedSemaphorePermit,
     instance_id: String,
     registry: RunSlotRegistry,
+    /// Bumped as the permit returns, so the count of finished runs cannot drift
+    /// from the count of released permits.
+    finished: Arc<AtomicU64>,
 }
 
 /// Turn a semaphore reading plus the slot map into an occupancy report.
@@ -145,6 +152,10 @@ fn compute_occupancy(
         oldest_held_ms: oldest
             .map(|(_, taken)| now.saturating_duration_since(*taken).as_millis() as u64),
         oldest_instance_id: oldest.map(|(id, _)| id.clone()),
+        // Filled in by the caller, which owns the lifetime counters; this
+        // function is about a single instant's occupancy.
+        runs_started: 0,
+        runs_finished: 0,
     }
 }
 
@@ -159,6 +170,7 @@ impl Drop for RunSlot {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         slots.remove(&self.instance_id);
+        self.finished.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -181,6 +193,8 @@ impl EmbeddedWasmRunner {
             run_permits: Arc::new(tokio::sync::Semaphore::new(run_limit)),
             run_limit,
             run_slots: Arc::new(Mutex::new(HashMap::new())),
+            runs_started: Arc::new(AtomicU64::new(0)),
+            runs_finished: Arc::new(AtomicU64::new(0)),
             persistence,
             executor: Arc::new(executor),
             tasks: Arc::new(Mutex::new(HashMap::new())),
@@ -672,12 +686,15 @@ impl Runner for EmbeddedWasmRunner {
             .run_slots
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        Some(compute_occupancy(
+        let mut occupancy = compute_occupancy(
             self.run_limit,
             self.run_permits.available_permits(),
             &slots,
             Instant::now(),
-        ))
+        );
+        occupancy.runs_started = self.runs_started.load(Ordering::Relaxed);
+        occupancy.runs_finished = self.runs_finished.load(Ordering::Relaxed);
+        Some(occupancy)
     }
 
     async fn run(
@@ -883,10 +900,12 @@ impl Runner for EmbeddedWasmRunner {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(options.instance_id.clone(), Instant::now());
+        self.runs_started.fetch_add(1, Ordering::Relaxed);
         let run_slot = RunSlot {
             _permit: permit,
             instance_id: options.instance_id.clone(),
             registry: Arc::clone(&self.run_slots),
+            finished: Arc::clone(&self.runs_finished),
         };
         tokio::spawn(async move {
             let _run_slot = run_slot;
@@ -1187,6 +1206,7 @@ mod tests {
     async fn dropping_a_slot_releases_the_permit_and_forgets_its_age() {
         let permits = Arc::new(tokio::sync::Semaphore::new(2));
         let registry: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let finished = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
         {
             let permit = Arc::clone(&permits).acquire_owned().await.expect("acquire");
@@ -1198,6 +1218,7 @@ mod tests {
                 _permit: permit,
                 instance_id: "inst-1".to_string(),
                 registry: Arc::clone(&registry),
+                finished: Arc::clone(&finished),
             };
 
             assert_eq!(permits.available_permits(), 1);
@@ -1213,6 +1234,11 @@ mod tests {
             registry.lock().expect("registry").is_empty(),
             "the acquisition time must retire with the permit"
         );
+        assert_eq!(
+            finished.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "a released permit is a finished run; the two must not drift"
+        );
     }
 
     /// A panicking run must not leave a phantom holder behind.
@@ -1224,6 +1250,7 @@ mod tests {
     async fn a_panicking_run_still_retires_its_slot() {
         let permits = Arc::new(tokio::sync::Semaphore::new(1));
         let registry: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let finished = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
         let permit = Arc::clone(&permits).acquire_owned().await.expect("acquire");
         registry
@@ -1234,6 +1261,7 @@ mod tests {
             _permit: permit,
             instance_id: "doomed".to_string(),
             registry: Arc::clone(&registry),
+            finished: Arc::clone(&finished),
         };
 
         let handle = tokio::spawn(async move {
@@ -1249,6 +1277,11 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .is_empty(),
             "drop runs while unwinding, so the entry must still be retired"
+        );
+        assert_eq!(
+            finished.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "a run that panicked still finished, and must be counted as such"
         );
     }
 

--- a/crates/runtara-environment/src/runner/traits.rs
+++ b/crates/runtara-environment/src/runner/traits.rs
@@ -140,6 +140,31 @@ pub struct LaunchResult {
 /// Cancellation token for stopping execution.
 pub type CancelToken = Arc<AtomicBool>;
 
+/// How much of a runner's concurrency bound is currently spoken for.
+///
+/// `held` answers "is the stage full"; `oldest_held_ms` answers the question a
+/// count cannot, which is whether a full stage is turning work over as fast as
+/// the host allows or holding work that never leaves. Those look identical on a
+/// gauge and call for opposite responses, so the age is the point of this type
+/// rather than a nicety: a runner pinned at its bound with a permit held for
+/// forty minutes is stalled, and the same runner pinned with permits recycling
+/// every few seconds is merely busy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerOccupancy {
+    /// Concurrency bound this runner enforces.
+    pub limit: u64,
+    /// Permits currently held.
+    ///
+    /// Read from the semaphore rather than counted from any bookkeeping map, so
+    /// it stays authoritative even in the window where a permit has been taken
+    /// but its acquisition time is not yet recorded.
+    pub held: u64,
+    /// Age of the longest-held permit, if anything is running.
+    pub oldest_held_ms: Option<u64>,
+    /// Instance holding that longest-held permit.
+    pub oldest_instance_id: Option<String>,
+}
+
 /// Trait for instance runners.
 ///
 /// Runners are responsible for launching and managing workflow guests.
@@ -181,6 +206,17 @@ pub trait Runner: Send + Sync {
         &self,
         handle: &RunnerHandle,
     ) -> (Option<Value>, Option<String>, ContainerMetrics);
+
+    /// Current occupancy of this runner's concurrency bound, if it has one.
+    ///
+    /// Defaults to `None` — "this runner does not report occupancy" — which is
+    /// distinct from `Some` with a zero `held`, i.e. "nothing is running". A
+    /// caller must render the two differently: collapsing an unavailable source
+    /// to zero is how a dashboard invents an idle system that is actually
+    /// unobserved.
+    fn occupancy(&self) -> Option<RunnerOccupancy> {
+        None
+    }
 
     /// Wait for the instance to exit, polling with the given interval.
     ///

--- a/crates/runtara-environment/src/runner/traits.rs
+++ b/crates/runtara-environment/src/runner/traits.rs
@@ -163,6 +163,17 @@ pub struct RunnerOccupancy {
     pub oldest_held_ms: Option<u64>,
     /// Instance holding that longest-held permit.
     pub oldest_instance_id: Option<String>,
+    /// Runs this runner has begun executing, since process start.
+    pub runs_started: u64,
+    /// Runs this runner has finished executing, since process start.
+    ///
+    /// "Finished" means the guest stopped and gave its permit back, which
+    /// includes a run that parked itself to await a wake or a signal. It is
+    /// therefore the throughput of the executing stage, and deliberately not a
+    /// count of instances reaching a terminal status — those differ whenever
+    /// durable workflows are in play, and conflating them would report a
+    /// healthy parking workload as a flood of completions.
+    pub runs_finished: u64,
 }
 
 /// Trait for instance runners.

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineRates/index.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineRates/index.tsx
@@ -1,0 +1,75 @@
+import { cn } from '@/lib/utils';
+import { formatRate, type PipelineRates as Rates } from '../../utils/pipeline';
+
+interface PipelineRatesProps {
+  rates: Rates | null;
+}
+
+/// Headline throughput across the pipeline.
+///
+/// `steps` is the one tile that can legitimately have nothing to show while
+/// everything else does: `trackEvents` is compile-time, so a deployment of
+/// workflows built without it runs perfectly and reports no steps at all. That
+/// renders as "not measured" rather than as zero, because a reader who saw
+/// `0/s` beside four healthy numbers would reasonably conclude work had
+/// stopped.
+export function PipelineRates({ rates }: PipelineRatesProps) {
+  const tiles: {
+    label: string;
+    value: number | null;
+    tone?: 'good' | 'bad';
+    unmeasured?: boolean;
+  }[] = [
+    { label: 'Offered', value: rates?.offered ?? null },
+    {
+      label: 'Accepted',
+      value: rates?.accepted ?? null,
+      tone: rates && rates.accepted < rates.offered ? undefined : 'good',
+    },
+    {
+      label: 'Denied 403',
+      value: rates?.denied ?? null,
+      tone: rates && rates.denied > 0 ? 'bad' : undefined,
+    },
+    { label: 'Started', value: rates?.started ?? null },
+    { label: 'Finished', value: rates?.finished ?? null, tone: 'good' },
+    {
+      label: 'Steps',
+      value: rates?.steps ?? null,
+      unmeasured: rates !== null && rates.steps === null,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border/40 bg-border/40 sm:grid-cols-3 lg:grid-cols-6">
+      {tiles.map((tile) => (
+        <div key={tile.label} className="bg-card px-4 py-2.5">
+          <div className="text-[10.5px] font-medium uppercase tracking-wider text-muted-foreground">
+            {tile.label}
+          </div>
+          {tile.unmeasured ? (
+            <div
+              className="text-sm font-medium text-muted-foreground"
+              title="These workflows were compiled without step tracking, so no step can be reported. This is not zero throughput."
+            >
+              not measured
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'text-xl font-semibold tabular-nums leading-tight',
+                tile.tone === 'bad' && 'text-destructive',
+                tile.tone === 'good' && 'text-emerald-600 dark:text-emerald-500'
+              )}
+            >
+              {formatRate(tile.value)}
+              <span className="ml-1 text-xs font-medium text-muted-foreground">
+                /s
+              </span>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PipelineStageRow } from './index';
+import { PipelineRates } from '../PipelineRates';
+import type { PipelineStage } from '../../utils/pipeline';
+
+function stage(over: Partial<PipelineStage> & { key: string }): PipelineStage {
+  return {
+    label: over.key,
+    knob: null,
+    limit: null,
+    used: null,
+    oldestAgeMs: null,
+    inflowKey: 'accepted',
+    ...over,
+  };
+}
+
+const HISTORY = Array.from({ length: 30 }, (_, i) => 8 + (i % 3));
+
+describe('PipelineStageRow', () => {
+  it('shows the knob name so an operator can act without looking it up', () => {
+    render(
+      <PipelineStageRow
+        stage={stage({
+          key: 'runPermits',
+          label: 'Run permits',
+          knob: 'RUNTARA_MAX_CONCURRENT_RUNS',
+          limit: 16,
+          used: 12,
+        })}
+        history={HISTORY}
+        inflow={398}
+        isChokepoint={false}
+      />
+    );
+    expect(screen.getByText('RUNTARA_MAX_CONCURRENT_RUNS')).toBeInTheDocument();
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('renders an unread occupancy as "not measured", never as 0%', () => {
+    // The distinction this whole view is built around. A stage whose source
+    // could not be read is unobserved, not empty, and showing 0% would present
+    // a blind spot as a confident all-clear.
+    render(
+      <PipelineStageRow
+        stage={stage({ key: 'runPermits', limit: 16, used: null })}
+        history={[]}
+        inflow={null}
+        isChokepoint={false}
+      />
+    );
+    expect(screen.getByText('not measured')).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+  });
+
+  it('marks an inflow of zero, which is where throughput died', () => {
+    const { container } = render(
+      <PipelineStageRow
+        stage={stage({ key: 'runPermits', limit: 8, used: 8 })}
+        history={HISTORY}
+        inflow={0}
+        isChokepoint
+      />
+    );
+    // Reading the inflow column top to bottom, the row where it hits zero is
+    // the row at fault — so zero has to be visually distinct from a small rate.
+    const inflow = container.querySelector('.text-destructive');
+    expect(inflow).not.toBeNull();
+  });
+
+  it('flags a stage that is full and not draining', () => {
+    render(
+      <PipelineStageRow
+        stage={stage({
+          key: 'runPermits',
+          limit: 8,
+          used: 8,
+          oldestAgeMs: 2_880_000,
+        })}
+        history={Array(30).fill(8)}
+        inflow={0}
+        isChokepoint
+      />
+    );
+    expect(screen.getByText('not draining')).toBeInTheDocument();
+    expect(screen.getByText('48m oldest')).toBeInTheDocument();
+  });
+
+  it('does not flag a stage that is full but still turning work over', () => {
+    // Full is not a fault. A stage pinned at its bound while recycling every
+    // few seconds is a system working as hard as the host allows.
+    render(
+      <PipelineStageRow
+        stage={stage({
+          key: 'runPermits',
+          limit: 16,
+          used: 16,
+          oldestAgeMs: 2_900,
+        })}
+        history={Array(30).fill(16)}
+        inflow={805}
+        isChokepoint={false}
+      />
+    );
+    expect(screen.queryByText('not draining')).not.toBeInTheDocument();
+    expect(screen.getByText('2.9s oldest')).toBeInTheDocument();
+  });
+
+  it('marks the chokepoint in the DOM so it can be asserted on', () => {
+    const { container } = render(
+      <PipelineStageRow
+        stage={stage({ key: 'runPermits', limit: 8, used: 8 })}
+        history={HISTORY}
+        inflow={0}
+        isChokepoint
+      />
+    );
+    const row = container.querySelector(
+      '[data-testid="pipeline-stage-runPermits"]'
+    );
+    expect(row?.getAttribute('data-chokepoint')).toBe('true');
+  });
+
+  it('shows an unbounded stage as having no limit rather than a percentage', () => {
+    render(
+      <PipelineStageRow
+        stage={stage({ key: 'parked', label: 'Parked', used: 1_009_739 })}
+        history={Array(30).fill(1_009_739)}
+        inflow={396}
+        isChokepoint={false}
+      />
+    );
+    expect(screen.getByText('1.01M')).toBeInTheDocument();
+    expect(screen.getByText('no limit')).toBeInTheDocument();
+  });
+
+  it('says it is still collecting rather than drawing a line from one point', () => {
+    render(
+      <PipelineStageRow
+        stage={stage({ key: 'runPermits', limit: 16, used: 4 })}
+        history={[4]}
+        inflow={10}
+        isChokepoint={false}
+      />
+    );
+    expect(screen.getByText('collecting…')).toBeInTheDocument();
+  });
+});
+
+describe('PipelineRates', () => {
+  const RATES = {
+    offered: 400,
+    accepted: 400,
+    denied: 0,
+    started: 398,
+    finished: 396,
+    steps: 1980,
+  };
+
+  it('shows every headline rate', () => {
+    render(<PipelineRates rates={RATES} />);
+    expect(screen.getByText('Offered')).toBeInTheDocument();
+    expect(screen.getByText('Denied 403')).toBeInTheDocument();
+    expect(screen.getByText('Steps')).toBeInTheDocument();
+    // 1,980/s renders as 2.0k: a headline tile trades the last digit for scale.
+    expect(screen.getByText('2.0k')).toBeInTheDocument();
+  });
+
+  it('renders unmeasured steps as "not measured", never as 0/s', () => {
+    // trackEvents is compile-time: a deployment built without it runs
+    // perfectly and reports no steps. Showing 0/s beside four healthy numbers
+    // would have a reader conclude work had stopped dead.
+    render(<PipelineRates rates={{ ...RATES, steps: null }} />);
+    expect(screen.getByText('not measured')).toBeInTheDocument();
+    // And the rest of the row is unaffected — Offered and Accepted both 400.
+    expect(screen.getAllByText('400')).toHaveLength(2);
+  });
+
+  it('shows dashes rather than zeros before the first window closes', () => {
+    // The first tick has no earlier reading to difference against. Rendering
+    // that as zeros would show a busy server as an idle one for a second.
+    render(<PipelineRates rates={null} />);
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
@@ -24,7 +24,7 @@ describe('PipelineStageRow', () => {
       <PipelineStageRow
         stage={stage({
           key: 'runPermits',
-          label: 'Run permits',
+          label: 'Concurrent runs',
           knob: 'RUNTARA_MAX_CONCURRENT_RUNS',
           limit: 16,
           used: 12,

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/PipelineStageRow.test.tsx
@@ -31,6 +31,7 @@ describe('PipelineStageRow', () => {
         })}
         history={HISTORY}
         inflow={398}
+        pipelineActive
         isChokepoint={false}
       />
     );
@@ -47,6 +48,7 @@ describe('PipelineStageRow', () => {
         stage={stage({ key: 'runPermits', limit: 16, used: null })}
         history={[]}
         inflow={null}
+        pipelineActive={false}
         isChokepoint={false}
       />
     );
@@ -60,6 +62,7 @@ describe('PipelineStageRow', () => {
         stage={stage({ key: 'runPermits', limit: 8, used: 8 })}
         history={HISTORY}
         inflow={0}
+        pipelineActive
         isChokepoint
       />
     );
@@ -67,6 +70,22 @@ describe('PipelineStageRow', () => {
     // the row at fault — so zero has to be visually distinct from a small rate.
     const inflow = container.querySelector('.text-destructive');
     expect(inflow).not.toBeNull();
+  });
+
+  it('does not redden a zero inflow on an idle pipeline', () => {
+    // Every stage of an idle deployment is legitimately at zero. Reddening all
+    // six would cry wolf on a system doing exactly what it should, and teach
+    // its reader to ignore the colour when it finally means something.
+    const { container } = render(
+      <PipelineStageRow
+        stage={stage({ key: 'runPermits', limit: 64, used: 0 })}
+        history={Array(30).fill(0)}
+        inflow={0}
+        pipelineActive={false}
+        isChokepoint={false}
+      />
+    );
+    expect(container.querySelector('.text-destructive')).toBeNull();
   });
 
   it('flags a stage that is full and not draining', () => {
@@ -80,6 +99,7 @@ describe('PipelineStageRow', () => {
         })}
         history={Array(30).fill(8)}
         inflow={0}
+        pipelineActive
         isChokepoint
       />
     );
@@ -100,6 +120,7 @@ describe('PipelineStageRow', () => {
         })}
         history={Array(30).fill(16)}
         inflow={805}
+        pipelineActive
         isChokepoint={false}
       />
     );
@@ -113,6 +134,7 @@ describe('PipelineStageRow', () => {
         stage={stage({ key: 'runPermits', limit: 8, used: 8 })}
         history={HISTORY}
         inflow={0}
+        pipelineActive
         isChokepoint
       />
     );
@@ -128,6 +150,7 @@ describe('PipelineStageRow', () => {
         stage={stage({ key: 'parked', label: 'Parked', used: 1_009_739 })}
         history={Array(30).fill(1_009_739)}
         inflow={396}
+        pipelineActive
         isChokepoint={false}
       />
     );
@@ -141,6 +164,7 @@ describe('PipelineStageRow', () => {
         stage={stage({ key: 'runPermits', limit: 16, used: 4 })}
         history={[4]}
         inflow={10}
+        pipelineActive
         isChokepoint={false}
       />
     );

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/index.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/index.tsx
@@ -17,6 +17,12 @@ interface PipelineStageRowProps {
   history: (number | null)[];
   /// Rate flowing into this stage, or `null` before the first window closes.
   inflow: number | null;
+  /// Is the pipeline being offered any work at all?
+  ///
+  /// Zero throughput is only a symptom when there is something upstream to
+  /// have moved. On an idle deployment every stage is legitimately at zero, and
+  /// reddening all six would cry wolf on a system doing exactly what it should.
+  pipelineActive: boolean;
   isChokepoint: boolean;
 }
 
@@ -45,6 +51,7 @@ export function PipelineStageRow({
   stage,
   history,
   inflow,
+  pipelineActive,
   isChokepoint,
 }: PipelineStageRowProps) {
   const pct = utilisation(stage);
@@ -73,7 +80,9 @@ export function PipelineStageRow({
         <span
           className={cn(
             'text-sm font-semibold tabular-nums',
-            inflow === 0 ? 'text-destructive' : 'text-foreground'
+            inflow === 0 && pipelineActive
+              ? 'text-destructive'
+              : 'text-foreground'
           )}
         >
           {formatRate(inflow)}

--- a/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/index.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/components/PipelineStageRow/index.tsx
@@ -1,0 +1,181 @@
+import { ArrowDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  formatAge,
+  formatCount,
+  formatRate,
+  isNotDraining,
+  severityOf,
+  sparklinePath,
+  utilisation,
+  type PipelineStage,
+} from '../../utils/pipeline';
+
+interface PipelineStageRowProps {
+  stage: PipelineStage;
+  /// Occupancy over the last minute, oldest first; `null` where unread.
+  history: (number | null)[];
+  /// Rate flowing into this stage, or `null` before the first window closes.
+  inflow: number | null;
+  isChokepoint: boolean;
+}
+
+const SEVERITY_STROKE: Record<string, string> = {
+  ok: 'stroke-primary',
+  warn: 'stroke-amber-500',
+  bad: 'stroke-destructive',
+  unknown: 'stroke-muted-foreground',
+};
+
+const SEVERITY_FILL: Record<string, string> = {
+  ok: 'fill-primary/15',
+  warn: 'fill-amber-500/20',
+  bad: 'fill-destructive/15',
+  unknown: 'fill-transparent',
+};
+
+const SEVERITY_BAR: Record<string, string> = {
+  ok: 'bg-primary',
+  warn: 'bg-amber-500',
+  bad: 'bg-destructive',
+  unknown: 'bg-muted-foreground/40',
+};
+
+export function PipelineStageRow({
+  stage,
+  history,
+  inflow,
+  isChokepoint,
+}: PipelineStageRowProps) {
+  const pct = utilisation(stage);
+  const severity = severityOf(stage);
+  const bounded = stage.limit !== null;
+  const path = sparklinePath(history, stage.limit);
+  const stuck = isNotDraining(stage);
+  const age = formatAge(stage.oldestAgeMs);
+
+  return (
+    <div
+      className={cn(
+        'grid items-center gap-x-4 rounded-lg border bg-card px-3 py-2.5',
+        'grid-cols-[64px_minmax(0,1fr)] md:grid-cols-[80px_180px_minmax(0,1fr)_150px_130px]',
+        isChokepoint
+          ? 'border-destructive/60 ring-1 ring-destructive/30'
+          : 'border-border/40'
+      )}
+      data-testid={`pipeline-stage-${stage.key}`}
+      data-chokepoint={isChokepoint ? 'true' : 'false'}
+    >
+      {/* Inflow. Read top to bottom, this column is where throughput dies —
+          and the row it dies on is the one at fault. */}
+      <div className="flex flex-col items-center gap-0.5 text-muted-foreground">
+        <ArrowDown className="size-3 opacity-50" aria-hidden="true" />
+        <span
+          className={cn(
+            'text-sm font-semibold tabular-nums',
+            inflow === 0 ? 'text-destructive' : 'text-foreground'
+          )}
+        >
+          {formatRate(inflow)}
+          <span className="ml-0.5 text-[10px] font-medium text-muted-foreground">
+            /s
+          </span>
+        </span>
+      </div>
+
+      <div className="min-w-0">
+        <h3 className="truncate text-sm font-semibold text-foreground">
+          {stage.label}
+        </h3>
+        {stage.knob && (
+          <div className="truncate font-mono text-[10.5px] leading-tight text-muted-foreground">
+            {stage.knob}
+          </div>
+        )}
+      </div>
+
+      {/* Occupancy over the last minute. A line pinned at the top is not by
+          itself a fault: textured means turning work over as fast as the host
+          allows, ruled-flat means holding work that never leaves. */}
+      <div className="hidden h-10 md:block">
+        {path ? (
+          <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="h-full w-full"
+            aria-hidden="true"
+          >
+            {bounded && (
+              <path
+                d={path.area}
+                className={SEVERITY_FILL[severity]}
+                stroke="none"
+              />
+            )}
+            <path
+              d={path.line}
+              fill="none"
+              strokeWidth={1.5}
+              vectorEffect="non-scaling-stroke"
+              strokeLinejoin="round"
+              className={SEVERITY_STROKE[severity]}
+            />
+          </svg>
+        ) : (
+          <div className="flex h-full items-center text-[11px] text-muted-foreground">
+            collecting…
+          </div>
+        )}
+      </div>
+
+      <div className="hidden md:block">
+        <div className="text-base font-semibold tabular-nums text-foreground">
+          {formatCount(stage.used)}
+          <span className="ml-1 text-xs font-medium text-muted-foreground">
+            {bounded ? `/ ${formatCount(stage.limit)}` : 'no limit'}
+          </span>
+        </div>
+        {bounded && (
+          <>
+            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-[width] duration-700 ease-linear',
+                  SEVERITY_BAR[severity]
+                )}
+                style={{ width: `${pct ?? 0}%` }}
+              />
+            </div>
+            <div className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+              {/* Unread is a dash, never 0% — an unobserved bound is not an
+                  empty one. */}
+              {pct === null ? (
+                <span>not measured</span>
+              ) : (
+                <>
+                  <span className="font-medium text-foreground">
+                    {pct.toFixed(0)}%
+                  </span>{' '}
+                  in use
+                </>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="hidden text-[11.5px] md:block">
+        {stuck && (
+          <span className="inline-block rounded bg-destructive/10 px-2 py-1 font-medium text-destructive">
+            not draining
+          </span>
+        )}
+        {age && (
+          <span className="mt-1 block tabular-nums text-muted-foreground">
+            {age} oldest
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/runtara-server/frontend/src/features/analytics/hooks/usePipelineStream.ts
+++ b/crates/runtara-server/frontend/src/features/analytics/hooks/usePipelineStream.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from 'react-oidc-context';
+import { getRuntimeBaseUrl } from '@/shared/queries/utils';
+import { readJsonEventStream } from '@/shared/utils/sse';
+import { stickyChokepoint, type PipelineSnapshot } from '../utils/pipeline';
+
+/// How many snapshots to keep for the sparklines.
+///
+/// The sampler ticks once a second, so this is a minute of history — long
+/// enough to show whether a full stage is recycling or holding, which is the
+/// distinction the whole view exists to make.
+export const HISTORY_LENGTH = 60;
+
+export interface PipelineStreamState {
+  snapshot: PipelineSnapshot | null;
+  /// Per-stage occupancy history, oldest first, `null` where a reading was
+  /// missing. Gaps are preserved rather than interpolated: a line drawn through
+  /// an outage claims knowledge of a period nothing was observed.
+  history: Record<string, (number | null)[]>;
+  /// The stage currently held as the constraint, damped across ticks.
+  chokepointKey: string | null;
+  connected: boolean;
+  error: string | null;
+}
+
+/// Subscribe to live pipeline snapshots, falling back to polling.
+///
+/// The stream is the normal path; polling exists because a proxy that buffers
+/// `text/event-stream` turns a live view into a page that never updates, and
+/// silently showing stale numbers is worse than showing slower ones.
+export function usePipelineStream(): PipelineStreamState {
+  const auth = useAuth();
+  const token = auth.user?.access_token;
+
+  const [snapshot, setSnapshot] = useState<PipelineSnapshot | null>(null);
+  const [history, setHistory] = useState<Record<string, (number | null)[]>>({});
+  const [chokepointKey, setChokepointKey] = useState<string | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Read inside the state updater rather than as a dependency, so accepting a
+  // snapshot does not re-create the effect and tear down the stream.
+  const chokepointRef = useRef<string | null>(null);
+
+  const accept = useCallback((next: PipelineSnapshot) => {
+    setSnapshot(next);
+    setHistory((prev) => {
+      const updated: Record<string, (number | null)[]> = {};
+      for (const stage of next.stages) {
+        const series = [...(prev[stage.key] ?? []), stage.used];
+        updated[stage.key] = series.slice(-HISTORY_LENGTH);
+      }
+      return updated;
+    });
+    const held = stickyChokepoint(next.stages, chokepointRef.current);
+    chokepointRef.current = held;
+    setChokepointKey(held);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+
+    const headers: Record<string, string> = { Accept: 'text/event-stream' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    async function poll() {
+      try {
+        const response = await fetch(
+          `${getRuntimeBaseUrl()}/analytics/pipeline`,
+          {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+            signal: controller.signal,
+          }
+        );
+        // 503 means the sampler has not produced a snapshot yet, which is a
+        // booting server rather than a failure. Keep waiting quietly.
+        if (response.status === 503) return;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const body = await response.json();
+        if (!cancelled && body?.data) accept(body.data as PipelineSnapshot);
+      } catch (e) {
+        if (!cancelled && !controller.signal.aborted) {
+          setError(e instanceof Error ? e.message : 'Failed to read pipeline');
+        }
+      }
+    }
+
+    function startPolling() {
+      if (pollTimer || cancelled) return;
+      setConnected(false);
+      void poll();
+      pollTimer = setInterval(() => void poll(), 2000);
+    }
+
+    async function stream() {
+      try {
+        const response = await fetch(
+          `${getRuntimeBaseUrl()}/analytics/pipeline/stream`,
+          { headers, signal: controller.signal }
+        );
+        if (!response.ok || !response.body) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        setConnected(true);
+        setError(null);
+
+        for await (const value of readJsonEventStream<PipelineSnapshot>(
+          response.body,
+          controller.signal
+        )) {
+          if (cancelled) break;
+          accept(value);
+        }
+
+        // The stream ended without an error — a redeploy, or a proxy timing
+        // out an idle connection. Polling keeps the page truthful until the
+        // component remounts.
+        if (!cancelled) startPolling();
+      } catch (e) {
+        if (cancelled || controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : 'Pipeline stream failed');
+        startPolling();
+      }
+    }
+
+    void stream();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (pollTimer) clearInterval(pollTimer);
+    };
+  }, [token, accept]);
+
+  return { snapshot, history, chokepointKey, connected, error };
+}

--- a/crates/runtara-server/frontend/src/features/analytics/pages/System/index.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/pages/System/index.tsx
@@ -97,6 +97,9 @@ export function System() {
                           )[stage.inflowKey] ?? null)
                         : null
                     }
+                    pipelineActive={
+                      (pipeline.snapshot?.rates?.offered ?? 0) > 0
+                    }
                     isChokepoint={pipeline.chokepointKey === stage.key}
                   />
                 ))}

--- a/crates/runtara-server/frontend/src/features/analytics/pages/System/index.tsx
+++ b/crates/runtara-server/frontend/src/features/analytics/pages/System/index.tsx
@@ -9,6 +9,9 @@ import {
 import { Card } from '@/shared/components/ui/card';
 import { Progress } from '@/shared/components/ui/progress';
 import { useSystemAnalytics } from '../../hooks/useAnalytics';
+import { usePipelineStream } from '../../hooks/usePipelineStream';
+import { PipelineRates } from '../../components/PipelineRates';
+import { PipelineStageRow } from '../../components/PipelineStageRow';
 import { formatBytes } from '../../utils';
 
 export function System() {
@@ -19,6 +22,8 @@ export function System() {
     isLoading: systemLoading,
     refetch: refetchSystem,
   } = useSystemAnalytics();
+
+  const pipeline = usePipelineStream();
 
   const handleRefresh = () => {
     refetchSystem();
@@ -51,8 +56,63 @@ export function System() {
         />
       }
     >
-      <div className="space-y-4">
-        <section>
+      <div className="space-y-6">
+        {/* Occupancy leads: it is the live thing, and the host description
+            below it is the context for why the bounds are what they are. */}
+        <section aria-label="Execution pipeline">
+          <div className="mb-3 flex items-baseline justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">
+                Execution pipeline
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                Occupancy against every concurrency limit, sampled each second
+              </p>
+            </div>
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {pipeline.connected
+                ? 'live'
+                : pipeline.snapshot
+                  ? 'polling'
+                  : 'connecting…'}
+            </span>
+          </div>
+
+          {pipeline.snapshot ? (
+            <div className="space-y-3">
+              <PipelineRates rates={pipeline.snapshot.rates} />
+              <div className="space-y-1.5">
+                {pipeline.snapshot.stages.map((stage) => (
+                  <PipelineStageRow
+                    key={stage.key}
+                    stage={stage}
+                    history={pipeline.history[stage.key] ?? []}
+                    inflow={
+                      pipeline.snapshot?.rates
+                        ? ((
+                            pipeline.snapshot.rates as unknown as Record<
+                              string,
+                              number | null
+                            >
+                          )[stage.inflowKey] ?? null)
+                        : null
+                    }
+                    isChokepoint={pipeline.chokepointKey === stage.key}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border/40 bg-card px-4 py-6 text-sm text-muted-foreground">
+              {pipeline.error
+                ? `Pipeline unavailable: ${pipeline.error}`
+                : 'Waiting for the first sample…'}
+            </div>
+          )}
+        </section>
+
+        <section aria-label="Host">
+          <h2 className="mb-3 text-sm font-semibold text-foreground">Host</h2>
           <div className="grid gap-4 md:grid-cols-3">
             {/* CPU Info */}
             <Card className="rounded-lg border border-border/40 bg-card px-4 py-4 shadow-none sm:px-5">

--- a/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.test.ts
+++ b/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHOKE_THRESHOLD,
+  findChokepoint,
+  formatAge,
+  formatCount,
+  formatRate,
+  isNotDraining,
+  severityOf,
+  sparklinePath,
+  stepsAreMeasured,
+  stickyChokepoint,
+  utilisation,
+  type PipelineStage,
+  type PipelineSnapshot,
+} from './pipeline';
+
+function stage(over: Partial<PipelineStage> & { key: string }): PipelineStage {
+  return {
+    label: over.key,
+    knob: null,
+    limit: null,
+    used: null,
+    oldestAgeMs: null,
+    inflowKey: 'accepted',
+    ...over,
+  };
+}
+
+/// Four fixtures matching the states this view exists to tell apart.
+const FIXTURES = {
+  /// Everything below threshold and moving.
+  healthy: [
+    stage({ key: 'admission', limit: 2048, used: 1180 }),
+    stage({ key: 'triggerQueue', used: 41, oldestAgeMs: 200 }),
+    stage({ key: 'triggerWorkers', limit: 32, used: 9 }),
+    stage({ key: 'runPermits', limit: 16, used: 11, oldestAgeMs: 2_700 }),
+    stage({ key: 'executing', used: 11 }),
+    stage({ key: 'parked', used: 1_009_739 }),
+  ],
+  /// At the ceiling, but turning work over — full is not a fault.
+  saturated: [
+    stage({ key: 'admission', limit: 2048, used: 2048 }),
+    stage({ key: 'triggerQueue', used: 3_417, oldestAgeMs: 4_100 }),
+    stage({ key: 'triggerWorkers', limit: 32, used: 31 }),
+    stage({ key: 'runPermits', limit: 16, used: 16, oldestAgeMs: 2_900 }),
+    stage({ key: 'executing', used: 16 }),
+    stage({ key: 'parked', used: 1_009_739 }),
+  ],
+  /// Permits full and held for 48 minutes; the queue has merely piled up behind.
+  stalled: [
+    stage({ key: 'admission', limit: 64, used: 44 }),
+    stage({ key: 'triggerQueue', used: 28, oldestAgeMs: 345_600_000 }),
+    stage({ key: 'triggerWorkers', limit: 16, used: 0 }),
+    stage({ key: 'runPermits', limit: 8, used: 8, oldestAgeMs: 2_880_000 }),
+    stage({ key: 'executing', used: 8, oldestAgeMs: 2_880_000 }),
+    stage({ key: 'parked', used: 1_766 }),
+  ],
+  /// Sources unreadable — Valkey down, runner not reporting.
+  degraded: [
+    stage({ key: 'admission', limit: 2048, used: null }),
+    stage({ key: 'triggerQueue', used: null }),
+    stage({ key: 'triggerWorkers', limit: null, used: null }),
+    stage({ key: 'runPermits', limit: null, used: null }),
+    stage({ key: 'executing', used: null }),
+    stage({ key: 'parked', used: null }),
+  ],
+};
+
+describe('utilisation', () => {
+  it('is null for an unbounded stage rather than zero', () => {
+    // An unbounded stage has no ceiling to be a fraction of. Reporting 0%
+    // would have it render as comfortably empty when the truth is that the
+    // question does not apply.
+    expect(utilisation(stage({ key: 'parked', used: 1_009_739 }))).toBeNull();
+  });
+
+  it('is null when the occupancy could not be read', () => {
+    expect(utilisation(stage({ key: 'q', limit: 16, used: null }))).toBeNull();
+  });
+
+  it('measures a bounded stage against its ceiling', () => {
+    expect(utilisation(stage({ key: 'r', limit: 16, used: 12 }))).toBe(75);
+  });
+});
+
+describe('severityOf', () => {
+  it('separates unknown from healthy', () => {
+    // The distinction the whole payload is built around: an unread source is
+    // not an idle stage.
+    expect(severityOf(stage({ key: 'a', limit: 16, used: null }))).toBe(
+      'unknown'
+    );
+    expect(severityOf(stage({ key: 'a', limit: 16, used: 0 }))).toBe('ok');
+  });
+
+  it('escalates as a stage fills', () => {
+    expect(severityOf(stage({ key: 'a', limit: 100, used: 50 }))).toBe('ok');
+    expect(severityOf(stage({ key: 'a', limit: 100, used: 85 }))).toBe('warn');
+    expect(severityOf(stage({ key: 'a', limit: 100, used: 100 }))).toBe('bad');
+  });
+});
+
+describe('isNotDraining', () => {
+  it('requires both full and old', () => {
+    // Full while recycling is a system working as hard as it can; old with
+    // headroom is nobody's constraint. Only the two together are a fault.
+    expect(
+      isNotDraining(stage({ key: 'a', limit: 8, used: 8, oldestAgeMs: 2_900 }))
+    ).toBe(false);
+    expect(
+      isNotDraining(
+        stage({ key: 'a', limit: 8, used: 2, oldestAgeMs: 9_999_999 })
+      )
+    ).toBe(false);
+    expect(
+      isNotDraining(
+        stage({ key: 'a', limit: 8, used: 8, oldestAgeMs: 2_880_000 })
+      )
+    ).toBe(true);
+  });
+
+  it('is never true without an age to judge', () => {
+    expect(isNotDraining(stage({ key: 'a', limit: 8, used: 8 }))).toBe(false);
+  });
+});
+
+describe('findChokepoint', () => {
+  it('accuses nothing when every stage has headroom', () => {
+    // Regression: this once named Run permits at 69% on a healthy pipeline.
+    // A page that always points somewhere teaches its reader to ignore where
+    // it points.
+    expect(findChokepoint(FIXTURES.healthy)).toBeNull();
+  });
+
+  it('names the full bounded stage when the pipeline is saturated', () => {
+    const choke = findChokepoint(FIXTURES.saturated);
+    expect(choke?.key).toBe('admission');
+  });
+
+  it('names the run permits, not the queue, when work has stopped moving', () => {
+    // Regression, and the reason this view exists. The trigger queue holds the
+    // oldest item by four orders of magnitude (four days against forty-eight
+    // minutes) and is the obvious thing to point at — but it is unbounded, so
+    // it is where the evidence piles up rather than the constraint. The run
+    // permits are full and not draining, and they are the fault.
+    const choke = findChokepoint(FIXTURES.stalled);
+    expect(choke?.key).toBe('runPermits');
+    expect(choke?.key).not.toBe('triggerQueue');
+  });
+
+  it('prefers a stuck stage over a merely fuller one', () => {
+    // Regression: ranking by utilisation alone let whichever full stage came
+    // first win. Full stages are routine; stuck ones are the emergency.
+    const stages = [
+      stage({ key: 'busy', limit: 100, used: 100, oldestAgeMs: 500 }),
+      stage({ key: 'stuck', limit: 8, used: 8, oldestAgeMs: 2_880_000 }),
+    ];
+    expect(findChokepoint(stages)?.key).toBe('stuck');
+  });
+
+  it('never accuses an unbounded stage however deep it gets', () => {
+    const stages = [
+      stage({ key: 'admission', limit: 2048, used: 10 }),
+      stage({ key: 'triggerQueue', used: 5_000_000, oldestAgeMs: 999_999_999 }),
+    ];
+    expect(findChokepoint(stages)).toBeNull();
+  });
+
+  it('accuses nothing when nothing can be read', () => {
+    // The false-red guard: missing data must never be evidence of a fault.
+    expect(findChokepoint(FIXTURES.degraded)).toBeNull();
+  });
+
+  it('holds the threshold it documents', () => {
+    const under = [stage({ key: 'a', limit: 100, used: CHOKE_THRESHOLD - 1 })];
+    const over = [stage({ key: 'a', limit: 100, used: CHOKE_THRESHOLD })];
+    expect(findChokepoint(under)).toBeNull();
+    expect(findChokepoint(over)?.key).toBe('a');
+  });
+});
+
+describe('stickyChokepoint', () => {
+  it('does not flicker when a stage hovers at the threshold', () => {
+    // Regression: recomputed every tick, a stage wobbling either side of 80%
+    // had its highlight appear and vanish once a second. Unreadable, and it
+    // makes a real constraint look like noise.
+    const above = [stage({ key: 'runPermits', limit: 100, used: 81 })];
+    const below = [stage({ key: 'runPermits', limit: 100, used: 78 })];
+
+    const first = stickyChokepoint(above, null);
+    expect(first).toBe('runPermits');
+    expect(stickyChokepoint(below, first)).toBe('runPermits');
+  });
+
+  it('releases a stage that genuinely recovers', () => {
+    const recovered = [stage({ key: 'runPermits', limit: 100, used: 40 })];
+    expect(stickyChokepoint(recovered, 'runPermits')).toBeNull();
+  });
+
+  it('does not resurrect a stage that has vanished from the snapshot', () => {
+    expect(stickyChokepoint([], 'runPermits')).toBeNull();
+  });
+});
+
+describe('stepsAreMeasured', () => {
+  it('treats a null steps rate as unmeasured, not as zero', () => {
+    // trackEvents is compile-time: a workflow built without it runs perfectly
+    // and reports nothing. Rendering that as 0/s would let a reader conclude a
+    // healthy deployment had stopped dead.
+    const rates = {
+      offered: 400,
+      accepted: 400,
+      denied: 0,
+      started: 398,
+      finished: 396,
+      steps: null,
+    };
+    expect(stepsAreMeasured(rates)).toBe(false);
+    expect(stepsAreMeasured({ ...rates, steps: 0 })).toBe(true);
+  });
+
+  it('is false before the first window closes', () => {
+    const snapshot: PipelineSnapshot = {
+      capturedAt: '2026-09-02T00:00:00Z',
+      windowMs: 0,
+      rates: null,
+      stages: [],
+    };
+    expect(stepsAreMeasured(snapshot.rates)).toBe(false);
+  });
+});
+
+describe('formatting', () => {
+  it('coarsens an age as it grows', () => {
+    expect(formatAge(420)).toBe('420ms');
+    expect(formatAge(2_700)).toBe('2.7s');
+    expect(formatAge(2_880_000)).toBe('48m');
+    expect(formatAge(345_600_000)).toBe('4d');
+    expect(formatAge(null)).toBeNull();
+  });
+
+  it('renders a million parked as a million', () => {
+    expect(formatCount(1_009_739)).toBe('1.01M');
+    expect(formatCount(1_766)).toBe('1,766');
+    expect(formatCount(null)).toBe('—');
+  });
+
+  it('shows an unread rate as a dash, not a zero', () => {
+    expect(formatRate(null)).toBe('—');
+    expect(formatRate(0)).toBe('0.0');
+    expect(formatRate(398)).toBe('398');
+  });
+});
+
+describe('sparklinePath', () => {
+  it('scales from zero so a flat stock stays flat', () => {
+    // Regression: scaling to the series' own min–max turned a 0.06% drift
+    // across a million parked instances into a dramatic climb. Zero-based, a
+    // stock that is not moving looks like one that is not moving.
+    const parked = Array.from({ length: 60 }, (_, i) => 1_009_100 + i * 11);
+    const path = sparklinePath(parked, null);
+    expect(path).not.toBeNull();
+
+    const ys = [...path!.line.matchAll(/[ML][\d.]+ ([\d.]+)/g)].map((m) =>
+      Number(m[1])
+    );
+    expect(Math.max(...ys) - Math.min(...ys)).toBeLessThan(1);
+  });
+
+  it('draws a bounded stage against its ceiling', () => {
+    const path = sparklinePath([0, 8, 16], 16);
+    const ys = [...path!.line.matchAll(/[ML][\d.]+ ([\d.]+)/g)].map((m) =>
+      Number(m[1])
+    );
+    expect(ys[0]).toBeCloseTo(100, 1);
+    expect(ys[2]).toBeCloseTo(0, 1);
+  });
+
+  it('ignores gaps where a reading was missing', () => {
+    const path = sparklinePath([4, null, 8, null, 12], 16);
+    expect(path).not.toBeNull();
+    expect(path!.line.split('L')).toHaveLength(3);
+  });
+
+  it('draws nothing from a single point', () => {
+    expect(sparklinePath([5], 16)).toBeNull();
+    expect(sparklinePath([], 16)).toBeNull();
+  });
+});

--- a/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.test.ts
+++ b/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.test.ts
@@ -127,7 +127,8 @@ describe('isNotDraining', () => {
 
 describe('findChokepoint', () => {
   it('accuses nothing when every stage has headroom', () => {
-    // Regression: this once named Run permits at 69% on a healthy pipeline.
+    // Regression: this once named the run-slot stage at 69% on a healthy
+    // pipeline.
     // A page that always points somewhere teaches its reader to ignore where
     // it points.
     expect(findChokepoint(FIXTURES.healthy)).toBeNull();

--- a/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.ts
+++ b/crates/runtara-server/frontend/src/features/analytics/utils/pipeline.ts
@@ -1,0 +1,220 @@
+/// Classification for the execution-pipeline view.
+///
+/// The server sends facts and no judgement, so deciding which stage is the
+/// constraint happens here — where it can be tested against fixtures without a
+/// running server. That matters more than it sounds: a prototype of this view
+/// got the choice wrong three separate ways, each of them plausible on
+/// inspection and each only visible under a fixture. Those three are pinned by
+/// name in `pipeline.test.ts`.
+
+export interface PipelineRates {
+  offered: number;
+  accepted: number;
+  denied: number;
+  started: number;
+  finished: number;
+  /** `null` means no live run could have reported a step — not that none did. */
+  steps: number | null;
+}
+
+export interface PipelineStage {
+  key: string;
+  label: string;
+  knob: string | null;
+  /** `null` for a stage with no ceiling. */
+  limit: number | null;
+  /** `null` when the source could not be read, which is not the same as 0. */
+  used: number | null;
+  oldestAgeMs: number | null;
+  inflowKey: string;
+}
+
+export interface PipelineSnapshot {
+  capturedAt: string;
+  windowMs: number;
+  /** `null` on the first tick after start, when there is no window yet. */
+  rates: PipelineRates | null;
+  stages: PipelineStage[];
+}
+
+/** Utilisation at which a stage is worth calling out. */
+export const CHOKE_THRESHOLD = 80;
+
+/** How long a full stage may hold its oldest item before that is remarkable. */
+export const DEFAULT_STUCK_AFTER_MS = 5 * 60 * 1000;
+
+export type StageSeverity = 'unknown' | 'ok' | 'warn' | 'bad';
+
+/// A stage's utilisation, or `null` when that question does not apply.
+///
+/// Two distinct reasons for `null`: the stage has no ceiling to be a fraction
+/// of, or its occupancy could not be read. Neither is zero percent.
+export function utilisation(stage: PipelineStage): number | null {
+  if (stage.limit === null || stage.limit === 0 || stage.used === null) {
+    return null;
+  }
+  return Math.min(100, (stage.used / stage.limit) * 100);
+}
+
+export function severityOf(stage: PipelineStage): StageSeverity {
+  const pct = utilisation(stage);
+  if (pct === null) return 'unknown';
+  if (pct >= 99) return 'bad';
+  if (pct >= CHOKE_THRESHOLD) return 'warn';
+  return 'ok';
+}
+
+/// Is this stage full and holding work that is not moving?
+///
+/// Both halves are required. Full alone is not a fault — a stage pinned at its
+/// bound while recycling every few seconds is a system working as hard as it
+/// can. Old alone is not either, since a stage with headroom is nobody's
+/// constraint however long its oldest item has sat.
+export function isNotDraining(
+  stage: PipelineStage,
+  stuckAfterMs: number = DEFAULT_STUCK_AFTER_MS
+): boolean {
+  const pct = utilisation(stage);
+  if (pct === null || pct < 99) return false;
+  return stage.oldestAgeMs !== null && stage.oldestAgeMs >= stuckAfterMs;
+}
+
+/// The stage actually constraining the pipeline, or `null` if none is.
+///
+/// Three rules, each of them a bug this had before:
+///
+/// 1. **Only bounded stages are candidates.** An unbounded queue is where the
+///    evidence piles up, never the constraint. Ranking by raw depth put the
+///    trigger queue at fault while the run permits — full, and holding work
+///    that had not moved in forty-eight minutes — went unnamed.
+/// 2. **Nothing is named below the threshold.** A page that always points at
+///    something teaches its reader to ignore where it points.
+/// 3. **Not-draining outranks merely-full.** Otherwise whichever full stage
+///    came first in the list won, and full stages are common while stuck ones
+///    are the emergency.
+///
+/// A fourth rule lives at the call site rather than here: this is a pure
+/// function of one snapshot, so a caller that re-runs it every tick must damp
+/// the result, or ordinary jitter across the threshold makes the highlight
+/// flicker while somebody is reading it. See `stickyChokepoint`.
+export function findChokepoint(
+  stages: PipelineStage[],
+  stuckAfterMs: number = DEFAULT_STUCK_AFTER_MS
+): PipelineStage | null {
+  let best: PipelineStage | null = null;
+  let bestScore = -1;
+
+  for (const stage of stages) {
+    const pct = utilisation(stage);
+    if (pct === null) continue;
+    const score = pct + (isNotDraining(stage, stuckAfterMs) ? 1000 : 0);
+    if (score > bestScore) {
+      bestScore = score;
+      best = stage;
+    }
+  }
+
+  return bestScore >= CHOKE_THRESHOLD ? best : null;
+}
+
+/// Hold a chokepoint choice steady across ticks.
+///
+/// Occupancy wobbles, and a stage hovering at the threshold would otherwise
+/// have its highlight appear and vanish once a second — unreadable, and it
+/// makes a real constraint look like noise. Once named, a stage keeps the
+/// label until it drops a clear margin below the threshold.
+export function stickyChokepoint(
+  stages: PipelineStage[],
+  previousKey: string | null,
+  stuckAfterMs: number = DEFAULT_STUCK_AFTER_MS
+): string | null {
+  const fresh = findChokepoint(stages, stuckAfterMs);
+  if (fresh) return fresh.key;
+
+  if (previousKey) {
+    const held = stages.find((s) => s.key === previousKey);
+    if (held) {
+      const pct = utilisation(held);
+      // Hysteresis: five points of margin, so a stage sitting on the line does
+      // not toggle, but one that genuinely recovers is released promptly.
+      if (pct !== null && pct >= CHOKE_THRESHOLD - 5) return previousKey;
+    }
+  }
+
+  return null;
+}
+
+/// Is the steps-per-second figure a measurement or an absence of one?
+///
+/// `trackEvents` is compile-time, so a workflow built without it runs perfectly
+/// and reports nothing. Rendering that absence as `0/s` would let a reader
+/// conclude a healthy deployment had stopped dead.
+export function stepsAreMeasured(rates: PipelineRates | null): boolean {
+  return rates !== null && rates.steps !== null;
+}
+
+/// Format an age for display, coarsening as it grows.
+///
+/// Sub-second precision matters when permits recycle in milliseconds; at
+/// forty-eight minutes nobody needs the seconds.
+export function formatAge(ms: number | null): string | null {
+  if (ms === null) return null;
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h`;
+  return `${Math.round(ms / 86_400_000)}d`;
+}
+
+/// Format a count, keeping large stocks legible.
+export function formatCount(value: number | null): string {
+  if (value === null) return '—';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 100_000) return `${Math.round(value / 1000)}k`;
+  if (value >= 10_000) return `${(value / 1000).toFixed(1)}k`;
+  return Math.round(value).toLocaleString();
+}
+
+/// Format a per-second rate.
+export function formatRate(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  if (value >= 100) return Math.round(value).toLocaleString();
+  if (value >= 10) return value.toFixed(0);
+  return value.toFixed(1);
+}
+
+/// Points for a sparkline, scaled from zero.
+///
+/// Zero-based on purpose. Scaling an unbounded series to its own min–max turns
+/// a 0.06% drift across a million parked instances into a dramatic climb, which
+/// is how a sparkline lies about a system that is not moving at all. A bounded
+/// stage is drawn against its ceiling so height reads as occupancy; an
+/// unbounded one against its own recent peak so height reads as "relative to
+/// how busy this has lately been".
+export function sparklinePath(
+  history: (number | null)[],
+  limit: number | null
+): { line: string; area: string; lastX: number; lastY: number } | null {
+  const points = history.filter((v): v is number => v !== null);
+  if (points.length < 2) return null;
+
+  const top = limit && limit > 0 ? limit : Math.max(...points) * 1.15 || 1;
+  const coords = points.map((value, index) => {
+    const x = (index / (points.length - 1)) * 100;
+    const y = 100 - Math.min(100, Math.max(0, (value / top) * 100));
+    return [x, y] as const;
+  });
+
+  const line = coords
+    .map(([x, y], i) => `${i ? 'L' : 'M'}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join('');
+  const last = coords[coords.length - 1];
+
+  return {
+    line,
+    area: `${line}L100 100L0 100Z`,
+    lastX: last[0],
+    lastY: last[1],
+  };
+}

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -3264,6 +3264,122 @@ export interface PeriodStatsDto {
   totalRequests: number;
 }
 
+/** Throughput between pipeline stages, per second. */
+export interface PipelineRatesDto {
+  /**
+   * Executions the gate admitted.
+   * @format double
+   */
+  accepted: number;
+  /**
+   * Executions the gate refused with `ENTITLEMENT_LIMIT_EXCEEDED`.
+   * @format double
+   */
+  denied: number;
+  /**
+   * Guests that stopped running, including those that parked themselves.
+   * @format double
+   */
+  finished: number;
+  /**
+   * Executions presented to the admission gate.
+   * @format double
+   */
+  offered: number;
+  /**
+   * Instances handed to the runtime for launch.
+   * @format double
+   */
+  started: number;
+  /**
+   * Workflow steps, or `null` when nothing live could report one.
+   *
+   * `trackEvents` is compile-time, so a workflow built without it runs
+   * perfectly and emits no steps. Rendering that as zero would let a
+   * consumer declare a healthy system stalled.
+   * @format double
+   */
+  steps?: number | null;
+}
+
+/** The pipeline at one instant. */
+export interface PipelineSnapshotDto {
+  /**
+   * When this was sampled.
+   * @format date-time
+   */
+  capturedAt: string;
+  /**
+   * Throughput, or `null` on the first tick after start.
+   *
+   * There is no earlier reading to difference against then, and treating the
+   * baseline as zero would publish the process's whole lifetime of work as
+   * one second's throughput.
+   */
+  rates?: null | PipelineRatesDto;
+  /** Every stage, in pipeline order. */
+  stages: PipelineStageDto[];
+  /**
+   * The window the rates were measured over.
+   *
+   * On the wire rather than assumed, so a consumer can tell a normal tick
+   * from one that followed a pause and discard the gap instead of drawing
+   * a spike that never happened.
+   * @format int64
+   * @min 0
+   */
+  windowMs: number;
+}
+
+/** Response envelope for the pipeline endpoint. */
+export interface PipelineSnapshotResponse {
+  /** The snapshot. */
+  data: PipelineSnapshotDto;
+  /** Human-readable status. */
+  message: string;
+  /** Whether the snapshot was produced. */
+  success: boolean;
+}
+
+/** One stage of the pipeline at one instant. */
+export interface PipelineStageDto {
+  /** Which rate feeds this stage, naming a field of [`PipelineRatesDto`]. */
+  inflowKey: string;
+  /**
+   * Stable identifier: `admission`, `triggerQueue`, `triggerWorkers`,
+   * `runPermits`, `executing`, `parked`.
+   */
+  key: string;
+  /**
+   * The setting that bounds this stage, shown verbatim so an operator can
+   * act on it without looking it up.
+   */
+  knob?: string | null;
+  /** Human-readable stage name. */
+  label: string;
+  /**
+   * The bound, or `null` for a stage with no ceiling.
+   * @format int64
+   * @min 0
+   */
+  limit?: number | null;
+  /**
+   * Age of the oldest item held here.
+   *
+   * The signal that separates a stage turning work over from one holding
+   * work that never leaves — the two are indistinguishable by occupancy.
+   * @format int64
+   * @min 0
+   */
+  oldestAgeMs?: number | null;
+  /**
+   * Current occupancy, or `null` when the source could not be read.
+   * @format int64
+   * @min 0
+   */
+  used?: number | null;
+}
+
 /** Position coordinates for UI elements */
 export interface Position {
   /** @format double */
@@ -6565,6 +6681,37 @@ export class Api<
     ) =>
       this.request<any, void>({
         path: `/api/runtime/agents/${name}/connection-schema`,
+        method: "GET",
+        ...params,
+      }),
+
+    /**
+     * @description Answers from the sampler's last snapshot rather than reading the world, so this costs the same whether one viewer or fifty ask for it and no request can ever cause a database query.
+     *
+     * @tags analytics-controller
+     * @name GetPipelineSnapshotHandler
+     * @summary Current occupancy of every stage of the execution pipeline.
+     * @request GET:/api/runtime/analytics/pipeline
+     */
+    getPipelineSnapshotHandler: (params: RequestParams = {}) =>
+      this.request<PipelineSnapshotResponse, any>({
+        path: `/api/runtime/analytics/pipeline`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Authenticated with the ordinary bearer extractor and no special-casing, because the frontend consumes this with `fetch` rather than `EventSource` — which cannot set headers and would otherwise push the token into a query string, where it would end up in every access log.
+     *
+     * @tags analytics-controller
+     * @name StreamPipelineHandler
+     * @summary Stream pipeline snapshots as they are sampled.
+     * @request GET:/api/runtime/analytics/pipeline/stream
+     */
+    streamPipelineHandler: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/api/runtime/analytics/pipeline/stream`,
         method: "GET",
         ...params,
       }),

--- a/crates/runtara-server/frontend/src/shared/utils/sse.test.ts
+++ b/crates/runtara-server/frontend/src/shared/utils/sse.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { parseDataFrame, readJsonEventStream } from './sse';
+
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe('parseDataFrame', () => {
+  it('parses a single data line', () => {
+    expect(parseDataFrame('data: {"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('joins multi-line data as one document', () => {
+    expect(parseDataFrame('data: {"a":\ndata: 1}')).toEqual({ a: 1 });
+  });
+
+  it('ignores the event name, which this reader has no use for', () => {
+    expect(parseDataFrame('event: snapshot\ndata: {"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('skips a keep-alive comment rather than treating it as data', () => {
+    // The server sends these to hold the connection open through proxies. A
+    // reader that choked on them would drop the stream on an idle system.
+    expect(parseDataFrame(': keep-alive')).toBeUndefined();
+    expect(parseDataFrame('')).toBeUndefined();
+  });
+
+  it('skips a malformed frame instead of throwing', () => {
+    // One bad frame must not end a stream the page depends on.
+    expect(parseDataFrame('data: {not json')).toBeUndefined();
+  });
+});
+
+describe('readJsonEventStream', () => {
+  it('yields every complete frame', async () => {
+    const stream = streamOf('data: {"n":1}\n\n', 'data: {"n":2}\n\n');
+    const seen: unknown[] = [];
+    for await (const value of readJsonEventStream(stream)) seen.push(value);
+    expect(seen).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it('reassembles a frame split across chunks', () => {
+    // A snapshot with six stages will not arrive in one TCP read, so a reader
+    // that assumed frame boundaries matched chunk boundaries would drop most
+    // of them.
+    const stream = streamOf('data: {"n":', '1}\n\ndata: {"n":2}\n\n');
+    return (async () => {
+      const seen: unknown[] = [];
+      for await (const value of readJsonEventStream(stream)) seen.push(value);
+      expect(seen).toEqual([{ n: 1 }, { n: 2 }]);
+    })();
+  });
+
+  it('handles CRLF line endings', async () => {
+    const stream = streamOf('data: {"n":1}\r\n\r\n');
+    const seen: unknown[] = [];
+    for await (const value of readJsonEventStream(stream)) seen.push(value);
+    expect(seen).toEqual([{ n: 1 }]);
+  });
+
+  it('yields a final frame that arrives without a trailing blank line', async () => {
+    const stream = streamOf('data: {"n":1}');
+    const seen: unknown[] = [];
+    for await (const value of readJsonEventStream(stream)) seen.push(value);
+    expect(seen).toEqual([{ n: 1 }]);
+  });
+
+  it('carries on past a malformed frame', async () => {
+    const stream = streamOf('data: broken\n\ndata: {"n":2}\n\n');
+    const seen: unknown[] = [];
+    for await (const value of readJsonEventStream(stream)) seen.push(value);
+    expect(seen).toEqual([{ n: 2 }]);
+  });
+
+  it('stops when the caller aborts', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const stream = streamOf('data: {"n":1}\n\n');
+    const seen: unknown[] = [];
+    for await (const value of readJsonEventStream(stream, controller.signal)) {
+      seen.push(value);
+    }
+    expect(seen).toEqual([]);
+  });
+});

--- a/crates/runtara-server/frontend/src/shared/utils/sse.ts
+++ b/crates/runtara-server/frontend/src/shared/utils/sse.ts
@@ -1,0 +1,73 @@
+/// Read an SSE stream whose every message is a JSON document.
+///
+/// Deliberately separate from `features/workflows/utils/sse`, which infers a
+/// chat event type from an `event:` line or a `type` field and logs each frame.
+/// This one has no notion of event types and says nothing: it yields parsed
+/// payloads. Generalising the chat reader instead would have meant changing a
+/// working path to serve a simpler caller.
+
+/// Consume a `fetch` body and yield each SSE `data:` payload, parsed.
+///
+/// Frames that are not valid JSON are skipped rather than thrown, because one
+/// malformed frame must not end a stream a page depends on. Keep-alive
+/// comments (`:` lines) carry no data and are skipped by the same rule.
+export async function* readJsonEventStream<T>(
+  stream: ReadableStream<Uint8Array>,
+  signal?: AbortSignal
+): AsyncGenerator<T> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      if (signal?.aborted) break;
+
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      // Normalise line endings before splitting, so a server or proxy that
+      // emits CRLF does not turn every frame into an unparseable fragment.
+      buffer += decoder.decode(value, { stream: true });
+      buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+      const frames = buffer.split('\n\n');
+      // The trailing piece may be a partial frame; hold it for the next chunk.
+      buffer = frames.pop() ?? '';
+
+      for (const frame of frames) {
+        const parsed = parseDataFrame<T>(frame);
+        if (parsed !== undefined) yield parsed;
+      }
+    }
+
+    const parsed = parseDataFrame<T>(buffer);
+    if (parsed !== undefined) yield parsed;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/// Extract and parse the `data:` lines of one SSE frame.
+///
+/// Exported for tests. Returns `undefined` for a frame carrying no data or
+/// data that is not JSON — both are ordinary in a live stream and neither is
+/// worth interrupting the caller for.
+export function parseDataFrame<T>(frame: string): T | undefined {
+  const trimmed = frame.trim();
+  if (!trimmed) return undefined;
+
+  const data = trimmed
+    .split('\n')
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trim())
+    .join('\n');
+
+  if (!data) return undefined;
+
+  try {
+    return JSON.parse(data) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/crates/runtara-server/src/api/dto/mod.rs
+++ b/crates/runtara-server/src/api/dto/mod.rs
@@ -11,6 +11,7 @@ pub mod executions;
 pub mod metrics;
 pub mod object_model;
 pub mod operators;
+pub mod pipeline;
 pub mod reports;
 pub mod trigger_event;
 pub mod triggers;

--- a/crates/runtara-server/src/api/dto/pipeline.rs
+++ b/crates/runtara-server/src/api/dto/pipeline.rs
@@ -33,7 +33,8 @@ pub struct PipelineRatesDto {
     pub denied: f64,
     /// Instances handed to the runtime for launch.
     pub started: f64,
-    /// Guests that stopped running, including those that parked themselves.
+    /// Runs that stopped, including those that parked themselves to await a
+    /// wake or a signal.
     pub finished: f64,
     /// Workflow steps, or `null` when nothing live could report one.
     ///

--- a/crates/runtara-server/src/api/dto/pipeline.rs
+++ b/crates/runtara-server/src/api/dto/pipeline.rs
@@ -1,0 +1,102 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Wire types for the execution-pipeline view.
+//!
+//! Two nullability rules carry the honesty of this whole payload, and both cost
+//! nothing to honour and a great deal to get wrong:
+//!
+//! - `used: None` means "this source could not be read", which is a different
+//!   fact from `Some(0)`, "this stage is empty". Collapsing them renders an
+//!   unobserved subsystem as an idle one.
+//! - `steps: None` means "nothing live could have reported a step", which is a
+//!   different fact from `Some(0.0)`, "work is live and none of it is
+//!   progressing". Only the second is a symptom, and a rule that confuses them
+//!   raises an alarm on a perfectly healthy deployment.
+//!
+//! Deliberately absent: any `health`, `severity` or `chokepoint` field. This
+//! payload reports facts; classifying them is the consumer's job, where it can
+//! be tested against fixtures without standing up a server.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Throughput between pipeline stages, per second.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineRatesDto {
+    /// Executions presented to the admission gate.
+    pub offered: f64,
+    /// Executions the gate admitted.
+    pub accepted: f64,
+    /// Executions the gate refused with `ENTITLEMENT_LIMIT_EXCEEDED`.
+    pub denied: f64,
+    /// Instances handed to the runtime for launch.
+    pub started: f64,
+    /// Guests that stopped running, including those that parked themselves.
+    pub finished: f64,
+    /// Workflow steps, or `null` when nothing live could report one.
+    ///
+    /// `trackEvents` is compile-time, so a workflow built without it runs
+    /// perfectly and emits no steps. Rendering that as zero would let a
+    /// consumer declare a healthy system stalled.
+    pub steps: Option<f64>,
+}
+
+/// One stage of the pipeline at one instant.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineStageDto {
+    /// Stable identifier: `admission`, `triggerQueue`, `triggerWorkers`,
+    /// `runPermits`, `executing`, `parked`.
+    pub key: String,
+    /// Human-readable stage name.
+    pub label: String,
+    /// The setting that bounds this stage, shown verbatim so an operator can
+    /// act on it without looking it up.
+    pub knob: Option<String>,
+    /// The bound, or `null` for a stage with no ceiling.
+    pub limit: Option<u64>,
+    /// Current occupancy, or `null` when the source could not be read.
+    pub used: Option<u64>,
+    /// Age of the oldest item held here.
+    ///
+    /// The signal that separates a stage turning work over from one holding
+    /// work that never leaves — the two are indistinguishable by occupancy.
+    pub oldest_age_ms: Option<u64>,
+    /// Which rate feeds this stage, naming a field of [`PipelineRatesDto`].
+    pub inflow_key: String,
+}
+
+/// The pipeline at one instant.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineSnapshotDto {
+    /// When this was sampled.
+    pub captured_at: DateTime<Utc>,
+    /// The window the rates were measured over.
+    ///
+    /// On the wire rather than assumed, so a consumer can tell a normal tick
+    /// from one that followed a pause and discard the gap instead of drawing
+    /// a spike that never happened.
+    pub window_ms: u64,
+    /// Throughput, or `null` on the first tick after start.
+    ///
+    /// There is no earlier reading to difference against then, and treating the
+    /// baseline as zero would publish the process's whole lifetime of work as
+    /// one second's throughput.
+    pub rates: Option<PipelineRatesDto>,
+    /// Every stage, in pipeline order.
+    pub stages: Vec<PipelineStageDto>,
+}
+
+/// Response envelope for the pipeline endpoint.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PipelineSnapshotResponse {
+    /// Whether the snapshot was produced.
+    pub success: bool,
+    /// Human-readable status.
+    pub message: String,
+    /// The snapshot.
+    pub data: PipelineSnapshotDto,
+}

--- a/crates/runtara-server/src/api/handlers/analytics.rs
+++ b/crates/runtara-server/src/api/handlers/analytics.rs
@@ -1,7 +1,7 @@
 // Analytics HTTP handlers
 // Provides runtime system information including memory, disk, and CPU details
 
-use axum::{http::StatusCode, response::Json};
+use axum::{http::StatusCode, http::header, response::Json};
 use serde_json::Value;
 use std::path::PathBuf;
 use sysinfo::Disks;
@@ -92,5 +92,119 @@ pub async fn get_system_analytics_handler(
     (
         StatusCode::OK,
         Json(serde_json::to_value(response).unwrap()),
+    )
+}
+
+// ============================================================================
+// Execution pipeline
+// ============================================================================
+
+/// Current occupancy of every stage of the execution pipeline.
+///
+/// Answers from the sampler's last snapshot rather than reading the world, so
+/// this costs the same whether one viewer or fifty ask for it and no request
+/// can ever cause a database query.
+#[utoipa::path(
+    get,
+    path = "/api/runtime/analytics/pipeline",
+    responses(
+        (status = 200, description = "Pipeline snapshot retrieved successfully", body = crate::api::dto::pipeline::PipelineSnapshotResponse),
+        (status = 503, description = "The sampler has not produced a snapshot yet", body = Value)
+    ),
+    tag = "analytics-controller"
+)]
+pub async fn get_pipeline_snapshot_handler(
+    crate::middleware::tenant_auth::OrgId(_tenant_id): crate::middleware::tenant_auth::OrgId,
+    axum::extract::State(latest): axum::extract::State<
+        crate::workers::pipeline_sampler::PipelineLatest,
+    >,
+) -> (StatusCode, Json<Value>) {
+    match latest.get() {
+        Some(snapshot) => {
+            let response = crate::api::dto::pipeline::PipelineSnapshotResponse {
+                success: true,
+                message: "Pipeline snapshot retrieved successfully".to_string(),
+                data: (*snapshot).clone(),
+            };
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(response).unwrap_or(Value::Null)),
+            )
+        }
+        // Distinct from an empty snapshot on purpose: "the sampler has not run
+        // yet" is a different fact from "the pipeline is empty", and answering
+        // the first with the second would show a booting server as an idle one.
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "success": false,
+                "message": "Pipeline sampler has not produced a snapshot yet",
+            })),
+        ),
+    }
+}
+
+/// Stream pipeline snapshots as they are sampled.
+///
+/// Authenticated with the ordinary bearer extractor and no special-casing,
+/// because the frontend consumes this with `fetch` rather than `EventSource` —
+/// which cannot set headers and would otherwise push the token into a query
+/// string, where it would end up in every access log.
+#[utoipa::path(
+    get,
+    path = "/api/runtime/analytics/pipeline/stream",
+    responses(
+        (status = 200, description = "SSE stream of pipeline snapshots", content_type = "text/event-stream")
+    ),
+    tag = "analytics-controller"
+)]
+pub async fn stream_pipeline_handler(
+    crate::middleware::tenant_auth::OrgId(_tenant_id): crate::middleware::tenant_auth::OrgId,
+    axum::extract::State(feed): axum::extract::State<
+        crate::workers::pipeline_sampler::PipelineFeed,
+    >,
+    axum::extract::State(latest): axum::extract::State<
+        crate::workers::pipeline_sampler::PipelineLatest,
+    >,
+) -> impl axum::response::IntoResponse {
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures::stream::{self, StreamExt};
+
+    let mut rx = feed.subscribe();
+
+    // Open with whatever is already known, so a freshly loaded page renders
+    // immediately instead of sitting blank until the next tick.
+    let initial = stream::iter(
+        latest
+            .get()
+            .and_then(|snapshot| Event::default().json_data(&*snapshot).ok())
+            .map(Ok::<_, std::convert::Infallible>),
+    );
+
+    let updates = async_stream::stream! {
+        loop {
+            match rx.recv().await {
+                Ok(snapshot) => {
+                    if let Ok(event) = Event::default().json_data(&*snapshot) {
+                        yield Ok::<_, std::convert::Infallible>(event);
+                    }
+                }
+                // This client fell behind; the sampler and every other viewer
+                // carried on. Resume from the current state rather than
+                // ending the stream — a laggard wants now, not a backlog.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    let headers = [
+        (header::CACHE_CONTROL, "no-cache, no-store, must-revalidate"),
+        (header::HeaderName::from_static("x-accel-buffering"), "no"),
+    ];
+
+    (
+        headers,
+        Sse::new(initial.chain(updates)).keep_alive(KeepAlive::default()),
     )
 }

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -137,6 +137,8 @@ use runtime_client::RuntimeClient;
         api::metrics::get_tenant_metrics,
         // Analytics endpoints
         api::analytics::get_system_analytics_handler,
+        api::analytics::get_pipeline_snapshot_handler,
+        api::analytics::stream_pipeline_handler,
         // Rate limit analytics endpoints (served by runtara-connections crate)
         runtara_connections::handler::rate_limits::list_rate_limits_handler,
         runtara_connections::handler::rate_limits::get_connection_rate_limit_status_handler,
@@ -347,6 +349,10 @@ use runtime_client::RuntimeClient;
             metrics::WorkflowMetricsHourly,
             // Analytics DTOs
             api::analytics::SystemAnalyticsResponse,
+            api::dto::pipeline::PipelineSnapshotResponse,
+            api::dto::pipeline::PipelineSnapshotDto,
+            api::dto::pipeline::PipelineStageDto,
+            api::dto::pipeline::PipelineRatesDto,
             api::analytics::SystemAnalyticsData,
             api::analytics::MemoryInfo,
             api::analytics::DiskInfo,
@@ -548,6 +554,25 @@ struct AppState {
     /// background drain batches the events and ships them to Valkey for smo-management's
     /// per-tenant consumer to persist into its `product_events` table.
     events: product_events::ProductEventSink,
+    /// Live pipeline snapshots, published by the sampler on its own tick.
+    ///
+    /// Handlers subscribe rather than read the world, so a viewer costs a
+    /// broadcast receiver and never a query.
+    pipeline_feed: workers::pipeline_sampler::PipelineFeed,
+    /// The most recent pipeline snapshot, so a plain GET need not await a tick.
+    pipeline_latest: workers::pipeline_sampler::PipelineLatest,
+}
+
+impl axum::extract::FromRef<AppState> for workers::pipeline_sampler::PipelineFeed {
+    fn from_ref(state: &AppState) -> Self {
+        state.pipeline_feed.clone()
+    }
+}
+
+impl axum::extract::FromRef<AppState> for workers::pipeline_sampler::PipelineLatest {
+    fn from_ref(state: &AppState) -> Self {
+        state.pipeline_latest.clone()
+    }
 }
 
 // Implement FromRef to allow extracting PgPool from AppState
@@ -1025,6 +1050,12 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     // writes them: the trigger workers spawn well ahead of the execution engine
     // and both must share these, or intake would be counted twice over.
     let pipeline_gauges = workers::pipeline_gauges::PipelineGauges::new();
+    let pipeline_feed = workers::pipeline_sampler::PipelineFeed::new();
+    let pipeline_latest = workers::pipeline_sampler::PipelineLatest::default();
+    // Empty until trigger intake is configured. An empty set reports "no
+    // workers", which the sampler renders as an unmeasured stage rather than
+    // an idle one — the two are different facts.
+    let mut trigger_permits_for_sampler = workers::pipeline_gauges::TriggerPermits::default();
 
     // Product-analytics: build the channel + sink up front so it can be injected into the
     // connections crate (constructed just below). The drain (single consumer) is spawned
@@ -1417,6 +1448,7 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             trigger_workers,
             workers::trigger_worker::trigger_concurrency(),
         );
+        trigger_permits_for_sampler = trigger_permits.clone();
         for worker_index in 0..trigger_workers {
             let trigger_worker_tenant_id = tenant_id.clone();
             let permits_for_worker = trigger_permits
@@ -1576,6 +1608,40 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&pipeline_gauges),
     ));
     println!("✓ Execution engine initialized");
+
+    // Pipeline sampler: one tick produces one snapshot for every viewer, so the
+    // System page costs a broadcast receiver per client rather than a query.
+    {
+        let sampler_inputs = workers::pipeline_sampler::SamplerInputs {
+            gauges: Arc::clone(&pipeline_gauges),
+            trigger_permits: trigger_permits_for_sampler.clone(),
+            runner: embedded_runtara
+                .as_ref()
+                .map(|r| Arc::clone(&r.environment_state().runner)),
+            valkey: valkey_conn.clone(),
+            stream: valkey::ValkeyConfig::from_env().map(|cfg| {
+                (
+                    cfg.trigger_stream_key(&tenant_id),
+                    cfg.trigger_consumer_group.clone(),
+                )
+            }),
+            pool: pool.clone(),
+            tenant_id: tenant_id.clone(),
+            admission_limit: config::max_concurrent_executions() as u64,
+        };
+        let sampler_feed = pipeline_feed.clone();
+        let sampler_latest = pipeline_latest.clone();
+        let sampler_shutdown = shutdown_signal.clone();
+        tokio::spawn(async move {
+            workers::pipeline_sampler::run(
+                sampler_inputs,
+                sampler_feed,
+                sampler_latest,
+                sampler_shutdown,
+            )
+            .await;
+        });
+    }
 
     // CORS — configured via CORS_ALLOWED_ORIGINS env var.
     // Supports: "*" (any origin), comma-separated origins, or defaults to localhost for dev.
@@ -1878,6 +1944,14 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             "/api/runtime/analytics/system",
             get(api::analytics::get_system_analytics_handler),
         )
+        .route(
+            "/api/runtime/analytics/pipeline",
+            get(api::analytics::get_pipeline_snapshot_handler),
+        )
+        .route(
+            "/api/runtime/analytics/pipeline/stream",
+            get(api::analytics::stream_pipeline_handler),
+        )
         // Reporting endpoints — defined in `reports_router` above and merged below.
         // NOTE: Rate limit analytics routes are now served by runtara-connections crate.
         // Invocation Trigger endpoints
@@ -1989,6 +2063,8 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             agents: agents_service.clone(),
             agent_catalog: agent_catalog.clone(),
             events: product_event_sink.clone(),
+            pipeline_feed: pipeline_feed.clone(),
+            pipeline_latest: pipeline_latest.clone(),
         })
         // Reject API-key-authenticated requests when the `api` feature is
         // off. Sits *between* auth (outermost) and the per-feature gates
@@ -2343,6 +2419,8 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             agents: agents_service.clone(),
             agent_catalog: agent_catalog.clone(),
             events: product_event_sink.clone(),
+            pipeline_feed: pipeline_feed.clone(),
+            pipeline_latest: pipeline_latest.clone(),
         })
         // Defense in depth: cap the request body on these public,
         // unauthenticated webhook ingest routes. events.rs also enforces this

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -1625,9 +1625,14 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
                     cfg.trigger_consumer_group.clone(),
                 )
             }),
-            pool: pool.clone(),
+            // The runtime database, where `instances` lives — not the server
+            // pool that most of this function passes around.
+            pool: embedded_runtara
+                .as_ref()
+                .map(|r| r.environment_state().pool.clone()),
             tenant_id: tenant_id.clone(),
             admission_limit: config::max_concurrent_executions() as u64,
+            engine: Some(Arc::clone(&execution_engine)),
         };
         let sampler_feed = pipeline_feed.clone();
         let sampler_latest = pipeline_latest.clone();

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -1021,6 +1021,11 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         runtara_connections::IntegrationCompatibility::from_catalog(&agent_catalog),
     );
 
+    // One set of pipeline counters for the process, built before anything that
+    // writes them: the trigger workers spawn well ahead of the execution engine
+    // and both must share these, or intake would be counted twice over.
+    let pipeline_gauges = workers::pipeline_gauges::PipelineGauges::new();
+
     // Product-analytics: build the channel + sink up front so it can be injected into the
     // connections crate (constructed just below). The drain (single consumer) is spawned
     // later, once the shutdown signal exists — it holds `product_event_rx`.
@@ -1404,8 +1409,20 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             .filter(|n| *n > 0)
             .unwrap_or(50);
         println!("  Trigger intake: {trigger_workers} worker(s), batch {trigger_batch_size}");
-        for _ in 0..trigger_workers {
+        // Built here rather than inside each worker so the analytics sampler can
+        // read the very semaphores the workers wait on. Each worker still gets
+        // its own, bounded exactly as before; nothing about the concurrency
+        // changes, only whether it can be observed.
+        let trigger_permits = workers::pipeline_gauges::TriggerPermits::new(
+            trigger_workers,
+            workers::trigger_worker::trigger_concurrency(),
+        );
+        for worker_index in 0..trigger_workers {
             let trigger_worker_tenant_id = tenant_id.clone();
+            let permits_for_worker = trigger_permits
+                .for_worker(worker_index)
+                .expect("a semaphore exists for every spawned trigger worker");
+            let gauges_for_worker = Arc::clone(&pipeline_gauges);
             let trigger_shutdown = shutdown_signal.clone();
             let trigger_events = product_event_sink.clone();
             let pool_for_worker = trigger_pool.clone();
@@ -1428,6 +1445,8 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
                     worker_config,
                     trigger_shutdown,
                     trigger_events,
+                    permits_for_worker,
+                    gauges_for_worker,
                 )
                 .await;
             });
@@ -1554,6 +1573,7 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         trigger_stream.clone(),
         Some(running_executions.clone()),
         product_event_sink.clone(),
+        Arc::clone(&pipeline_gauges),
     ));
     println!("✓ Execution engine initialized");
 

--- a/crates/runtara-server/src/valkey/stream.rs
+++ b/crates/runtara-server/src/valkey/stream.rs
@@ -653,6 +653,177 @@ mod tests {
         let count = parse_delivery_count_from_xpending(response);
         assert_eq!(count, 1);
     }
+
+    /// A stream ID's millisecond prefix is the entry's arrival time.
+    ///
+    /// This is what lets depth and age come from one round trip instead of two,
+    /// so the parsing has to hold for the shapes Valkey actually returns —
+    /// including the sentinel IDs it uses when nothing is pending.
+    #[test]
+    fn stream_ids_yield_their_arrival_millis() {
+        assert_eq!(
+            super::stream_id_millis("1756800000000-0"),
+            Some(1_756_800_000_000)
+        );
+        assert_eq!(
+            super::stream_id_millis("1756800000000-42"),
+            Some(1_756_800_000_000)
+        );
+        assert_eq!(
+            super::stream_id_millis("1756800000000"),
+            Some(1_756_800_000_000)
+        );
+        assert_eq!(
+            super::stream_id_millis("-"),
+            None,
+            "the empty-range sentinel is not a time"
+        );
+        assert_eq!(super::stream_id_millis("+"), None);
+        assert_eq!(super::stream_id_millis(""), None);
+        assert_eq!(super::stream_id_millis("not-an-id"), None);
+    }
+
+    /// A backlog reports both how much is held and how long the oldest has waited.
+    #[test]
+    fn xpending_summary_yields_depth_and_age() {
+        let now_ms = 1_756_800_060_000u64;
+        let response = Value::Array(vec![
+            Value::Int(28),
+            Value::BulkString(b"1756800000000-0".to_vec()),
+            Value::BulkString(b"1756800059000-3".to_vec()),
+            Value::Array(vec![]),
+        ]);
+
+        let backlog = super::parse_xpending_summary(response, now_ms);
+        assert_eq!(backlog.pending, 28);
+        assert_eq!(
+            backlog.oldest_pending_ms,
+            Some(60_000),
+            "the age comes from the summary's minimum id, not a second query"
+        );
+    }
+
+    /// An empty pending list must read as empty, not as an unknown age.
+    ///
+    /// Valkey answers a drained group with a zero count and nil ids rather than
+    /// an empty array, and reading that as a pending entry of unknown age would
+    /// show an idle queue as one holding work.
+    #[test]
+    fn a_drained_group_reports_nothing_pending() {
+        let response = Value::Array(vec![Value::Int(0), Value::Nil, Value::Nil, Value::Nil]);
+        let backlog = super::parse_xpending_summary(response, 1_756_800_060_000);
+        assert_eq!(backlog.pending, 0);
+        assert_eq!(backlog.oldest_pending_ms, None);
+    }
+
+    /// A malformed or unexpected reply must degrade to "nothing known".
+    #[test]
+    fn an_unparseable_reply_is_not_invented_into_a_backlog() {
+        assert_eq!(
+            super::parse_xpending_summary(Value::Nil, 1_000),
+            super::StreamBacklog::default()
+        );
+        assert_eq!(
+            super::parse_xpending_summary(Value::Array(vec![]), 1_000),
+            super::StreamBacklog::default()
+        );
+    }
+
+    /// A clock skew must not manufacture an enormous age.
+    ///
+    /// The entry timestamp comes from whichever node wrote it, so it can sit
+    /// slightly ahead of the sampler's clock. Unsigned subtraction there would
+    /// wrap into an age of half a billion years and paint a healthy queue as
+    /// catastrophically stuck.
+    #[test]
+    fn an_entry_from_the_future_reads_as_just_arrived() {
+        let response = Value::Array(vec![
+            Value::Int(1),
+            Value::BulkString(b"1756800005000-0".to_vec()),
+            Value::BulkString(b"1756800005000-0".to_vec()),
+            Value::Array(vec![]),
+        ]);
+        let backlog = super::parse_xpending_summary(response, 1_756_800_000_000);
+        assert_eq!(backlog.oldest_pending_ms, Some(0), "must saturate at zero");
+    }
+}
+
+/// How much work a consumer group has claimed but not finished.
+///
+/// Depth alone cannot tell a busy queue from a stuck one, so the age of the
+/// oldest pending entry is carried alongside it. Both come from a single
+/// `XPENDING` summary: Valkey stream IDs are `<ms-timestamp>-<seq>`, so the
+/// summary's minimum ID *is* the arrival time of the oldest unfinished entry
+/// and needs no second query and no timestamp of our own.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StreamBacklog {
+    /// Entries delivered to a consumer and not yet acknowledged.
+    pub pending: u64,
+    /// Age of the oldest such entry, or `None` when nothing is pending.
+    pub oldest_pending_ms: Option<u64>,
+}
+
+/// Milliseconds encoded in a Valkey stream ID (`<ms>-<seq>`).
+///
+/// Returns `None` for anything that is not that shape, including the special
+/// IDs (`-`, `+`) a summary reports for an empty pending list.
+fn stream_id_millis(id: &str) -> Option<u64> {
+    id.split_once('-')
+        .map(|(ms, _)| ms)
+        .unwrap_or(id)
+        .parse::<u64>()
+        .ok()
+}
+
+/// Parse the summary form of `XPENDING`: `[count, min-id, max-id, [[consumer, count]...]]`.
+///
+/// Split out from the query so the shape handling is testable without a live
+/// Valkey — including the empty case, where Valkey answers with a zero count
+/// and nil IDs rather than an empty array.
+fn parse_xpending_summary(value: Value, now_ms: u64) -> StreamBacklog {
+    let Value::Array(parts) = value else {
+        return StreamBacklog::default();
+    };
+    let pending = match parts.first() {
+        Some(Value::Int(n)) if *n > 0 => *n as u64,
+        _ => return StreamBacklog::default(),
+    };
+    let oldest_pending_ms = parts
+        .get(1)
+        .and_then(|v| match v {
+            Value::BulkString(bytes) => std::str::from_utf8(bytes).ok().map(str::to_owned),
+            Value::SimpleString(text) => Some(text.clone()),
+            _ => None,
+        })
+        .and_then(|id| stream_id_millis(&id))
+        // Saturating: a clock skew that puts the entry in the future must read
+        // as "just arrived", not wrap into an age of half a billion years.
+        .map(|arrived| now_ms.saturating_sub(arrived));
+
+    StreamBacklog {
+        pending,
+        oldest_pending_ms,
+    }
+}
+
+/// Read a consumer group's backlog: how much it holds and how old the oldest is.
+///
+/// One round trip, issued on a sampler's timer and never on a request path.
+/// Takes its own connection clone, so it neither waits on nor blocks the
+/// consumer's mutex.
+pub async fn stream_backlog(
+    connection: &ConnectionManager,
+    stream_name: &str,
+    consumer_group: &str,
+    now_ms: u64,
+) -> RedisResult<StreamBacklog> {
+    let mut connection = connection.clone();
+    let result: Value = redis::cmd("XPENDING")
+        .arg(stream_name)
+        .arg(consumer_group)
+        .query_async(&mut connection)
+        .await?;
+    Ok(parse_xpending_summary(result, now_ms))
 }
 
 /// Lock-free acknowledger for a [`StreamConsumer`]'s stream and group.

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -351,6 +351,11 @@ pub struct ExecutionEngine {
     /// caching it briefly removes a blob read and a hash from the hot path
     /// without changing what the check means.
     registered_images: Arc<RegisteredImageCache>,
+    /// Monotonic counters for the execution pipeline.
+    ///
+    /// Read by the analytics sampler; written only from the gate below, where
+    /// the cost is one relaxed atomic add per intake.
+    gauges: Arc<crate::workers::pipeline_gauges::PipelineGauges>,
 }
 
 /// How long an in-flight execution count stays usable for the concurrency gate.
@@ -408,6 +413,7 @@ impl ExecutionEngine {
         trigger_stream: Option<Arc<TriggerStreamPublisher>>,
         running_executions: Option<Arc<DashMap<Uuid, CancellationHandle>>>,
         events: ProductEventSink,
+        gauges: Arc<crate::workers::pipeline_gauges::PipelineGauges>,
     ) -> Self {
         Self {
             pool,
@@ -421,7 +427,13 @@ impl ExecutionEngine {
             concurrency_reservations: Arc::new(DashMap::new()),
             concurrency_refresh: Arc::new(DashMap::new()),
             registered_images: Arc::new(DashMap::new()),
+            gauges,
         }
+    }
+
+    /// The pipeline counters this engine writes to.
+    pub fn gauges(&self) -> &Arc<crate::workers::pipeline_gauges::PipelineGauges> {
+        &self.gauges
     }
 
     /// Count the tenant's currently in-flight executions (Running + Pending)
@@ -535,6 +547,9 @@ impl ExecutionEngine {
         &self,
         tenant_id: &str,
     ) -> Result<(), crate::entitlement_error::EntitlementDenial> {
+        // Counted here rather than at either call site, so the identity
+        // `offered == accepted + denied` cannot drift as call sites are added.
+        self.gauges.record_offered();
         let snapshot = crate::config::entitlements();
         // No early return when the tenant has no `maxConcurrentExecutions`:
         // the infra cap (`MAX_CONCURRENT_EXECUTIONS`, default cores x 32) has
@@ -566,8 +581,14 @@ impl ExecutionEngine {
         // Record the admission so the next caller sees it even though the
         // cached count still cannot.
         if decision.is_ok() {
+            self.gauges.record_accepted();
             self.reservations_for(tenant_id)
                 .fetch_add(1, Ordering::SeqCst);
+        } else {
+            // The refusal rate had no counter at all before this: the denial
+            // was returned to the caller and observed nowhere, so the first
+            // question anyone asks about failing intake was unanswerable.
+            self.gauges.record_denied();
         }
         decision
     }
@@ -1151,7 +1172,10 @@ impl ExecutionEngine {
             )
             .await
         {
-            Ok(start) => start,
+            Ok(start) => {
+                self.gauges.record_started();
+                start
+            }
             Err(RuntimeError::ImageNotFound(error)) => {
                 tracing::warn!(
                     tenant_id = %event.tenant_id,
@@ -2435,6 +2459,7 @@ mod tests {
                 None,
                 None,
                 ProductEventSink::new(tx.clone()),
+                crate::workers::pipeline_gauges::PipelineGauges::new(),
             )
         };
 
@@ -2481,6 +2506,7 @@ mod tests {
             None,
             None,
             ProductEventSink::new(tx),
+            crate::workers::pipeline_gauges::PipelineGauges::new(),
         );
         let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
 

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -436,6 +436,19 @@ impl ExecutionEngine {
         &self.gauges
     }
 
+    /// In-flight executions as the admission gate itself counts them.
+    ///
+    /// The same cached figure the gate decides on, so a viewer sees what the
+    /// gate sees rather than a second opinion taken from a different query at
+    /// a different moment — two numbers that disagree about the same thing are
+    /// worse than one.
+    ///
+    /// Never queries: it reads the cache the gate maintains, so calling it on
+    /// a sampler tick costs nothing and cannot slow intake.
+    pub fn observed_in_flight(&self, tenant_id: &str, ceiling: u64) -> u64 {
+        self.active_execution_count(tenant_id, ceiling)
+    }
+
     /// Count the tenant's currently in-flight executions (Running + Pending)
     /// as reported by the runtime — the source of truth. Two cheap
     /// `total_count` lookups (limit 1) rather than fetching rows.

--- a/crates/runtara-server/src/workers/mod.rs
+++ b/crates/runtara-server/src/workers/mod.rs
@@ -8,6 +8,7 @@ pub mod cron_scheduler;
 pub mod execution_engine;
 pub mod invocation_cleanup_worker;
 pub mod pipeline_gauges;
+pub mod pipeline_sampler;
 pub mod runtara_dto;
 pub mod trigger_worker;
 

--- a/crates/runtara-server/src/workers/mod.rs
+++ b/crates/runtara-server/src/workers/mod.rs
@@ -7,6 +7,7 @@ pub mod compilation_worker;
 pub mod cron_scheduler;
 pub mod execution_engine;
 pub mod invocation_cleanup_worker;
+pub mod pipeline_gauges;
 pub mod runtara_dto;
 pub mod trigger_worker;
 

--- a/crates/runtara-server/src/workers/pipeline_gauges.rs
+++ b/crates/runtara-server/src/workers/pipeline_gauges.rs
@@ -1,0 +1,458 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Monotonic counters for the execution pipeline.
+//!
+//! These sit on the intake path, so the only operation any of them performs is
+//! a relaxed atomic add. Nothing here allocates, locks, or does I/O: a signal
+//! that needs more than an atomic belongs behind a bounded drop-on-full channel
+//! like [`crate::product_events::ProductEventSink`], never inline.
+//!
+//! The counters are deliberately monotonic rather than rates. A rate has to be
+//! computed against a window, and computing it here would mean either holding a
+//! window on the hot path or lying about which window a reading covers. Instead
+//! a sampler reads the totals on a timer and derives rates from the difference,
+//! which keeps the window explicit for whoever consumes it and degrades a
+//! missed tick into coarser resolution rather than lost counts.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Totals read at one instant.
+///
+/// A plain snapshot rather than a borrow of the counters, so the six values are
+/// read together and a consumer cannot accidentally mix readings taken at
+/// different moments — which is what produces a negative rate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PipelineTotals {
+    /// Executions presented to the admission gate.
+    pub offered: u64,
+    /// Executions the gate admitted.
+    pub accepted: u64,
+    /// Executions the gate refused with `ENTITLEMENT_LIMIT_EXCEEDED`.
+    pub denied: u64,
+    /// Instances handed to the runtime for launch.
+    ///
+    /// Submissions, not outcomes. What a run finally did is the runner's to
+    /// report — see `RunnerOccupancy::runs_finished`, which counts a guest
+    /// actually stopping. Deriving completion here from submissions would count
+    /// a workflow that parked itself as one that finished.
+    pub started: u64,
+    /// Workflow steps that reported starting.
+    ///
+    /// See [`PipelineGauges::record_step`] for why this can be legitimately
+    /// zero while workflows run perfectly.
+    pub steps: u64,
+    /// Runs live in this process that were compiled with step tracking on.
+    ///
+    /// Exists so a consumer can tell "no steps ran" from "no run could have
+    /// reported a step", which is the difference between a stalled system and
+    /// an unobserved one.
+    pub tracked_runs: u64,
+}
+
+/// The pipeline's monotonic counters.
+///
+/// Cloned freely via `Arc`; every method takes `&self`.
+#[derive(Debug, Default)]
+pub struct PipelineGauges {
+    offered: AtomicU64,
+    accepted: AtomicU64,
+    denied: AtomicU64,
+    started: AtomicU64,
+    steps: AtomicU64,
+    tracked_runs: AtomicU64,
+}
+
+impl PipelineGauges {
+    /// Build a fresh set of counters, all at zero.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// An execution was presented to the admission gate.
+    ///
+    /// Recorded before the decision, so `offered` always equals
+    /// `accepted + denied` once the decision has been recorded. A consumer
+    /// relies on that identity to show refusals as a share of demand.
+    pub fn record_offered(&self) {
+        self.offered.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The gate admitted an execution.
+    pub fn record_accepted(&self) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The gate refused an execution.
+    ///
+    /// This closes a real hole: the denial path returned its error without
+    /// incrementing anything, so the refusal rate — the first number anyone
+    /// asks for when intake looks wrong — could not be observed at all.
+    pub fn record_denied(&self) {
+        self.denied.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// An instance was handed to the runtime for launch.
+    pub fn record_started(&self) {
+        self.started.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A workflow step reported starting.
+    ///
+    /// **This is not a universal progress signal.** `trackEvents` is a
+    /// compile-time property baked into the artifact, so a workflow built with
+    /// tracking off never emits the call this counts. Such a workflow runs
+    /// perfectly and reports zero steps forever.
+    ///
+    /// Treating that zero as evidence of a stall would raise an alarm on a
+    /// healthy system, which is worse than raising none. Consumers must consult
+    /// [`PipelineTotals::tracked_runs`] and render "not measured" when it is
+    /// zero; run-permit age is the progress signal that works regardless of how
+    /// an artifact was built.
+    pub fn record_step(&self) {
+        self.steps.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A run that can report steps started.
+    pub fn enter_tracked_run(&self) {
+        self.tracked_runs.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A run that could report steps finished.
+    ///
+    /// Saturating, so an unbalanced release — a path that leaves without a
+    /// matching enter — parks the gauge at zero instead of wrapping to
+    /// eighteen quintillion and claiming the host is measurable when it is not.
+    pub fn leave_tracked_run(&self) {
+        let _ = self
+            .tracked_runs
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            });
+    }
+
+    /// Read every counter.
+    pub fn totals(&self) -> PipelineTotals {
+        PipelineTotals {
+            offered: self.offered.load(Ordering::Relaxed),
+            accepted: self.accepted.load(Ordering::Relaxed),
+            denied: self.denied.load(Ordering::Relaxed),
+            started: self.started.load(Ordering::Relaxed),
+            steps: self.steps.load(Ordering::Relaxed),
+            tracked_runs: self.tracked_runs.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Per-second rates between two readings of the counters.
+///
+/// `steps` is `Option` and not `f64`, because "no step was reported" and "no
+/// step could have been reported" are different facts and only one of them is a
+/// symptom.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PipelineRates {
+    /// Offered per second.
+    pub offered: f64,
+    /// Accepted per second.
+    pub accepted: f64,
+    /// Denied per second.
+    pub denied: f64,
+    /// Started per second.
+    pub started: f64,
+    /// Steps per second, or `None` when nothing live could report one.
+    pub steps: Option<f64>,
+    /// The window these rates were measured over.
+    pub window_ms: u64,
+}
+
+/// Derive per-second rates from two readings and the time between them.
+///
+/// Returns `None` when the window is empty, which is what the first tick after
+/// start looks like: there is no earlier reading to subtract, and inventing one
+/// from zero would report the process's entire lifetime of work as a single
+/// second's throughput.
+pub fn rates_between(
+    prev: PipelineTotals,
+    next: PipelineTotals,
+    window_ms: u64,
+) -> Option<PipelineRates> {
+    if window_ms == 0 {
+        return None;
+    }
+    let per_sec = |a: u64, b: u64| b.saturating_sub(a) as f64 * 1000.0 / window_ms as f64;
+
+    // Steps are reportable only if something that could report them was live at
+    // either end of the window. A run that started and finished entirely inside
+    // the window is covered by the `next` reading having counted its steps.
+    let measurable = prev.tracked_runs > 0 || next.tracked_runs > 0 || next.steps > prev.steps;
+
+    Some(PipelineRates {
+        offered: per_sec(prev.offered, next.offered),
+        accepted: per_sec(prev.accepted, next.accepted),
+        denied: per_sec(prev.denied, next.denied),
+        started: per_sec(prev.started, next.started),
+        steps: measurable.then(|| per_sec(prev.steps, next.steps)),
+        window_ms,
+    })
+}
+
+/// The trigger workers' event-concurrency semaphores.
+///
+/// Each worker owns its own semaphore, so `RUNTARA_TRIGGER_CONCURRENCY` bounds
+/// a worker rather than the process. Reporting only one of them would understate
+/// the bound whenever `RUNTARA_TRIGGER_WORKERS` is above its default of one, so
+/// the sampler is handed every semaphore and sums them.
+///
+/// Built once at startup and never mutated, so reading it needs no lock.
+#[derive(Debug, Clone, Default)]
+pub struct TriggerPermits {
+    permits: Vec<Arc<tokio::sync::Semaphore>>,
+    per_worker_limit: usize,
+}
+
+impl TriggerPermits {
+    /// Build one semaphore per worker, each bounded by `per_worker_limit`.
+    pub fn new(workers: usize, per_worker_limit: usize) -> Self {
+        Self {
+            permits: (0..workers)
+                .map(|_| Arc::new(tokio::sync::Semaphore::new(per_worker_limit)))
+                .collect(),
+            per_worker_limit,
+        }
+    }
+
+    /// The semaphore for one worker, by index.
+    pub fn for_worker(&self, index: usize) -> Option<Arc<tokio::sync::Semaphore>> {
+        self.permits.get(index).map(Arc::clone)
+    }
+
+    /// Total bound and how much of it is in use, summed across workers.
+    ///
+    /// `None` when no worker is running — trigger intake is off, which must
+    /// render as "not measured" rather than as an idle stage at 0/0.
+    pub fn occupancy(&self) -> Option<(u64, u64)> {
+        if self.permits.is_empty() {
+            return None;
+        }
+        let limit = self.per_worker_limit * self.permits.len();
+        let available: usize = self.permits.iter().map(|p| p.available_permits()).sum();
+        Some((limit as u64, limit.saturating_sub(available) as u64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gate's own arithmetic must hold: every offer is decided exactly once.
+    ///
+    /// A consumer shows refusals as a share of demand, so a drift between these
+    /// three would render as a refusal rate above 100% or below zero.
+    #[test]
+    fn offered_equals_accepted_plus_denied() {
+        let g = PipelineGauges::new();
+        for i in 0..50 {
+            g.record_offered();
+            if i % 3 == 0 {
+                g.record_denied();
+            } else {
+                g.record_accepted();
+            }
+        }
+        let t = g.totals();
+        assert_eq!(t.offered, 50);
+        assert_eq!(t.accepted + t.denied, t.offered);
+        assert_eq!(t.denied, 17);
+    }
+
+    /// Rates are a difference over the window, not a total over it.
+    #[test]
+    fn rates_are_the_delta_across_the_window() {
+        let prev = PipelineTotals {
+            offered: 1_000,
+            accepted: 900,
+            denied: 100,
+            started: 880,
+            steps: 4_000,
+            tracked_runs: 4,
+        };
+        let next = PipelineTotals {
+            offered: 1_400,
+            accepted: 1_300,
+            denied: 100,
+            started: 1_280,
+            steps: 6_000,
+            tracked_runs: 6,
+        };
+        let r = rates_between(prev, next, 1_000).expect("a non-empty window yields rates");
+        assert_eq!(r.offered, 400.0);
+        assert_eq!(r.accepted, 400.0);
+        assert_eq!(
+            r.denied, 0.0,
+            "an unmoving counter is zero, not carried over"
+        );
+        assert_eq!(r.steps, Some(2_000.0));
+        assert_eq!(r.window_ms, 1_000);
+    }
+
+    /// A half-second window must double the rate, not report the raw delta.
+    #[test]
+    fn rates_scale_by_the_real_elapsed_time() {
+        let prev = PipelineTotals::default();
+        let next = PipelineTotals {
+            accepted: 100,
+            ..PipelineTotals::default()
+        };
+        let r = rates_between(prev, next, 500).expect("rates");
+        assert_eq!(
+            r.accepted, 200.0,
+            "the sampler's real elapsed time decides the rate, not its nominal interval"
+        );
+    }
+
+    /// An empty window has no rate at all.
+    ///
+    /// This is the first tick after start. Dividing by it, or treating the
+    /// baseline as zero, would publish the process's whole lifetime of work as
+    /// one second's throughput — a spike that looks exactly like a thundering
+    /// herd that never happened.
+    #[test]
+    fn an_empty_window_yields_no_rates() {
+        let next = PipelineTotals {
+            accepted: 9_999,
+            ..PipelineTotals::default()
+        };
+        assert!(rates_between(PipelineTotals::default(), next, 0).is_none());
+    }
+
+    /// With nothing tracked live, steps must be absent rather than zero.
+    ///
+    /// This is the false-red guard. A workflow compiled with `trackEvents` off
+    /// runs perfectly and emits no step calls; reporting that as `0.0/s` would
+    /// let a chokepoint rule declare a healthy system stalled.
+    #[test]
+    fn steps_are_absent_when_nothing_could_report_them() {
+        let quiet = PipelineTotals {
+            accepted: 500,
+            started: 500,
+            steps: 0,
+            tracked_runs: 0,
+            ..PipelineTotals::default()
+        };
+        let later = PipelineTotals {
+            accepted: 900,
+            started: 900,
+            steps: 0,
+            tracked_runs: 0,
+            ..PipelineTotals::default()
+        };
+        let r = rates_between(quiet, later, 1_000).expect("rates");
+        assert_eq!(
+            r.steps, None,
+            "no tracked run means not measured, which is not the same as zero"
+        );
+        assert_eq!(
+            r.accepted, 400.0,
+            "the rest of the pipeline is still fully observable"
+        );
+    }
+
+    /// With tracked runs live and no steps, zero is a real and alarming reading.
+    #[test]
+    fn steps_are_zero_when_tracked_runs_report_nothing() {
+        let held = PipelineTotals {
+            steps: 700,
+            tracked_runs: 8,
+            ..PipelineTotals::default()
+        };
+        let r = rates_between(held, held, 1_000).expect("rates");
+        assert_eq!(
+            r.steps,
+            Some(0.0),
+            "eight tracked runs making no progress is the stall this must show"
+        );
+    }
+
+    /// Tracked-run accounting must survive an unbalanced release.
+    #[test]
+    fn leaving_more_tracked_runs_than_were_entered_saturates() {
+        let g = PipelineGauges::new();
+        g.enter_tracked_run();
+        g.leave_tracked_run();
+        g.leave_tracked_run();
+        assert_eq!(
+            g.totals().tracked_runs,
+            0,
+            "must floor at zero, never wrap to a huge count"
+        );
+    }
+
+    /// Counters must survive concurrent writers without losing an increment.
+    #[tokio::test]
+    async fn concurrent_writers_lose_nothing() {
+        let g = PipelineGauges::new();
+        let mut set = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let g = Arc::clone(&g);
+            set.spawn(async move {
+                for _ in 0..500 {
+                    g.record_offered();
+                    g.record_accepted();
+                    g.record_step();
+                }
+            });
+        }
+        while let Some(res) = set.join_next().await {
+            res.expect("task");
+        }
+        let t = g.totals();
+        assert_eq!(t.offered, 8_000);
+        assert_eq!(t.accepted, 8_000);
+        assert_eq!(t.steps, 8_000);
+    }
+
+    /// The reported bound must cover every worker, not just one.
+    ///
+    /// `RUNTARA_TRIGGER_CONCURRENCY` bounds a worker, so with four workers the
+    /// process-wide bound is four times it. Reporting one worker's semaphore
+    /// would show a stage at 100% while three quarters of the capacity sat idle.
+    #[tokio::test]
+    async fn trigger_occupancy_sums_across_workers() {
+        let permits = TriggerPermits::new(4, 8);
+        let (limit, busy) = permits.occupancy().expect("workers are running");
+        assert_eq!(limit, 32, "four workers of eight is a bound of thirty-two");
+        assert_eq!(busy, 0);
+
+        let held = permits
+            .for_worker(2)
+            .expect("worker 2")
+            .acquire_owned()
+            .await;
+        let (_, busy) = permits.occupancy().expect("occupancy");
+        assert_eq!(busy, 1, "a permit taken on any worker counts");
+        drop(held);
+        assert_eq!(permits.occupancy().expect("occupancy").1, 0);
+    }
+
+    /// No workers must read as unmeasured, not as an idle stage.
+    #[test]
+    fn trigger_occupancy_is_absent_without_workers() {
+        assert_eq!(TriggerPermits::new(0, 8).occupancy(), None);
+        assert_eq!(TriggerPermits::default().occupancy(), None);
+    }
+
+    /// A counter reset by a restart must not produce a negative rate.
+    #[test]
+    fn a_counter_going_backwards_clamps_to_zero() {
+        let prev = PipelineTotals {
+            accepted: 5_000,
+            ..PipelineTotals::default()
+        };
+        let next = PipelineTotals::default();
+        let r = rates_between(prev, next, 1_000).expect("rates");
+        assert_eq!(
+            r.accepted, 0.0,
+            "saturating subtraction, never a negative rate"
+        );
+    }
+}

--- a/crates/runtara-server/src/workers/pipeline_gauges.rs
+++ b/crates/runtara-server/src/workers/pipeline_gauges.rs
@@ -159,6 +159,13 @@ pub struct PipelineRates {
     pub denied: f64,
     /// Started per second.
     pub started: f64,
+    /// Guests that stopped running, per second.
+    ///
+    /// Sourced from the runner rather than these counters, because only the
+    /// runner knows when a guest actually stopped. A workflow that parked
+    /// itself has finished executing without having completed, and counting
+    /// submissions as outcomes would conflate the two.
+    pub finished: f64,
     /// Steps per second, or `None` when nothing live could report one.
     pub steps: Option<f64>,
     /// The window these rates were measured over.
@@ -174,6 +181,8 @@ pub struct PipelineRates {
 pub fn rates_between(
     prev: PipelineTotals,
     next: PipelineTotals,
+    prev_finished: u64,
+    next_finished: u64,
     window_ms: u64,
 ) -> Option<PipelineRates> {
     if window_ms == 0 {
@@ -191,6 +200,7 @@ pub fn rates_between(
         accepted: per_sec(prev.accepted, next.accepted),
         denied: per_sec(prev.denied, next.denied),
         started: per_sec(prev.started, next.started),
+        finished: per_sec(prev_finished, next_finished),
         steps: measurable.then(|| per_sec(prev.steps, next.steps)),
         window_ms,
     })
@@ -284,7 +294,7 @@ mod tests {
             steps: 6_000,
             tracked_runs: 6,
         };
-        let r = rates_between(prev, next, 1_000).expect("a non-empty window yields rates");
+        let r = rates_between(prev, next, 0, 0, 1_000).expect("a non-empty window yields rates");
         assert_eq!(r.offered, 400.0);
         assert_eq!(r.accepted, 400.0);
         assert_eq!(
@@ -303,7 +313,7 @@ mod tests {
             accepted: 100,
             ..PipelineTotals::default()
         };
-        let r = rates_between(prev, next, 500).expect("rates");
+        let r = rates_between(prev, next, 0, 0, 500).expect("rates");
         assert_eq!(
             r.accepted, 200.0,
             "the sampler's real elapsed time decides the rate, not its nominal interval"
@@ -322,7 +332,7 @@ mod tests {
             accepted: 9_999,
             ..PipelineTotals::default()
         };
-        assert!(rates_between(PipelineTotals::default(), next, 0).is_none());
+        assert!(rates_between(PipelineTotals::default(), next, 0, 0, 0).is_none());
     }
 
     /// With nothing tracked live, steps must be absent rather than zero.
@@ -346,7 +356,7 @@ mod tests {
             tracked_runs: 0,
             ..PipelineTotals::default()
         };
-        let r = rates_between(quiet, later, 1_000).expect("rates");
+        let r = rates_between(quiet, later, 0, 0, 1_000).expect("rates");
         assert_eq!(
             r.steps, None,
             "no tracked run means not measured, which is not the same as zero"
@@ -365,7 +375,7 @@ mod tests {
             tracked_runs: 8,
             ..PipelineTotals::default()
         };
-        let r = rates_between(held, held, 1_000).expect("rates");
+        let r = rates_between(held, held, 0, 0, 1_000).expect("rates");
         assert_eq!(
             r.steps,
             Some(0.0),
@@ -449,7 +459,7 @@ mod tests {
             ..PipelineTotals::default()
         };
         let next = PipelineTotals::default();
-        let r = rates_between(prev, next, 1_000).expect("rates");
+        let r = rates_between(prev, next, 0, 0, 1_000).expect("rates");
         assert_eq!(
             r.accepted, 0.0,
             "saturating subtraction, never a negative rate"

--- a/crates/runtara-server/src/workers/pipeline_gauges.rs
+++ b/crates/runtara-server/src/workers/pipeline_gauges.rs
@@ -159,10 +159,10 @@ pub struct PipelineRates {
     pub denied: f64,
     /// Started per second.
     pub started: f64,
-    /// Guests that stopped running, per second.
+    /// Runs that stopped, per second.
     ///
     /// Sourced from the runner rather than these counters, because only the
-    /// runner knows when a guest actually stopped. A workflow that parked
+    /// runner knows when a run actually stopped. A workflow that parked
     /// itself has finished executing without having completed, and counting
     /// submissions as outcomes would conflate the two.
     pub finished: f64,

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -82,6 +82,12 @@ pub struct PipelineReading {
 
 /// Turn one tick's readings into the wire snapshot.
 ///
+/// Labels name what an operator is looking at, never what it is built from:
+/// the queue is where work waits for a worker, not "a Valkey stream", and a run
+/// is a run, not "a guest". The exception is a `knob` that is a real setting —
+/// those are printed verbatim because the operator has to type them exactly to
+/// change anything, and paraphrasing an environment variable helps nobody.
+///
 /// Every stage is emitted even when its source could not be read, so the shape
 /// of the pipeline stays stable and a missing reading shows up as an absent
 /// value on a stage that is still there — rather than as a stage that vanished,
@@ -104,7 +110,7 @@ pub fn build_snapshot(
         PipelineStageDto {
             key: "triggerQueue".to_string(),
             label: "Trigger queue".to_string(),
-            knob: Some("Valkey stream depth".to_string()),
+            knob: Some("waiting for a worker".to_string()),
             // Unbounded on purpose: the stream has no ceiling this process
             // enforces, and inventing one would make a consumer render a
             // percentage of a limit that does not exist.
@@ -124,7 +130,7 @@ pub fn build_snapshot(
         },
         PipelineStageDto {
             key: "runPermits".to_string(),
-            label: "Run permits".to_string(),
+            label: "Concurrent runs".to_string(),
             knob: Some("RUNTARA_MAX_CONCURRENT_RUNS".to_string()),
             limit: reading.run_limit,
             used: reading.run_used,
@@ -133,8 +139,8 @@ pub fn build_snapshot(
         },
         PipelineStageDto {
             key: "executing".to_string(),
-            label: "Executing".to_string(),
-            knob: Some("live guests".to_string()),
+            label: "Running now".to_string(),
+            knob: Some("started, not yet finished".to_string()),
             limit: None,
             used: reading.run_used,
             oldest_age_ms: reading.run_oldest_ms,

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -241,12 +241,18 @@ pub struct SamplerInputs {
     pub valkey: Option<redis::aio::ConnectionManager>,
     /// Trigger stream key and consumer group.
     pub stream: Option<(String, String)>,
-    /// Environment pool and tenant, for the parked count.
-    pub pool: sqlx::PgPool,
+    /// The **runtime** database pool, for the parked count.
+    ///
+    /// Not the server pool: `instances` lives in the runtime database, and
+    /// pointing this at the server one makes every parked count fail silently
+    /// and the stage read as permanently unmeasured.
+    pub pool: Option<sqlx::PgPool>,
     /// Tenant whose instances are counted.
     pub tenant_id: String,
     /// Composed admission cap.
     pub admission_limit: u64,
+    /// The engine, for the in-flight count the gate itself decides on.
+    pub engine: Option<Arc<crate::workers::execution_engine::ExecutionEngine>>,
 }
 
 /// Run the sampler until shutdown.
@@ -284,7 +290,10 @@ pub async fn run(
         // carry its last value between slow ticks.
         if last_slow.elapsed() >= SLOW_TICK {
             last_slow = Instant::now();
-            parked = count_parked(&inputs.pool, &inputs.tenant_id).await;
+            parked = match inputs.pool.as_ref() {
+                Some(pool) => count_parked(pool, &inputs.tenant_id).await,
+                None => None,
+            };
         }
 
         let occupancy = inputs.runner.as_ref().and_then(|r| r.occupancy());
@@ -335,7 +344,10 @@ pub async fn run(
 
         let reading = PipelineReading {
             admission_limit: Some(inputs.admission_limit),
-            admission_used: None,
+            admission_used: inputs
+                .engine
+                .as_ref()
+                .map(|e| e.observed_in_flight(&inputs.tenant_id, inputs.admission_limit)),
             queue_depth: backlog.map(|b| b.pending),
             queue_oldest_ms: backlog.and_then(|b| b.oldest_pending_ms),
             trigger_limit,
@@ -383,7 +395,10 @@ async fn count_parked(pool: &sqlx::PgPool, tenant_id: &str) -> Option<u64> {
             Some(count.max(0) as u64)
         }
         Err(e) => {
-            tracing::debug!(error = %e, "pipeline sampler could not count parked instances");
+            // Warn, not debug: this stage reading as permanently unmeasured is
+            // exactly the symptom of pointing at the wrong database, and a
+            // debug line would hide it behind the default log level.
+            tracing::warn!(error = %e, "pipeline sampler could not count parked instances");
             None
         }
     }

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -1,0 +1,611 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Samples the execution pipeline on a timer and publishes snapshots.
+//!
+//! One tick produces one snapshot, broadcast to every subscriber, so fifty
+//! dashboard clients cost exactly what one does and no client can ever cause a
+//! database query. That is the whole reason a sampler exists rather than a
+//! handler that reads the world per request.
+//!
+//! Two cadences, because one of the readings is not like the others. Everything
+//! on the fast tick is an atomic load or a single Valkey round trip. The parked
+//! count is a database scan whose cost grows with the table, so it runs on its
+//! own slow tick and its last value is carried between them — see
+//! [`SLOW_TICK`].
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use tokio::sync::broadcast;
+
+use crate::api::dto::pipeline::{PipelineRatesDto, PipelineSnapshotDto, PipelineStageDto};
+use crate::workers::pipeline_gauges::{
+    PipelineGauges, PipelineRates, PipelineTotals, TriggerPermits, rates_between,
+};
+
+/// How often the cheap readings are taken.
+pub const FAST_TICK: Duration = Duration::from_secs(1);
+
+/// How often the parked count is taken.
+///
+/// Counting suspended instances without a ceiling is the one genuinely
+/// expensive reading here: on a host holding a million of them it is a scan of
+/// every matching index entry. A parked population moves at a few hundred a
+/// second at most, so half a minute of staleness costs a viewer nothing while
+/// keeping that scan off the fast path entirely.
+pub const SLOW_TICK: Duration = Duration::from_secs(30);
+
+/// How long a stage may sit full before its age is worth remarking on.
+///
+/// Advisory only, and only ever attached to facts the consumer classifies for
+/// itself. A batch workflow can legitimately hold a permit for an hour, so this
+/// must never drive an automatic action — it exists so an operator's eye lands
+/// on the right row.
+pub fn stuck_after() -> Duration {
+    std::env::var("RUNTARA_PIPELINE_STUCK_AFTER_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(300))
+}
+
+/// Everything one tick reads, before it becomes a wire snapshot.
+///
+/// A plain data struct so [`build_snapshot`] is pure and every decision it
+/// makes — which stage is bounded, what feeds it, when a reading is absent
+/// rather than zero — is testable without a runtime, a database or a Valkey.
+#[derive(Debug, Clone, Default)]
+pub struct PipelineReading {
+    /// Composed admission cap.
+    pub admission_limit: Option<u64>,
+    /// In-flight executions as the gate counts them.
+    pub admission_used: Option<u64>,
+    /// Entries the trigger group holds but has not finished.
+    pub queue_depth: Option<u64>,
+    /// Age of the oldest such entry.
+    pub queue_oldest_ms: Option<u64>,
+    /// Trigger-worker concurrency bound, summed across workers.
+    pub trigger_limit: Option<u64>,
+    /// Trigger-worker slots in use.
+    pub trigger_used: Option<u64>,
+    /// Run-permit bound.
+    pub run_limit: Option<u64>,
+    /// Run permits held.
+    pub run_used: Option<u64>,
+    /// Age of the longest-held run permit.
+    pub run_oldest_ms: Option<u64>,
+    /// Instances suspended awaiting a wake or a signal.
+    pub parked: Option<u64>,
+}
+
+/// Turn one tick's readings into the wire snapshot.
+///
+/// Every stage is emitted even when its source could not be read, so the shape
+/// of the pipeline stays stable and a missing reading shows up as an absent
+/// value on a stage that is still there — rather than as a stage that vanished,
+/// which reads as a system that no longer has that bound at all.
+pub fn build_snapshot(
+    reading: &PipelineReading,
+    rates: Option<PipelineRates>,
+    window_ms: u64,
+) -> PipelineSnapshotDto {
+    let stages = vec![
+        PipelineStageDto {
+            key: "admission".to_string(),
+            label: "Admission".to_string(),
+            knob: Some("MAX_CONCURRENT_EXECUTIONS".to_string()),
+            limit: reading.admission_limit,
+            used: reading.admission_used,
+            oldest_age_ms: None,
+            inflow_key: "offered".to_string(),
+        },
+        PipelineStageDto {
+            key: "triggerQueue".to_string(),
+            label: "Trigger queue".to_string(),
+            knob: Some("Valkey stream depth".to_string()),
+            // Unbounded on purpose: the stream has no ceiling this process
+            // enforces, and inventing one would make a consumer render a
+            // percentage of a limit that does not exist.
+            limit: None,
+            used: reading.queue_depth,
+            oldest_age_ms: reading.queue_oldest_ms,
+            inflow_key: "accepted".to_string(),
+        },
+        PipelineStageDto {
+            key: "triggerWorkers".to_string(),
+            label: "Trigger workers".to_string(),
+            knob: Some("RUNTARA_TRIGGER_CONCURRENCY".to_string()),
+            limit: reading.trigger_limit,
+            used: reading.trigger_used,
+            oldest_age_ms: None,
+            inflow_key: "accepted".to_string(),
+        },
+        PipelineStageDto {
+            key: "runPermits".to_string(),
+            label: "Run permits".to_string(),
+            knob: Some("RUNTARA_MAX_CONCURRENT_RUNS".to_string()),
+            limit: reading.run_limit,
+            used: reading.run_used,
+            oldest_age_ms: reading.run_oldest_ms,
+            inflow_key: "started".to_string(),
+        },
+        PipelineStageDto {
+            key: "executing".to_string(),
+            label: "Executing".to_string(),
+            knob: Some("live guests".to_string()),
+            limit: None,
+            used: reading.run_used,
+            oldest_age_ms: reading.run_oldest_ms,
+            inflow_key: "started".to_string(),
+        },
+        PipelineStageDto {
+            key: "parked".to_string(),
+            label: "Parked".to_string(),
+            knob: Some("awaiting wake or signal".to_string()),
+            limit: None,
+            used: reading.parked,
+            oldest_age_ms: None,
+            inflow_key: "finished".to_string(),
+        },
+    ];
+
+    PipelineSnapshotDto {
+        captured_at: Utc::now(),
+        window_ms,
+        rates: rates.map(|r| PipelineRatesDto {
+            offered: r.offered,
+            accepted: r.accepted,
+            denied: r.denied,
+            started: r.started,
+            finished: r.finished,
+            steps: r.steps,
+        }),
+        stages,
+    }
+}
+
+/// Publishes snapshots to whoever is listening.
+///
+/// A `broadcast` and not a per-client task: a slow subscriber falls behind on
+/// its own receiver and is dropped from the stream, which must never be allowed
+/// to hold up the sampler or any other viewer.
+#[derive(Clone)]
+pub struct PipelineFeed {
+    tx: broadcast::Sender<Arc<PipelineSnapshotDto>>,
+}
+
+impl PipelineFeed {
+    /// Build a feed retaining a few snapshots for late subscribers.
+    pub fn new() -> Self {
+        // Small on purpose. A subscriber that cannot keep up with a one-second
+        // cadence wants the current state, not a backlog of stale ones.
+        let (tx, _rx) = broadcast::channel(8);
+        Self { tx }
+    }
+
+    /// Subscribe to future snapshots.
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<PipelineSnapshotDto>> {
+        self.tx.subscribe()
+    }
+
+    /// Publish a snapshot.
+    ///
+    /// A send with no receivers is the ordinary case — nobody has the page
+    /// open — and is deliberately not an error and never logged.
+    pub fn publish(&self, snapshot: Arc<PipelineSnapshotDto>) {
+        let _ = self.tx.send(snapshot);
+    }
+}
+
+impl Default for PipelineFeed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Holds the most recent snapshot so a plain `GET` needs no tick to answer.
+#[derive(Clone, Default)]
+pub struct PipelineLatest {
+    inner: Arc<std::sync::RwLock<Option<Arc<PipelineSnapshotDto>>>>,
+}
+
+impl PipelineLatest {
+    /// Read the most recent snapshot, if the sampler has produced one.
+    pub fn get(&self) -> Option<Arc<PipelineSnapshotDto>> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Store a snapshot.
+    pub fn set(&self, snapshot: Arc<PipelineSnapshotDto>) {
+        *self
+            .inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(snapshot);
+    }
+}
+
+/// What the sampler needs to read the world.
+pub struct SamplerInputs {
+    /// Intake counters.
+    pub gauges: Arc<PipelineGauges>,
+    /// Trigger-worker semaphores.
+    pub trigger_permits: TriggerPermits,
+    /// The embedded runner, for permit occupancy and age.
+    pub runner: Option<Arc<dyn runtara_environment::runner::Runner>>,
+    /// Valkey connection, for the trigger backlog.
+    pub valkey: Option<redis::aio::ConnectionManager>,
+    /// Trigger stream key and consumer group.
+    pub stream: Option<(String, String)>,
+    /// Environment pool and tenant, for the parked count.
+    pub pool: sqlx::PgPool,
+    /// Tenant whose instances are counted.
+    pub tenant_id: String,
+    /// Composed admission cap.
+    pub admission_limit: u64,
+}
+
+/// Run the sampler until shutdown.
+///
+/// Reads on the fast tick, counts parked instances on the slow one, and
+/// publishes a snapshot each time.
+pub async fn run(
+    inputs: SamplerInputs,
+    feed: PipelineFeed,
+    latest: PipelineLatest,
+    shutdown: crate::shutdown::ShutdownSignal,
+) {
+    let mut prev: Option<(PipelineTotals, u64, Instant)> = None;
+    let mut parked: Option<u64> = None;
+    let mut last_slow = Instant::now() - SLOW_TICK;
+    let mut ticker = tokio::time::interval(FAST_TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    tracing::info!(
+        fast_tick_ms = FAST_TICK.as_millis() as u64,
+        slow_tick_ms = SLOW_TICK.as_millis() as u64,
+        "Pipeline sampler started"
+    );
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {}
+            _ = shutdown.clone().wait() => {
+                tracing::info!("Pipeline sampler stopping");
+                return;
+            }
+        }
+
+        // The parked count is the expensive one; keep it off the fast tick and
+        // carry its last value between slow ticks.
+        if last_slow.elapsed() >= SLOW_TICK {
+            last_slow = Instant::now();
+            parked = count_parked(&inputs.pool, &inputs.tenant_id).await;
+        }
+
+        let occupancy = inputs.runner.as_ref().and_then(|r| r.occupancy());
+        let (trigger_limit, trigger_used) = match inputs.trigger_permits.occupancy() {
+            Some((limit, used)) => (Some(limit), Some(used)),
+            None => (None, None),
+        };
+
+        let backlog = match (&inputs.valkey, &inputs.stream) {
+            (Some(conn), Some((stream, group))) => {
+                let now_ms = Utc::now().timestamp_millis().max(0) as u64;
+                match crate::valkey::stream::stream_backlog(conn, stream, group, now_ms).await {
+                    Ok(b) => Some(b),
+                    Err(e) => {
+                        // Valkey being unreachable must blank one stage, never
+                        // the page: every other reading this tick is still good.
+                        tracing::debug!(error = %e, "pipeline sampler could not read trigger backlog");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+
+        let totals = inputs.gauges.totals();
+        let finished_total = occupancy.as_ref().map(|o| o.runs_finished).unwrap_or(0);
+        let now = Instant::now();
+
+        let (rates, window_ms) = match prev {
+            Some((prev_totals, prev_finished, at)) => {
+                let window_ms = now.duration_since(at).as_millis() as u64;
+                (
+                    rates_between(
+                        prev_totals,
+                        totals,
+                        prev_finished,
+                        finished_total,
+                        window_ms,
+                    ),
+                    window_ms,
+                )
+            }
+            // First tick: no earlier reading, so no rate. Differencing against
+            // zero would publish the process's entire lifetime as one window.
+            None => (None, 0),
+        };
+        prev = Some((totals, finished_total, now));
+
+        let reading = PipelineReading {
+            admission_limit: Some(inputs.admission_limit),
+            admission_used: None,
+            queue_depth: backlog.map(|b| b.pending),
+            queue_oldest_ms: backlog.and_then(|b| b.oldest_pending_ms),
+            trigger_limit,
+            trigger_used,
+            run_limit: occupancy.as_ref().map(|o| o.limit),
+            run_used: occupancy.as_ref().map(|o| o.held),
+            run_oldest_ms: occupancy.as_ref().and_then(|o| o.oldest_held_ms),
+            parked,
+        };
+
+        let snapshot = Arc::new(build_snapshot(&reading, rates, window_ms));
+        latest.set(Arc::clone(&snapshot));
+        feed.publish(snapshot);
+    }
+}
+
+/// Count instances parked awaiting a wake or a signal.
+///
+/// Uncapped on purpose: the admission gate's own count stops at its ceiling
+/// because it only needs to know whether the cap is reached, but a viewer wants
+/// the actual figure. That is why this runs on [`SLOW_TICK`] and never on the
+/// fast one.
+async fn count_parked(pool: &sqlx::PgPool, tenant_id: &str) -> Option<u64> {
+    let started = Instant::now();
+    let result = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM instances WHERE tenant_id = $1 AND status = 'suspended'",
+    )
+    .bind(tenant_id)
+    .fetch_one(pool)
+    .await;
+
+    match result {
+        Ok(count) => {
+            let elapsed = started.elapsed();
+            if elapsed > Duration::from_millis(200) {
+                // Surfaced rather than swallowed: this is the one reading whose
+                // cost grows with the table, and a slow one is the signal to
+                // lengthen the interval or accept a displayed ceiling.
+                tracing::warn!(
+                    elapsed_ms = elapsed.as_millis() as u64,
+                    count,
+                    "parked-instance count is slow; consider a longer RUNTARA pipeline slow tick"
+                );
+            }
+            Some(count.max(0) as u64)
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "pipeline sampler could not count parked instances");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reading() -> PipelineReading {
+        PipelineReading {
+            admission_limit: Some(2048),
+            admission_used: Some(1180),
+            queue_depth: Some(41),
+            queue_oldest_ms: Some(200),
+            trigger_limit: Some(32),
+            trigger_used: Some(9),
+            run_limit: Some(16),
+            run_used: Some(11),
+            run_oldest_ms: Some(2700),
+            parked: Some(1_009_739),
+        }
+    }
+
+    /// Every stage must be present, in pipeline order, with its real knob name.
+    ///
+    /// The order is the reading order: a viewer follows the inflow column down
+    /// the rows to find where throughput dies, and that only works if the rows
+    /// are the pipeline.
+    #[test]
+    fn the_snapshot_is_the_pipeline_in_order() {
+        let snap = build_snapshot(&reading(), None, 0);
+        let keys: Vec<_> = snap.stages.iter().map(|s| s.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "admission",
+                "triggerQueue",
+                "triggerWorkers",
+                "runPermits",
+                "executing",
+                "parked"
+            ]
+        );
+        let run = &snap.stages[3];
+        assert_eq!(run.knob.as_deref(), Some("RUNTARA_MAX_CONCURRENT_RUNS"));
+        assert_eq!(run.limit, Some(16));
+        assert_eq!(run.used, Some(11));
+        assert_eq!(run.oldest_age_ms, Some(2700));
+    }
+
+    /// Unbounded stages must carry no limit at all.
+    ///
+    /// A stream and a parked population have no ceiling this process enforces.
+    /// Inventing one would have a consumer draw a percentage of a limit that
+    /// does not exist.
+    #[test]
+    fn stages_without_a_ceiling_report_none() {
+        let snap = build_snapshot(&reading(), None, 0);
+        for key in ["triggerQueue", "executing", "parked"] {
+            let stage = snap.stages.iter().find(|s| s.key == key).expect(key);
+            assert_eq!(stage.limit, None, "{key} has no bound to be a fraction of");
+        }
+        for key in ["admission", "triggerWorkers", "runPermits"] {
+            let stage = snap.stages.iter().find(|s| s.key == key).expect(key);
+            assert!(stage.limit.is_some(), "{key} is bounded and must say so");
+        }
+    }
+
+    /// An unreadable source must stay a stage with no value, not disappear.
+    ///
+    /// A vanishing row reads as a system that no longer has that bound; an
+    /// empty one reads as a bound whose occupancy is unknown. Only the second
+    /// is true, and only the second keeps the layout stable between ticks.
+    #[test]
+    fn an_unreadable_source_leaves_the_stage_in_place_and_empty() {
+        let blind = PipelineReading {
+            admission_limit: Some(2048),
+            ..PipelineReading::default()
+        };
+        let snap = build_snapshot(&blind, None, 0);
+        assert_eq!(snap.stages.len(), 6, "the pipeline still has six stages");
+
+        let queue = &snap.stages[1];
+        assert_eq!(
+            queue.used, None,
+            "unreadable must be absent, never zero — zero would read as an empty queue"
+        );
+        let parked = snap.stages.last().expect("parked");
+        assert_eq!(parked.used, None);
+    }
+
+    /// The first tick must publish no rates at all.
+    #[test]
+    fn the_first_tick_has_no_rates() {
+        let snap = build_snapshot(&reading(), None, 0);
+        assert!(
+            snap.rates.is_none(),
+            "with no earlier reading there is no window, and inventing one \
+             publishes the whole process lifetime as a single second"
+        );
+        assert_eq!(snap.window_ms, 0);
+    }
+
+    /// Rates and their window must travel together.
+    #[test]
+    fn rates_carry_the_window_they_were_measured_over() {
+        let rates = PipelineRates {
+            offered: 400.0,
+            accepted: 400.0,
+            denied: 0.0,
+            started: 398.0,
+            finished: 396.0,
+            steps: Some(1980.0),
+            window_ms: 1000,
+        };
+        let snap = build_snapshot(&reading(), Some(rates), 1000);
+        let published = snap.rates.expect("rates");
+        assert_eq!(published.offered, 400.0);
+        assert_eq!(published.steps, Some(1980.0));
+        assert_eq!(
+            snap.window_ms, 1000,
+            "a consumer needs the window to tell a normal tick from one after a pause"
+        );
+    }
+
+    /// Absent steps must survive to the wire as absent.
+    ///
+    /// This is the false-red guard at its last hop: everything upstream can be
+    /// careful about `None` and it still becomes a stalled-looking zero if the
+    /// serialiser flattens it here.
+    #[test]
+    fn unmeasured_steps_reach_the_wire_as_null() {
+        let rates = PipelineRates {
+            offered: 400.0,
+            accepted: 400.0,
+            denied: 0.0,
+            started: 398.0,
+            finished: 396.0,
+            steps: None,
+            window_ms: 1000,
+        };
+        let snap = build_snapshot(&reading(), Some(rates), 1000);
+        let json = serde_json::to_value(&snap).expect("serialise");
+        assert!(
+            json["rates"]["steps"].is_null(),
+            "steps must serialise as null, not 0 — a workflow compiled without \
+             trackEvents runs perfectly and reports nothing"
+        );
+    }
+
+    /// The wire shape must be camelCase, as every other analytics DTO is.
+    #[test]
+    fn the_wire_shape_is_camel_case() {
+        let snap = build_snapshot(&reading(), None, 0);
+        let json = serde_json::to_value(&snap).expect("serialise");
+        assert!(json.get("capturedAt").is_some());
+        assert!(json.get("windowMs").is_some());
+        let stage = &json["stages"][3];
+        assert!(stage.get("oldestAgeMs").is_some());
+        assert!(stage.get("inflowKey").is_some());
+        assert_eq!(stage["inflowKey"], "started");
+    }
+
+    /// The feed must publish happily with nobody listening.
+    #[tokio::test]
+    async fn publishing_to_an_empty_feed_is_not_an_error() {
+        let feed = PipelineFeed::new();
+        let snap = Arc::new(build_snapshot(&reading(), None, 0));
+        feed.publish(Arc::clone(&snap));
+
+        let mut rx = feed.subscribe();
+        feed.publish(snap);
+        let received = rx.recv().await.expect("a subscriber receives");
+        assert_eq!(received.stages.len(), 6);
+    }
+
+    /// A slow subscriber must not hold up the others.
+    ///
+    /// The alternative — a bounded channel that blocks the sampler — lets one
+    /// stalled browser tab stop every other viewer's page and the sampling
+    /// itself.
+    #[tokio::test]
+    async fn a_lagging_subscriber_does_not_stall_the_feed() {
+        let feed = PipelineFeed::new();
+        let mut slow = feed.subscribe();
+        let mut quick = feed.subscribe();
+
+        // Overrun the buffer without reading from `slow`.
+        for _ in 0..40 {
+            feed.publish(Arc::new(build_snapshot(&reading(), None, 0)));
+            let _ = quick.try_recv();
+        }
+
+        match slow.recv().await {
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                assert!(skipped > 0, "the laggard is told what it missed");
+            }
+            other => panic!("expected the slow receiver to lag, got {other:?}"),
+        }
+
+        // And the feed still works for everyone else.
+        feed.publish(Arc::new(build_snapshot(&reading(), None, 0)));
+        assert!(quick.recv().await.is_ok(), "the feed survives a laggard");
+    }
+
+    /// The latest snapshot must be readable before any tick has happened.
+    #[test]
+    fn latest_is_empty_until_the_first_tick() {
+        let latest = PipelineLatest::default();
+        assert!(latest.get().is_none());
+        latest.set(Arc::new(build_snapshot(&reading(), None, 0)));
+        assert_eq!(latest.get().expect("stored").stages.len(), 6);
+    }
+
+    /// The stuck threshold must be configurable and sanely defaulted.
+    #[test]
+    fn the_stuck_threshold_defaults_to_five_minutes() {
+        // Read without setting the variable: whatever the environment holds,
+        // an unset or unparseable value must land on the documented default.
+        if std::env::var("RUNTARA_PIPELINE_STUCK_AFTER_SECS").is_err() {
+            assert_eq!(stuck_after(), Duration::from_secs(300));
+        }
+    }
+}

--- a/crates/runtara-server/src/workers/trigger_worker.rs
+++ b/crates/runtara-server/src/workers/trigger_worker.rs
@@ -104,6 +104,8 @@ pub async fn run(
     worker_config: TriggerWorkerConfig,
     shutdown: ShutdownSignal,
     event_sink: ProductEventSink,
+    event_permits: Arc<tokio::sync::Semaphore>,
+    gauges: Arc<crate::workers::pipeline_gauges::PipelineGauges>,
 ) {
     let worker_id = format!("trigger-worker-{}", Uuid::new_v4());
     let tenant_id = worker_config.tenant_id.clone();
@@ -155,7 +157,9 @@ pub async fn run(
     // count), so it sits behind a mutex held for microseconds while the slow
     // part of each event runs outside it.
     let consumer = Arc::new(tokio::sync::Mutex::new(consumer));
-    let event_permits = Arc::new(tokio::sync::Semaphore::new(trigger_concurrency()));
+    // Supplied by the caller rather than built here, so the analytics sampler
+    // can read the same semaphore this worker waits on. Each worker still gets
+    // its own, exactly as before — see `TriggerPermits`.
 
     info!(
         worker_id = %worker_id,
@@ -175,6 +179,7 @@ pub async fn run(
         None, // trigger_stream not needed for the trigger worker
         Some(running_executions.clone()),
         event_sink.clone(),
+        Arc::clone(&gauges),
     ));
 
     // Acknowledging through the consumer would hold its mutex across the XACK
@@ -340,7 +345,7 @@ async fn recreate_consumer_group(consumer: &mut StreamConsumer, autoclaim_start_
 /// bounds. Raising the *worker* count instead does not help: workers share one
 /// consumer group and contend, and the pending-entry autoclaim between them
 /// makes it actively worse.
-fn trigger_concurrency() -> usize {
+pub fn trigger_concurrency() -> usize {
     std::env::var("RUNTARA_TRIGGER_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())

--- a/e2e/test_pipeline_analytics.sh
+++ b/e2e/test_pipeline_analytics.sh
@@ -136,7 +136,12 @@ make_workflow() {
     }')
     resp=$(api_post "/workflows/${wf_id}/update" "{\"executionGraph\": ${definition}}")
     [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Update failed: ${resp}"; exit 1; }
-    version=$(curl -sS "${API}/workflows/${wf_id}/versions" | jq -r '[.data[]?.version // .data[]?.versionNumber // empty] | max // 1')
+    # `versionNumber` is the field the API returns; `.version` is always null,
+    # and jq's `//` treats that as falsy only per-element — so a list of nulls
+    # yields a null max and silently falls back to 1. That compiles version 1
+    # of a workflow whose steps live in version 2, which fails as "no steps
+    # defined" nowhere near the mistake.
+    version=$(curl -sS "${API}/workflows/${wf_id}/versions" | jq -r '[.data[]?.versionNumber // empty] | max // 1')
     resp=$(api_post "/workflows/${wf_id}/versions/${version}/compile" '{}' 900)
     [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Compile failed: ${resp}"; exit 1; }
     echo "${wf_id}"

--- a/e2e/test_pipeline_analytics.sh
+++ b/e2e/test_pipeline_analytics.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+# E2E Test: the execution pipeline must be observable while it is running.
+#
+# The System analytics page could describe the host — cores, memory, disk — but
+# not how much of it was in use. That gap let a stalled runner hold every run
+# permit for forty-eight minutes with nothing on screen changing, and it is the
+# gap this closes.
+#
+# This exercises the whole chain no unit test can reach: the admission gate's
+# counters -> the sampler's tick -> the broadcast -> the HTTP snapshot and the
+# SSE stream. In particular it covers the one piece deliberately left untested
+# in unit tests, because faking the global config to reach it costs more than
+# it proves: that the gate actually calls the counters at all.
+#
+# Asserts:
+#   * the snapshot endpoint reports all six stages, in pipeline order
+#   * every bound is a real knob name an operator can act on
+#   * the run-permit stage carries a bound read from the live runner
+#   * driving executions moves offered/accepted, proving the gate is wired
+#   * offered == accepted + denied holds across real traffic
+#   * an unbounded stage reports no limit rather than a fabricated one
+#   * unmeasured steps serialise as null, never as a stalled-looking zero
+#   * the SSE stream opens with a snapshot immediately, not after a tick
+#   * the stream keeps delivering, and its window is a real elapsed time
+#   * a second concurrent subscriber does not disturb the first
+#
+# On UNPATCHED code this FAILS at the first assertion: there is no
+# /analytics/pipeline route at all.
+#
+# Prereqs: Postgres (POSTGRES_* env or the PG_CONTAINER docker container),
+# docker (isolated Valkey), jq, and a built runtara-server.
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+print_step()    { echo -e "${GREEN}[STEP]${NC} $1"; }
+print_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-smo_worker}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-GueUkDKea0CjKP4Rn5Bk0FDV}"
+PG_CONTAINER="${PG_CONTAINER:-runtara-dev-postgres}"
+
+TEST_DB_SERVER="pipeline_e2e_server_$$"
+TEST_DB_RUNTIME="pipeline_e2e_runtime_$$"
+TEST_PORT_PUBLIC="${TEST_PORT_PUBLIC:-17780}"
+TEST_PORT_INTERNAL="${TEST_PORT_INTERNAL:-17781}"
+TEST_CORE_PORT="${TEST_CORE_PORT:-18781}"
+TEST_ENV_PORT="${TEST_ENV_PORT:-18782}"
+TEST_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT:-18783}"
+TEST_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT:-18784}"
+TEST_VALKEY_PORT="${TEST_VALKEY_PORT:-16398}"
+TEST_DATA_DIR="$(mktemp -d -t runtara_pipeline_e2e_XXXXXX)"
+TEST_LOG="${TEST_DATA_DIR}/server.log"
+SERVER_PID=""
+VALKEY_CONTAINER=""
+TENANT="pipeline_e2e"
+
+RUNTARA_SERVER_BIN="${RUNTARA_SERVER_BIN:-${PROJECT_ROOT}/target/debug/runtara-server}"
+COMPONENTS_DIR="${RUNTARA_AGENT_COMPONENTS_DIR:-${PROJECT_ROOT}/target/wasm32-wasip2/release}"
+SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
+SERVER_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_SERVER}"
+RUNTIME_DB_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${TEST_DB_RUNTIME}"
+API="http://127.0.0.1:${TEST_PORT_PUBLIC}/api/runtime"
+
+FAILURES=0
+
+if command -v psql >/dev/null 2>&1 && PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA -d postgres -c "SELECT 1" >/dev/null 2>&1; then
+    psql_quiet() { PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA "$@"; }
+elif docker exec "${PG_CONTAINER}" true >/dev/null 2>&1; then
+    print_warn "host psql unusable — using docker exec ${PG_CONTAINER}"
+    psql_quiet() { docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${PG_CONTAINER}" psql -U "${POSTGRES_USER}" -tA "$@"; }
+else
+    print_error "no psql available (host psql or ${PG_CONTAINER} container required)"; exit 1
+fi
+
+expect_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        echo "  ✓ ${label}: ${actual}"
+    else
+        print_error "${label}: expected [${expected}], got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+expect_true() {
+    local label="$1" actual="$2"
+    if [ "${actual}" = "true" ]; then
+        echo "  ✓ ${label}"
+    else
+        print_error "${label}: expected true, got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+pipeline() { curl -sS "${API}/analytics/pipeline"; }
+
+api_post() {
+    local path="$1" body="$2" timeout="${3:-60}"
+    curl -sS --max-time "${timeout}" -X POST "${API}${path}" \
+        -H 'Content-Type: application/json' -d "${body}"
+}
+
+# Create + compile a trivial workflow, echo its id.
+#
+# A real one is required rather than a probe against a made-up id: `queue()`
+# resolves the workflow first and returns NotFound *before* it reaches the
+# admission gate, so requests for a workflow that does not exist never touch
+# the counters. A test built on those would assert `offered == accepted +
+# denied` and pass vacuously at 0 == 0 + 0, proving nothing about the wiring
+# it exists to check.
+make_workflow() {
+    local name="$1" resp wf_id definition version
+    resp=$(api_post /workflows/create "{\"name\": \"${name}\", \"description\": \"pipeline analytics harness\"}")
+    wf_id=$(echo "${resp}" | jq -r '.data.id // empty')
+    [ -n "${wf_id}" ] || { print_error "Workflow create failed: ${resp}"; exit 1; }
+
+    definition=$(jq -n '{
+      name: "pipeline-harness",
+      durable: false,
+      entryPoint: "finish",
+      steps: {
+        finish: { stepType: "Finish", id: "finish",
+                  inputMapping: { ok: { valueType: "immediate", value: true } } }
+      },
+      executionPlan: [],
+      variables: {}, inputSchema: {}, outputSchema: {}
+    }')
+    resp=$(api_post "/workflows/${wf_id}/update" "{\"executionGraph\": ${definition}}")
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Update failed: ${resp}"; exit 1; }
+    version=$(curl -sS "${API}/workflows/${wf_id}/versions" | jq -r '[.data[]?.version // .data[]?.versionNumber // empty] | max // 1')
+    resp=$(api_post "/workflows/${wf_id}/versions/${version}/compile" '{}' 900)
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || { print_error "Compile failed: ${resp}"; exit 1; }
+    echo "${wf_id}"
+}
+
+cleanup() {
+    if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        kill -9 "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+    fi
+    [ -n "${VALKEY_CONTAINER}" ] && docker rm -f "${VALKEY_CONTAINER}" >/dev/null 2>&1 || true
+    if [ "${KEEP_DB:-0}" = "1" ]; then
+        echo "KEEP_DB=1 — leaving ${TEST_DB_SERVER}/${TEST_DB_RUNTIME} and ${TEST_DATA_DIR}"
+        return
+    fi
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_SERVER}" >/dev/null 2>&1 || true
+    psql_quiet -d postgres -c "DROP DATABASE IF EXISTS ${TEST_DB_RUNTIME}" >/dev/null 2>&1 || true
+    rm -rf "${TEST_DATA_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+start_server() {
+    RUNTARA_SERVER_DATABASE_URL="${SERVER_DB_URL}" \
+    OBJECT_MODEL_DATABASE_URL="${SERVER_DB_URL}" \
+    RUNTARA_DATABASE_URL="${RUNTIME_DB_URL}" \
+    TENANT_ID="${TENANT}" \
+    SERVER_HOST=127.0.0.1 \
+    SERVER_PORT="${TEST_PORT_PUBLIC}" \
+    INTERNAL_PORT="${TEST_PORT_INTERNAL}" \
+    RUNTARA_CORE_PORT="${TEST_CORE_PORT}" \
+    RUNTARA_ENVIRONMENT_PORT="${TEST_ENV_PORT}" \
+    RUNTARA_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT}" \
+    RUNTARA_ENV_HTTP_PORT="${TEST_ENV_HTTP_PORT}" \
+    DATA_DIR="${TEST_DATA_DIR}" \
+    RUNTARA_AGENT_COMPONENTS_DIR="${COMPONENTS_DIR}" \
+    RUNTARA_DEV_MODE=false \
+    RUST_LOG="${RUST_LOG_OVERRIDE:-warn,runtara_server=info}" \
+    AUTH_PROVIDER=local \
+    SESSION_TOKEN_SECRET=8efacf953eb244e07346edb64d1a8adca5bdf92049611737ce09e2c6388cb5f2 \
+    VALKEY_HOST=127.0.0.1 \
+    VALKEY_PORT="${TEST_VALKEY_PORT}" \
+    OTEL_SDK_DISABLED=true \
+    RUNTARA_SDK_BACKEND=http \
+    SQLX_OFFLINE="${SQLX_OFFLINE}" \
+    "${RUNTARA_SERVER_BIN}" >>"${TEST_LOG}" 2>&1 &
+    SERVER_PID=$!
+
+    for i in {1..60}; do
+        if curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${TEST_PORT_PUBLIC}/health" 2>/dev/null | grep -q "^2"; then
+            return 0
+        fi
+        sleep 1
+        if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            print_error "Server exited during boot."; tail -40 "${TEST_LOG}"; exit 1
+        fi
+    done
+    print_error "Server did not become healthy."; tail -40 "${TEST_LOG}"; exit 1
+}
+
+echo "==============================================================="
+echo "E2E: execution pipeline analytics"
+echo "==============================================================="
+
+[ -x "${RUNTARA_SERVER_BIN}" ] || { print_error "Missing server bin ${RUNTARA_SERVER_BIN} (cargo build -p runtara-server --bin runtara-server)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { print_error "jq required"; exit 1; }
+psql_quiet -d postgres -c "SELECT 1" >/dev/null 2>&1 || { print_error "Cannot reach Postgres"; exit 1; }
+docker info >/dev/null 2>&1 || { print_error "docker required (isolated Valkey)"; exit 1; }
+[ -d "${COMPONENTS_DIR}" ] || { print_error "Missing components dir ${COMPONENTS_DIR} — run scripts/build-agent-components.sh"; exit 1; }
+
+print_step "Starting isolated Valkey on :${TEST_VALKEY_PORT}..."
+VALKEY_CONTAINER=$(docker run -d --rm -p "${TEST_VALKEY_PORT}:6379" valkey/valkey:8-alpine)
+for i in {1..20}; do (echo > /dev/tcp/127.0.0.1/${TEST_VALKEY_PORT}) 2>/dev/null && break; sleep 0.5; done
+
+print_step "Creating databases..."
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_SERVER}" >/dev/null
+psql_quiet -d postgres -c "CREATE DATABASE ${TEST_DB_RUNTIME}" >/dev/null
+
+print_step "Starting runtara-server on :${TEST_PORT_PUBLIC}..."
+start_server
+echo "  Server up (PID ${SERVER_PID})"
+
+# The sampler has to have ticked at least twice before rates exist: the first
+# tick has no earlier reading to difference against.
+print_step "Waiting for the sampler's first snapshots..."
+SNAPSHOT=""
+for i in {1..30}; do
+    SNAPSHOT="$(pipeline)"
+    if [ "$(echo "${SNAPSHOT}" | jq -r '.success // false')" = "true" ]; then break; fi
+    sleep 1
+done
+if [ "$(echo "${SNAPSHOT}" | jq -r '.success // false')" != "true" ]; then
+    print_error "Sampler never produced a snapshot"; echo "${SNAPSHOT}"; tail -40 "${TEST_LOG}"; exit 1
+fi
+echo "  First snapshot after ~${i}s"
+
+print_step "1. The snapshot is the pipeline, in order"
+expect_eq "stage count" "6" "$(echo "${SNAPSHOT}" | jq -r '.data.stages | length')"
+expect_eq "stage keys in pipeline order" \
+  "admission triggerQueue triggerWorkers runPermits executing parked" \
+  "$(echo "${SNAPSHOT}" | jq -r '[.data.stages[].key] | join(" ")')"
+
+print_step "2. Every bound names a knob an operator can act on"
+expect_eq "admission knob" "MAX_CONCURRENT_EXECUTIONS" \
+  "$(echo "${SNAPSHOT}" | jq -r '.data.stages[] | select(.key=="admission") | .knob')"
+expect_eq "trigger worker knob" "RUNTARA_TRIGGER_CONCURRENCY" \
+  "$(echo "${SNAPSHOT}" | jq -r '.data.stages[] | select(.key=="triggerWorkers") | .knob')"
+expect_eq "run permit knob" "RUNTARA_MAX_CONCURRENT_RUNS" \
+  "$(echo "${SNAPSHOT}" | jq -r '.data.stages[] | select(.key=="runPermits") | .knob')"
+
+print_step "3. The run-permit bound comes from the live runner"
+# Not a constant echoed back: the runner reports the semaphore it actually
+# waits on, so this is the number that will refuse the next launch.
+RUN_LIMIT="$(echo "${SNAPSHOT}" | jq -r '.data.stages[] | select(.key=="runPermits") | .limit')"
+expect_true "run permit limit is a positive number" \
+  "$(echo "${SNAPSHOT}" | jq -r '(.data.stages[] | select(.key=="runPermits") | .limit) > 0')"
+echo "    runner reports a bound of ${RUN_LIMIT}"
+expect_true "run permit occupancy is readable" \
+  "$(echo "${SNAPSHOT}" | jq -r '(.data.stages[] | select(.key=="runPermits") | .used) != null')"
+
+print_step "4. Unbounded stages report no limit rather than inventing one"
+for key in triggerQueue executing parked; do
+    expect_eq "${key} has no ceiling" "null" \
+      "$(echo "${SNAPSHOT}" | jq -r ".data.stages[] | select(.key==\"${key}\") | .limit")"
+done
+
+print_step "5. Driving real executions moves the gate's counters"
+# The piece no unit test here reaches: that check_concurrency_gate actually
+# calls the counters on the live path. A made-up workflow id would be rejected
+# before the gate, so this uses a real compiled one.
+WF_ID="$(make_workflow "pipeline-probe")"
+echo "  workflow ${WF_ID} compiled"
+
+# Drive continuously while sampling, so at least one window contains traffic.
+# A single burst can land entirely between two ticks and read as zero.
+(
+  for _ in $(seq 1 60); do
+      curl -sS -o /dev/null --max-time 5 -X POST "${API}/workflows/${WF_ID}/execute" \
+        -H 'Content-Type: application/json' -d '{"inputs": {"data": {}}}' 2>/dev/null || true
+  done
+) &
+DRIVER_PID=$!
+
+SAW_OFFERED=0
+SAW_ACCEPTED=0
+IDENTITY_HELD=1
+for _ in $(seq 1 12); do
+    sleep 1
+    SNAP="$(pipeline)"
+    [ "$(echo "${SNAP}" | jq -r '.data.rates != null')" = "true" ] || continue
+    OFFERED="$(echo "${SNAP}" | jq -r '.data.rates.offered')"
+    ACCEPTED="$(echo "${SNAP}" | jq -r '.data.rates.accepted')"
+    [ "$(echo "${SNAP}" | jq -r '.data.rates.offered > 0')" = "true" ] && SAW_OFFERED=1
+    [ "$(echo "${SNAP}" | jq -r '.data.rates.accepted > 0')" = "true" ] && SAW_ACCEPTED=1
+    # Check the identity on every sampled window, not just a lucky one.
+    if [ "$(echo "${SNAP}" | jq -r '.data.rates as $r | (($r.accepted + $r.denied) - $r.offered | fabs) < 0.001')" != "true" ]; then
+        IDENTITY_HELD=0
+        print_error "identity broke: offered=${OFFERED} accepted=${ACCEPTED} denied=$(echo "${SNAP}" | jq -r '.data.rates.denied')"
+    fi
+    [ "${SAW_OFFERED}" = "1" ] && [ "${SAW_ACCEPTED}" = "1" ] && break
+done
+wait "${DRIVER_PID}" 2>/dev/null || true
+
+expect_eq "the gate counted offers while traffic ran" "1" "${SAW_OFFERED}"
+expect_eq "the gate counted admissions while traffic ran" "1" "${SAW_ACCEPTED}"
+
+AFTER="$(pipeline)"
+expect_true "the snapshot carries rates" "$(echo "${AFTER}" | jq -r '.data.rates != null')"
+expect_true "the rate window is a real elapsed time, not the nominal interval" \
+  "$(echo "${AFTER}" | jq -r '.data.windowMs > 0')"
+
+print_step "6. offered == accepted + denied on every sampled window"
+# The identity a viewer relies on to show refusals as a share of demand. If it
+# drifts, the refusal rate renders above 100% or below zero.
+expect_eq "held across every window sampled under load" "1" "${IDENTITY_HELD}"
+
+print_step "7. Unmeasured steps are null, never a stalled-looking zero"
+# trackEvents is compile-time. Nothing here was compiled with it, so the
+# honest answer is "not measured" — and rendering that as 0/s would let a
+# reader conclude a healthy deployment had stopped dead.
+expect_eq "steps report as unmeasured" "null" \
+  "$(echo "${AFTER}" | jq -r '.data.rates.steps')"
+expect_true "the other rates are still fully reported" \
+  "$(echo "${AFTER}" | jq -r '.data.rates | (.offered != null) and (.accepted != null) and (.denied != null)')"
+
+print_step "8. The stream opens with a snapshot immediately"
+# A freshly loaded page must not sit blank waiting for the next tick.
+STREAM_OUT="${TEST_DATA_DIR}/stream.txt"
+curl -sS --max-time 4 -H 'Accept: text/event-stream' \
+  "${API}/analytics/pipeline/stream" > "${STREAM_OUT}" 2>/dev/null || true
+
+FIRST_FRAME="$(grep -m1 '^data:' "${STREAM_OUT}" | sed 's/^data: *//')"
+expect_true "the first frame arrives and is a snapshot" \
+  "$(echo "${FIRST_FRAME}" | jq -r '(.stages | length) == 6' 2>/dev/null || echo false)"
+
+print_step "9. The stream keeps delivering"
+FRAME_COUNT="$(grep -c '^data:' "${STREAM_OUT}" || true)"
+if [ "${FRAME_COUNT}" -ge 2 ]; then
+    echo "  ✓ received ${FRAME_COUNT} frames in ~4s at a 1s cadence"
+else
+    print_error "expected at least 2 frames in 4 seconds, got ${FRAME_COUNT}"
+    FAILURES=$((FAILURES + 1))
+fi
+
+print_step "10. A second subscriber does not disturb the first"
+# One tick feeds every viewer from a broadcast, so a second reader must cost
+# nothing and interfere with nothing.
+A_OUT="${TEST_DATA_DIR}/sub_a.txt"; B_OUT="${TEST_DATA_DIR}/sub_b.txt"
+curl -sS --max-time 4 -H 'Accept: text/event-stream' "${API}/analytics/pipeline/stream" > "${A_OUT}" 2>/dev/null &
+A_PID=$!
+curl -sS --max-time 4 -H 'Accept: text/event-stream' "${API}/analytics/pipeline/stream" > "${B_OUT}" 2>/dev/null &
+B_PID=$!
+wait "${A_PID}" 2>/dev/null || true
+wait "${B_PID}" 2>/dev/null || true
+
+A_FRAMES="$(grep -c '^data:' "${A_OUT}" || true)"
+B_FRAMES="$(grep -c '^data:' "${B_OUT}" || true)"
+if [ "${A_FRAMES}" -ge 2 ] && [ "${B_FRAMES}" -ge 2 ]; then
+    echo "  ✓ both subscribers fed (${A_FRAMES} and ${B_FRAMES} frames)"
+else
+    print_error "concurrent subscribers starved: ${A_FRAMES} and ${B_FRAMES} frames"
+    FAILURES=$((FAILURES + 1))
+fi
+
+print_step "11. The server is still healthy after all of it"
+expect_eq "health" "200" \
+  "$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:${TEST_PORT_PUBLIC}/health")"
+
+echo
+echo "==============================================================="
+if [ "${FAILURES}" -eq 0 ]; then
+    print_success "All pipeline analytics assertions passed"
+    exit 0
+fi
+print_error "${FAILURES} assertion(s) failed"
+echo "Server log: ${TEST_LOG}"
+tail -30 "${TEST_LOG}"
+exit 1

--- a/scripts/pipeline-playground.sh
+++ b/scripts/pipeline-playground.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# A local server for experimenting with the System analytics pipeline view.
+#
+# Brings up an isolated Postgres pair, a Valkey, and a runtara-server serving
+# the built UI, then seeds workflows shaped to drive the view into each of the
+# states it exists to tell apart. Everything is namespaced `pipelinelab`, on
+# ports well away from the usual dev ones, so it cannot disturb a running :7001.
+#
+# Usage:
+#   scripts/pipeline-playground.sh up          # start, seed, print the URL
+#   scripts/pipeline-playground.sh load [N]    # offer N executions (default 300)
+#   scripts/pipeline-playground.sh saturate    # hold every run permit
+#   scripts/pipeline-playground.sh park [N]    # add N parked instances
+#   scripts/pipeline-playground.sh squeeze     # restart with a tiny cap
+#   scripts/pipeline-playground.sh snapshot    # print the raw JSON
+#   scripts/pipeline-playground.sh watch       # follow the SSE stream
+#   scripts/pipeline-playground.sh logs
+#   scripts/pipeline-playground.sh down        # stop and remove everything
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+say()  { echo -e "${GREEN}▸${NC} $1"; }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+die()  { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LAB_DIR="${RUNTARA_LAB_DIR:-${TMPDIR:-/tmp}/runtara-pipeline-lab}"
+PORT="${LAB_PORT:-17800}"
+INTERNAL_PORT=$((PORT + 1))
+CORE_PORT=$((PORT + 100))
+ENV_PORT=$((PORT + 101))
+CORE_HTTP_PORT=$((PORT + 102))
+ENV_HTTP_PORT=$((PORT + 103))
+VALKEY_PORT="${LAB_VALKEY_PORT:-16410}"
+VALKEY_NAME=pipelinelab-valkey
+TENANT=pipelinelab
+DB_SERVER=pipelinelab_server
+DB_RUNTIME=pipelinelab_runtime
+
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_USER="${POSTGRES_USER:-smo_worker}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-GueUkDKea0CjKP4Rn5Bk0FDV}"
+PG_CONTAINER="${PG_CONTAINER:-runtara-dev-postgres}"
+
+BIN="${RUNTARA_SERVER_BIN:-${ROOT}/target/debug/runtara-server}"
+COMPONENTS_DIR="${RUNTARA_AGENT_COMPONENTS_DIR:-${ROOT}/target/wasm32-wasip2/release}"
+DIST_DIR="${ROOT}/crates/runtara-server/frontend/dist"
+
+API="http://127.0.0.1:${PORT}/api/runtime"
+UI="http://127.0.0.1:${PORT}/ui/analytics/system"
+PIDFILE="${LAB_DIR}/server.pid"
+LOG="${LAB_DIR}/server.log"
+WF_FILE="${LAB_DIR}/workflows.env"
+
+if command -v psql >/dev/null 2>&1 && PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA -d postgres -c "SELECT 1" >/dev/null 2>&1; then
+    psql_lab() { PGPASSWORD="${POSTGRES_PASSWORD}" psql -U "${POSTGRES_USER}" -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -tA "$@"; }
+elif docker exec "${PG_CONTAINER}" true >/dev/null 2>&1; then
+    psql_lab() { docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${PG_CONTAINER}" psql -U "${POSTGRES_USER}" -tA "$@"; }
+else
+    die "no Postgres reachable (host psql, or the '${PG_CONTAINER}' container)"
+fi
+
+api_post() {
+    curl -sS --max-time "${3:-120}" -X POST "${API}$1" \
+        -H 'Content-Type: application/json' -d "$2"
+}
+
+# Create + compile a workflow, echo its id.
+#
+# `versionNumber` is the field the API returns; `.version` is always null, and
+# a list of nulls yields a null max that silently falls back to 1 — which
+# compiles an empty version 1 of a workflow whose steps are in version 2.
+make_workflow() {
+    local name="$1" graph="$2" resp wf_id version
+    resp=$(api_post /workflows/create "{\"name\":\"${name}\",\"description\":\"pipeline playground\"}")
+    wf_id=$(echo "${resp}" | jq -r '.data.id // empty')
+    [ -n "${wf_id}" ] || die "create failed: ${resp}"
+
+    resp=$(api_post "/workflows/${wf_id}/update" "{\"executionGraph\": ${graph}}")
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || die "update failed: ${resp}"
+
+    version=$(curl -sS "${API}/workflows/${wf_id}/versions" | jq -r '[.data[]?.versionNumber // empty] | max // 1')
+    resp=$(api_post "/workflows/${wf_id}/versions/${version}/compile" '{}' 900)
+    [ "$(echo "${resp}" | jq -r '.success // false')" = "true" ] || die "compile failed: ${resp}"
+    echo "${wf_id}"
+}
+
+server_running() {
+    [ -f "${PIDFILE}" ] && kill -0 "$(cat "${PIDFILE}")" 2>/dev/null
+}
+
+require_up() {
+    server_running || die "not running — start it with: scripts/pipeline-playground.sh up"
+}
+
+start_server() {
+    # Guarded expansion: macOS ships bash 3.2, where "${arr[@]}" on an empty
+    # array is an unbound-variable error under `set -u` — and it surfaces as
+    # "server exited during boot", nowhere near the actual mistake.
+    mkdir -p "${LAB_DIR}"
+    (
+        if [ "$#" -gt 0 ]; then
+            for kv in "$@"; do export "${kv?}"; done
+        fi
+        export RUNTARA_SERVER_DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${DB_SERVER}"
+        export OBJECT_MODEL_DATABASE_URL="${RUNTARA_SERVER_DATABASE_URL}"
+        export RUNTARA_DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${DB_RUNTIME}"
+        export TENANT_ID="${TENANT}"
+        export SERVER_HOST=127.0.0.1 SERVER_PORT="${PORT}" INTERNAL_PORT="${INTERNAL_PORT}"
+        export RUNTARA_CORE_PORT="${CORE_PORT}" RUNTARA_ENVIRONMENT_PORT="${ENV_PORT}"
+        export RUNTARA_CORE_HTTP_PORT="${CORE_HTTP_PORT}" RUNTARA_ENV_HTTP_PORT="${ENV_HTTP_PORT}"
+        export DATA_DIR="${LAB_DIR}/data"
+        export RUNTARA_AGENT_COMPONENTS_DIR="${COMPONENTS_DIR}"
+        # Serves the built dist from disk, so a frontend rebuild needs no relink.
+        export RUNTARA_UI_DIST_DIR="${DIST_DIR}"
+        # The origin only: the client appends /api/runtime itself, and including
+        # it here produces /api/runtime/api/runtime/... and a page of 404s.
+        export RUNTARA_UI_API_BASE_URL="http://127.0.0.1:${PORT}"
+        export RUNTARA_DEV_MODE=false
+        export RUST_LOG="${RUST_LOG:-warn,runtara_server=info}"
+        export AUTH_PROVIDER=local
+        export SESSION_TOKEN_SECRET=8efacf953eb244e07346edb64d1a8adca5bdf92049611737ce09e2c6388cb5f2
+        export VALKEY_HOST=127.0.0.1 VALKEY_PORT="${VALKEY_PORT}"
+        export OTEL_SDK_DISABLED=true RUNTARA_SDK_BACKEND=http SQLX_OFFLINE=true
+        exec "${BIN}" >>"${LOG}" 2>&1
+    ) &
+    echo $! > "${PIDFILE}"
+
+    for i in $(seq 1 90); do
+        if curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/health" 2>/dev/null | grep -q '^2'; then
+            return 0
+        fi
+        sleep 1
+        kill -0 "$(cat "${PIDFILE}")" 2>/dev/null || { tail -30 "${LOG}"; die "server exited during boot"; }
+    done
+    tail -30 "${LOG}"; die "server never became healthy"
+}
+
+stop_server() {
+    if server_running; then
+        kill "$(cat "${PIDFILE}")" 2>/dev/null || true
+        sleep 2
+        kill -9 "$(cat "${PIDFILE}")" 2>/dev/null || true
+    fi
+    rm -f "${PIDFILE}"
+}
+
+FINISH_GRAPH='{
+  "name": "instant", "durable": false, "entryPoint": "finish",
+  "steps": { "finish": { "stepType": "Finish", "id": "finish",
+             "inputMapping": { "ok": { "valueType": "immediate", "value": true } } } },
+  "executionPlan": [], "variables": {}, "inputSchema": {}, "outputSchema": {}
+}'
+
+slow_graph() {
+    jq -n --argjson ms "$1" '{
+      name: "slow", durable: false, entryPoint: "wait",
+      steps: {
+        wait:   { stepType: "Delay", id: "wait", name: "Hold a run slot",
+                  durationMs: { valueType: "immediate", value: $ms } },
+        finish: { stepType: "Finish", id: "finish",
+                  inputMapping: { ok: { valueType: "immediate", value: true } } }
+      },
+      executionPlan: [ { fromStep: "wait", toStep: "finish" } ],
+      variables: {}, inputSchema: {}, outputSchema: {}
+    }'
+}
+
+cmd_up() {
+    [ -x "${BIN}" ] || die "missing ${BIN} — cargo build -p runtara-server --bin runtara-server"
+    [ -d "${COMPONENTS_DIR}" ] || die "missing ${COMPONENTS_DIR} — scripts/build-agent-components.sh"
+    [ -d "${DIST_DIR}" ] || die "missing ${DIST_DIR} — (cd crates/runtara-server/frontend && npm run build)"
+    command -v jq >/dev/null || die "jq required"
+    docker info >/dev/null 2>&1 || die "docker required (isolated Valkey)"
+
+    server_running && { warn "already running"; cmd_where; return 0; }
+
+    mkdir -p "${LAB_DIR}/data"; : > "${LOG}"
+
+    say "Valkey on :${VALKEY_PORT}"
+    docker rm -f "${VALKEY_NAME}" >/dev/null 2>&1 || true
+    docker run -d --rm --name "${VALKEY_NAME}" -p "${VALKEY_PORT}:6379" valkey/valkey:8-alpine >/dev/null \
+        || die "could not start Valkey (is :${VALKEY_PORT} taken? set LAB_VALKEY_PORT)"
+    for _ in $(seq 1 20); do (echo > "/dev/tcp/127.0.0.1/${VALKEY_PORT}") 2>/dev/null && break; sleep 0.5; done
+
+    say "databases"
+    for db in "${DB_SERVER}" "${DB_RUNTIME}"; do
+        psql_lab -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null 2>&1
+        psql_lab -d postgres -c "CREATE DATABASE ${db}" >/dev/null 2>&1
+    done
+
+    say "server on :${PORT}"
+    start_server
+
+    say "seeding workflows (compiling, ~30s)"
+    {
+        echo "WF_INSTANT=$(make_workflow "lab-instant" "${FINISH_GRAPH}")"
+        echo "WF_SLOW=$(make_workflow "lab-slow" "$(slow_graph 20000)")"
+        echo "WF_PARK=$(make_workflow "lab-park" "$(slow_graph 86400000)")"
+    } > "${WF_FILE}"
+    # shellcheck disable=SC1090
+    source "${WF_FILE}"
+    echo "    lab-instant  ${WF_INSTANT}"
+    echo "    lab-slow     ${WF_SLOW}   (20s per run — fills run slots)"
+    echo "    lab-park     ${WF_PARK}   (24h delay — parks immediately)"
+
+    cmd_where
+}
+
+cmd_where() {
+    echo
+    echo -e "  ${BLUE}Open${NC}      ${UI}"
+    echo -e "  ${BLUE}Snapshot${NC}  ${API}/analytics/pipeline"
+    echo -e "  ${BLUE}Stream${NC}    ${API}/analytics/pipeline/stream"
+    echo
+    echo "  Drive it:"
+    echo "    scripts/pipeline-playground.sh load 300     # steady throughput"
+    echo "    scripts/pipeline-playground.sh saturate     # every run slot held"
+    echo "    scripts/pipeline-playground.sh park 5000    # a big parked population"
+    echo "    scripts/pipeline-playground.sh squeeze      # restart with a tiny cap"
+    echo
+}
+
+cmd_load() {
+    require_up
+    # shellcheck disable=SC1090
+    source "${WF_FILE}"
+    local n="${1:-300}"
+    say "offering ${n} instant executions — watch Offered/Accepted climb"
+    for _ in $(seq 1 "${n}"); do
+        curl -sS -o /dev/null --max-time 5 -X POST "${API}/workflows/${WF_INSTANT}/execute" \
+            -H 'Content-Type: application/json' -d '{"inputs":{"data":{}}}' 2>/dev/null || true
+    done
+    say "done"
+    cmd_snapshot
+}
+
+cmd_saturate() {
+    require_up
+    # shellcheck disable=SC1090
+    source "${WF_FILE}"
+    local limit
+    limit=$(curl -sS "${API}/analytics/pipeline" | jq -r '.data.stages[] | select(.key=="runPermits") | .limit // 16')
+    local n=$(( limit * 2 ))
+    say "launching ${n} runs of 20s each against a bound of ${limit}"
+    say "expect: Concurrent runs pins at ${limit}/${limit} and is named the chokepoint"
+    for _ in $(seq 1 "${n}"); do
+        curl -sS -o /dev/null --max-time 3 -X POST "${API}/workflows/${WF_SLOW}/execute" \
+            -H 'Content-Type: application/json' -d '{"inputs":{"data":{}}}' 2>/dev/null || true &
+    done
+    wait 2>/dev/null || true
+    sleep 3
+    cmd_snapshot
+}
+
+cmd_park() {
+    require_up
+    local n="${1:-5000}"
+    # Inserted directly rather than executed: the point is a large parked
+    # population to look at, and running 5000 workflows to get one is slow.
+    # The count is read from this table either way.
+    say "adding ${n} parked instances"
+    psql_lab -d "${DB_RUNTIME}" -c "
+        INSERT INTO instances (instance_id, tenant_id, status, created_at)
+        SELECT 'lab-park-'||md5(random()::text||g), '${TENANT}', 'suspended'::instance_status, NOW()
+        FROM generate_series(1, ${n}) g;" >/dev/null
+    say "done — the Parked row updates on the 30s slow tick"
+}
+
+cmd_squeeze() {
+    require_up
+    say "restarting with MAX_CONCURRENT_EXECUTIONS=4 and RUNTARA_MAX_CONCURRENT_RUNS=2"
+    say "expect: Admission fills fast and starts refusing (Denied 403 climbs)"
+    stop_server
+    start_server MAX_CONCURRENT_EXECUTIONS=4 RUNTARA_MAX_CONCURRENT_RUNS=2
+    cmd_where
+}
+
+cmd_snapshot() {
+    require_up
+    curl -sS "${API}/analytics/pipeline" | jq '{
+        rates: .data.rates,
+        stages: [.data.stages[] | {stage: .label, knob, used, limit, oldestAgeMs}]
+    }'
+}
+
+cmd_watch() {
+    require_up
+    say "following the stream (ctrl-c to stop)"
+    curl -sSN -H 'Accept: text/event-stream' "${API}/analytics/pipeline/stream" \
+    | while IFS= read -r line; do
+        case "${line}" in
+          data:*) echo "${line#data: }" | jq -c '{
+              t: (.capturedAt | split("T")[1][0:8]),
+              offered: (.rates.offered // null), accepted: (.rates.accepted // null),
+              denied: (.rates.denied // null),
+              runs: [(.stages[] | select(.key=="runPermits") | .used, .limit)],
+              parked: (.stages[] | select(.key=="parked") | .used)
+          }' 2>/dev/null ;;
+        esac
+      done
+}
+
+cmd_logs() { tail -f "${LOG}"; }
+
+cmd_down() {
+    say "stopping"
+    stop_server
+    docker rm -f "${VALKEY_NAME}" >/dev/null 2>&1 || true
+    if [ "${KEEP_DB:-0}" != "1" ]; then
+        for db in "${DB_SERVER}" "${DB_RUNTIME}"; do
+            psql_lab -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null 2>&1
+        done
+        rm -rf "${LAB_DIR}"
+    else
+        say "KEEP_DB=1 — databases and ${LAB_DIR} left in place"
+    fi
+    say "down"
+}
+
+case "${1:-up}" in
+    up)       cmd_up ;;
+    load)     cmd_load "${2:-300}" ;;
+    saturate) cmd_saturate ;;
+    park)     cmd_park "${2:-5000}" ;;
+    squeeze)  cmd_squeeze ;;
+    snapshot) cmd_snapshot ;;
+    watch)    cmd_watch ;;
+    logs)     cmd_logs ;;
+    where)    cmd_where ;;
+    down)     cmd_down ;;
+    *)        sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ; exit 1 ;;
+esac


### PR DESCRIPTION
## Why

The System analytics page could describe the host — cores, memory, disk — but not how much of it was in use. That gap is why a stalled runner on a live instance held every run slot for 48 minutes with nothing on screen changing, and why the regression behind it went unnoticed for weeks.

This adds occupancy against every concurrency limit, the rates between stages, and which stage is actually the constraint.

## What it looks like

Six stages as rows, with the inflow rate down the left. You read that column top to bottom and watch throughput collapse — the row it dies on is the row outlined as the chokepoint.

Under a real saturation (`MAX_CONCURRENT_EXECUTIONS=4`, sustained load):

```
OFFERED 29/s   ACCEPTED 2.0/s   DENIED 403 27/s   STARTED 0.0/s   STEPS not measured

>> Admission        29/s   MAX_CONCURRENT_EXECUTIONS      4/4    100% in use
   Trigger queue    2.0/s  waiting for a worker           1      13.4s oldest
   Trigger workers  2.0/s  RUNTARA_TRIGGER_CONCURRENCY    1/128  1% in use
   Concurrent runs  0.0/s  RUNTARA_MAX_CONCURRENT_RUNS    2/2    100% in use
   Running now      0.0/s  started, not yet finished      2      13.5s oldest
   Parked           0.0/s  awaiting wake or signal        3,000
```

## Design decisions worth reviewing

**No new tables, processes, or execution-path changes.** Everything is already one process — `server.rs:1275` calls the runtime client "a direct handle on the embedded environment" — so in-process gauges are complete and authoritative. The hot path does one relaxed atomic add per intake; nothing allocates, locks, or does I/O.

**One tick feeds every viewer.** Snapshots go out on a `broadcast`, so fifty dashboard clients cost what one does and no client can ever cause a database query. A lagging subscriber resumes from current state rather than stalling the sampler.

**Two cadences.** Everything on the 1s tick is an atomic load or a single Valkey round trip. The parked count is the one reading whose cost grows with the table, so it runs on its own 30s tick and warns if it exceeds 200ms.

**The payload carries facts, not judgement.** No `health` or `chokepoint` field on the wire — classification is a pure frontend function tested against fixtures. That matters because a prototype got it wrong three ways, each plausible on inspection and each only visible under a fixture. All three are pinned by name in `pipeline.test.ts`:

- it named an *unbounded* queue that was merely holding the evidence, while the bounded stage that was full and not draining went unnamed
- it accused a stage at 69% on a healthy pipeline
- it flickered, because it recomputed every tick and ordinary jitter crossed the threshold

**Nullability is load-bearing.** `used: null` means "could not read", distinct from `Some(0)`, "empty". `steps: null` means "nothing live could have reported a step", distinct from `0.0`, "work is live and none of it is progressing". `trackEvents` is compile-time, so a workflow built without it runs perfectly and emits nothing — rendering that as `0/s` would let the view declare a healthy deployment stalled. Run-slot **age** is the progress signal that works regardless of how an artifact was built.

**Sources of truth stay separate.** `finished` comes from the runner, because only it knows when a run actually stopped — and a workflow that parked itself has finished executing without having completed. Admission occupancy comes from the gate's own cached figure, so a viewer sees what the gate decides on rather than a second opinion about the same thing.

## What this deliberately does not do

The admission gate still counts from the database rather than reading the new gauge. That would remove two queries per intake, but an in-process counter starts at zero after a restart and would over-admit against instances already `Running`. It needs a seed-and-reconcile design and belongs in its own change.

## Also fixed along the way

- `worker_executions_total`, `worker_executions_active`, `worker_execution_duration` and `compilation_queue_size` are declared in `observability/mod.rs`, constructed and exported — with **zero write sites** anywhere in the workspace. A dashboard built on them would show flat zero forever. Not reused.
- The admission-denial path returned `ENTITLEMENT_LIMIT_EXCEEDED` without incrementing anything, so the refusal rate — the first number anyone asks for when intake looks wrong — was unobservable.
- `valkey/stream.rs` had no length or pending-summary helper. Stream ids carry their arrival time, so `XPENDING`'s minimum id gives depth *and* age in one round trip.

## Testing

| | |
|---|---|
| Rust unit | 1,240 pass (`runtara-server` 1,132, `runtara-environment` 108) — 53 new |
| Frontend unit | 1,494 pass — 49 new (26 utils, 12 component, 11 SSE) |
| E2E | `e2e/test_pipeline_analytics.sh` 11/11 against a live server |
| Regression E2E | `test_durable_delay_parks_and_wakes.sh` passes (exercises the modified runner) |
| Gates | `clippy --workspace --all-targets` clean · `fmt --check` clean · `npm run lint` 0 errors · `npm run build` clean |

Two test traps worth knowing about, both hit and fixed:

- The e2e originally probed made-up workflow ids. `queue()` resolves the workflow and returns `NotFound` **before** the admission gate, so those requests never touch the counters — `offered == accepted + denied` passed vacuously at `0 == 0 + 0`. It now drives a real compiled workflow and asserts the counters actually move.
- The versions API returns `versionNumber`, not `version`. A list of nulls yields a null max that silently falls back to 1, compiling an empty version 1 of a workflow whose steps are in version 2.

## Try it

```bash
scripts/pipeline-playground.sh up
```

Isolated on `pipelinelab` — own databases, own Valkey on 16410, server on 17800. Does not touch a running `:7001`. Then `load`, `saturate`, `park`, `squeeze` to drive it into each state; `down` to remove everything.

## Known rough edge

`Concurrent runs` and `Running now` always show the same number — both read `run_used` — and the second additionally says "no limit" about something that plainly has one. Merging them would drop the duplicate, but it changes the pipeline's shape, so I left the call open.
