### PR TITLE
ci: stop evicting the caches that matter

### DIFF
--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -24,8 +24,6 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   SQLX_OFFLINE: true
-  CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
   WASM_PACK_VERSION: "0.13.1"
 
 jobs:
@@ -40,10 +38,17 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-bin: false
+          cache: false
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+      # sccache here had the same fault as release.yml: wired as a workspace
+      # wrapper, so it never touched the dependencies that dominate the build, and
+      # its writes were evicted before any later run could read them. Read-only
+      # against main's cache — this workflow builds arbitrary branches on demand
+      # and shouldn't spend the repo's cache budget.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-bundle-linux-x86_64
+          save-if: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -52,24 +57,10 @@ jobs:
           cache: npm
           cache-dependency-path: crates/runtara-server/frontend/package-lock.json
 
-      - name: Add Cargo bin to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Cache wasm-pack binary
-        id: cache-wasm-pack
-        uses: actions/cache@v4
+      - name: Install wasm-pack (prebuilt)
+        uses: taiki-e/install-action@v2
         with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.ImageOS }}-${{ runner.arch }}-${{ env.WASM_PACK_VERSION }}
-
-      - name: Install wasm-pack
-        run: |
-          if command -v wasm-pack >/dev/null 2>&1 \
-            && wasm-pack --version | grep -q "wasm-pack ${WASM_PACK_VERSION}"; then
-            echo "wasm-pack ${WASM_PACK_VERSION} already installed"
-          else
-            cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked --force
-          fi
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
       - name: Build bundle
         run: ./scripts/build-bundle.sh --output-dir target/bundle --version "${{ inputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+# Supersede in-flight runs for the same ref. Without this, every push to a
+# branch left its predecessor running to completion, burning runner minutes and
+# (worse) cache-write slots against the repo's 10 GB budget.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Default-deny: every job reads source via actions/checkout. No job needs
 # to write to issues, PRs, releases, packages, etc. Per-job overrides go
 # at the job level if ever required.
@@ -20,6 +27,14 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   SQLX_OFFLINE: "true"
+  # Full DWARF costs ~25% of compile wall-clock and inflates the target dir from
+  # 19 GB to 54 GB (measured, `--workspace --all-targets --features GATE_FEATURES`).
+  # rust-cache then compresses ~900 MB per job instead of ~320 MB, and ten of those
+  # blow the 10 GB per-repo cache cap, which is what evicted the build and lint
+  # caches on every run. line-tables-only keeps file/line in panics and backtraces
+  # and only drops the variable-level DWARF a debugger would attach for. Set here
+  # rather than in [profile.dev] so local builds keep full debug info.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
   # Every marker feature that gates a [[test]] target via required-features,
   # plus embed-ui. Used by the lint and build jobs so `--all-targets` really
   # means all targets. Static value — no workflow-context interpolation.
@@ -85,8 +100,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache: true
-          cache-workspaces: ". -> target"
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -95,24 +116,10 @@ jobs:
           cache: npm
           cache-dependency-path: crates/runtara-server/frontend/package-lock.json
 
-      - name: Add Cargo bin to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Cache wasm-pack binary
-        id: cache-wasm-pack
-        uses: actions/cache@v4
+      - name: Install wasm-pack (prebuilt)
+        uses: taiki-e/install-action@v2
         with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.ImageOS }}-${{ runner.arch }}-${{ env.WASM_PACK_VERSION }}
-
-      - name: Install wasm-pack
-        run: |
-          if command -v wasm-pack >/dev/null 2>&1 \
-            && wasm-pack --version | grep -q "wasm-pack ${WASM_PACK_VERSION}"; then
-            echo "wasm-pack ${WASM_PACK_VERSION} already installed"
-          else
-            cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked --force
-          fi
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
 
       - name: Build frontend (embedded UI)
         working-directory: crates/runtara-server/frontend
@@ -144,8 +151,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache: true
-          cache-workspaces: ". -> target"
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download frontend (embedded UI)
         uses: actions/download-artifact@v4
@@ -178,8 +191,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache: true
-          cache-workspaces: ". -> target"
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download frontend (embedded UI)
         uses: actions/download-artifact@v4
@@ -192,18 +211,8 @@ jobs:
           cargo build --workspace --all-targets \
             --features "$GATE_FEATURES"
 
-      - name: Save build cache
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
-
   test-sdk:
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -212,22 +221,28 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run runtara-sdk tests
         run: cargo test -p runtara-sdk
 
   test-workflows:
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -236,22 +251,28 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run runtara-workflows tests
         run: cargo test -p runtara-workflows
 
   test-core:
     runs-on: ubuntu-latest
-    needs: build
 
     services:
       postgres:
@@ -275,15 +296,22 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run runtara-core tests
         env:
@@ -292,7 +320,6 @@ jobs:
 
   test-server:
     runs-on: ubuntu-latest
-    needs: build
 
     services:
       postgres:
@@ -325,15 +352,22 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The service container creates only POSTGRES_DB. The runtime schema needs
       # a database of its own — see the note on TEST_RUNTARA_DATABASE_URL below.
@@ -373,7 +407,6 @@ jobs:
 
   test-environment:
     runs-on: ubuntu-latest
-    needs: build
 
     services:
       postgres:
@@ -397,15 +430,22 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run runtara-environment tests
         env:
@@ -432,7 +472,6 @@ jobs:
   # Service-bound integration targets stay in their own jobs below.
   test-units:
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -441,15 +480,22 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Every crate's lib target, workspace-wide, one cargo invocation.
       - name: Run all workspace unit tests
@@ -474,7 +520,6 @@ jobs:
   # because the suites share container ports and the connection tables.
   test-connections:
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -483,15 +528,22 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache: false
+
+      # Under resolver v2 a `-p <crate> --features …` invocation resolves features
+      # over that crate's subgraph, which differs from the workspace-wide
+      # resolution `build` uses. Verified: this job rebuilt 80 third-party crates
+      # (wasmtime, cranelift, sqlx, openssl) straight after restoring a 1.3 GB
+      # target dir `build` had produced minutes earlier in the same run. A cache
+      # keyed on the build job's resolution can never serve these jobs, so each
+      # keeps its own job-scoped key instead.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run runtara-connections tests
         run: cargo test -p runtara-connections -- --test-threads=1
@@ -507,41 +559,17 @@ jobs:
         with:
           submodules: true
 
-      - name: Add Cargo bin to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Cache wit-deps binary
-        id: cache-wit-deps
-        uses: actions/cache@v4
+      # These were `cargo install`-from-source behind an actions/cache of the
+      # built binary. Both caches are only a few MB, which made them the first
+      # things evicted once the repo went over its 10 GB budget — so the fallback
+      # ran on nearly every run: 89s for wit-deps plus 128s for wasm-tools, on the
+      # wit-package -> components-build critical path. Prebuilt downloads are a
+      # few seconds and cannot be evicted. install-action falls back to
+      # cargo-binstall, then to a source build, for anything it has no binary for.
+      - name: Install WIT tooling (prebuilt)
+        uses: taiki-e/install-action@v2
         with:
-          path: ~/.cargo/bin/wit-deps
-          key: wit-deps-${{ runner.os }}-${{ runner.arch }}-${{ env.WIT_DEPS_VERSION }}
-
-      - name: Install wit-deps
-        if: steps.cache-wit-deps.outputs.cache-hit != 'true'
-        run: |
-          if command -v wit-deps >/dev/null 2>&1; then
-            echo "wit-deps already installed"
-          else
-            cargo install wit-deps-cli --version "$WIT_DEPS_VERSION" --locked
-          fi
-
-      - name: Cache wasm-tools binary
-        id: cache-wasm-tools
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/wasm-tools
-          key: wasm-tools-${{ runner.os }}-${{ runner.arch }}-${{ env.WASM_TOOLS_VERSION }}
-
-      - name: Install wasm-tools
-        if: steps.cache-wasm-tools.outputs.cache-hit != 'true'
-        run: |
-          if command -v wasm-tools >/dev/null 2>&1 \
-            && wasm-tools --version | grep -q "wasm-tools ${WASM_TOOLS_VERSION}"; then
-            echo "wasm-tools ${WASM_TOOLS_VERSION} already installed"
-          else
-            cargo install wasm-tools --version "$WASM_TOOLS_VERSION" --locked
-          fi
+          tool: wasm-tools@${{ env.WASM_TOOLS_VERSION }},wit-deps-cli@${{ env.WIT_DEPS_VERSION }}
 
       - name: Lock and resolve WIT dependencies
         working-directory: crates/runtara-agent-wit
@@ -567,8 +595,14 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: wasm32-wasip2
-          cache: true
-          cache-workspaces: ". -> target"
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Only main writes. PR runs read main's cache and never add to the
+          # 10 GB per-repo budget — the churn that was evicting these caches
+          # into partial matches ("full match: false") on nearly every run.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build all agent components + emit sidecar meta.json
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ permissions:
   contents: write
   packages: write
 
+# Serialise releases for a given ref. Deliberately NOT cancel-in-progress:
+# interrupting a run mid-publish can leave a partial GitHub Release or a GHCR
+# manifest referencing images that were never pushed. Queue instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -26,12 +33,112 @@ env:
   WASM_PACK_VERSION: "0.13.1"
 
 jobs:
+  # Built once and shared, exactly as ci.yml's frontend-embed job does. Was
+  # inside every bundle job (~128s x 3 platforms), even though the output is
+  # identical across them.
+  #
+  # Carries dist/ AND src/wasm/validation/ on purpose: runtara-server's build.rs
+  # re-derives the validation-WASM fingerprint and, if it disagrees, shells out to
+  # wasm-pack and re-runs `npm run build` itself. Shipping the fingerprint keeps
+  # the consumers on the up-to-date path, so they need neither Node nor wasm-pack.
+  frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-frontend
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: crates/runtara-server/frontend/.node-version
+          cache: npm
+          cache-dependency-path: crates/runtara-server/frontend/package-lock.json
+
+      - name: Install wasm-pack (prebuilt)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@${{ env.WASM_PACK_VERSION }}
+
+      - name: Build frontend
+        working-directory: crates/runtara-server/frontend
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Upload frontend
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-frontend
+          path: |
+            crates/runtara-server/frontend/dist/
+            crates/runtara-server/frontend/src/wasm/validation/
+          if-no-files-found: error
+          retention-days: 1
+
+  # The agent/workflow components target wasm32-wasip2, so one build serves all
+  # three platforms. Previously this ran *after* the server build inside each
+  # bundle job — 114s of components plus 160s of emit-meta on the critical path,
+  # despite depending on nothing the server build produces.
+  #
+  # emit-meta is the expensive half: it compiles all 27 agent crates a second time
+  # for the host target to read their macro-emitted metadata.
+  components:
+    name: Build WASM Components
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip2
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-components
+
+      - name: Build agent components + emit sidecar meta.json
+        env:
+          RUNTARA_NO_INSTALL_TOOLS: "1"
+        run: scripts/build-agent-components.sh
+
+      - name: Verify every component + meta.json is present
+        run: |
+          expected=$(ls -d crates/agents/runtara-agent-*/ | wc -l)
+          wasm_count=$(find target/wasm32-wasip2/release -maxdepth 1 -name 'runtara_agent_*.wasm' | wc -l)
+          meta_count=$(find target/wasm32-wasip2/release -maxdepth 1 -name 'runtara_agent_*.meta.json' | wc -l)
+          echo "expected=$expected wasm=$wasm_count meta=$meta_count"
+          test "$wasm_count" -eq "$expected"
+          test "$meta_count" -eq "$expected"
+
+      - name: Upload WASM components
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-components
+          path: |
+            target/wasm32-wasip2/release/*.wasm
+            target/wasm32-wasip2/release/*.meta.json
+          if-no-files-found: error
+          retention-days: 1
+
   bundle:
     name: Build Bundle (${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    env:
-      CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+    needs: [frontend, components]
     strategy:
       fail-fast: false
       matrix:
@@ -71,39 +178,40 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-bin: false
+          cache: false
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      # Replaces sccache, which was contributing nothing. It was wired as
+      # CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER — that only wraps the 52 workspace
+      # crates, never the 761 dependencies where 388s of this build goes — and the
+      # few entries it did write were evicted by the repo's over-budget Actions
+      # cache before the next release could read them. Its own post-step
+      # --show-stats reported "Cache hits 0 ... hit rate 0.00 %" on every release,
+      # having spent 17.5s writing them. rust-cache is the mechanism ci.yml already
+      # uses, is predictable in size, and covers exactly that dependency phase.
+      - uses: Swatinem/rust-cache@v2
         with:
-          node-version-file: crates/runtara-server/frontend/.node-version
-          cache: npm
-          cache-dependency-path: crates/runtara-server/frontend/package-lock.json
+          shared-key: release-bundle-${{ matrix.os }}-${{ matrix.arch }}
 
-      - name: Add Cargo bin to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Cache wasm-pack binary
-        id: cache-wasm-pack
-        uses: actions/cache@v4
+      # Node and wasm-pack are gone from this job: the frontend arrives prebuilt,
+      # fingerprint included, so build.rs stays on its up-to-date path.
+      - name: Download frontend
+        uses: actions/download-artifact@v4
         with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.ImageOS }}-${{ runner.arch }}-${{ env.WASM_PACK_VERSION }}
+          name: release-frontend
+          path: crates/runtara-server/frontend
 
-      - name: Install wasm-pack
-        run: |
-          if command -v wasm-pack >/dev/null 2>&1 \
-            && wasm-pack --version | grep -q "wasm-pack ${WASM_PACK_VERSION}"; then
-            echo "wasm-pack ${WASM_PACK_VERSION} already installed"
-          else
-            cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked --force
-          fi
+      - name: Download WASM components
+        uses: actions/download-artifact@v4
+        with:
+          name: release-components
+          path: target/wasm32-wasip2/release
 
       - name: Build bundle
-        run: ./scripts/build-bundle.sh --output-dir target/bundle --version "${{ steps.get_version.outputs.version }}"
+        run: |
+          ./scripts/build-bundle.sh \
+            --skip-frontend --skip-components \
+            --output-dir target/bundle \
+            --version "${{ steps.get_version.outputs.version }}"
 
       # The bundle's agent-component gate lives in
       # scripts/build-bundle.sh, which invokes scripts/build-agent-components.sh

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -16,6 +16,8 @@
 # Usage:
 #   ./scripts/build-bundle.sh                   # build for the current host
 #   ./scripts/build-bundle.sh --skip-build      # assemble from existing target/release
+#   ./scripts/build-bundle.sh --skip-frontend   # frontend/dist already built elsewhere
+#   ./scripts/build-bundle.sh --skip-components # wasm32-wasip2 components built elsewhere
 #   ./scripts/build-bundle.sh --output-dir /tmp # write bundle to custom dir
 #
 # Prerequisites (BUILD-time only — used to build the agent/shared components):
@@ -32,6 +34,12 @@ cd "$ROOT_DIR"
 # ─── Defaults ────────────────────────────────────────────────────────────────
 
 SKIP_BUILD=0
+# Granular skips, so CI can build the frontend and the (architecture-independent)
+# WASM components in jobs that run alongside the server build instead of after it.
+# Each still runs the same existence check --skip-build does, so a missing input
+# fails loudly here rather than producing a bundle with a hole in it.
+SKIP_FRONTEND=0
+SKIP_COMPONENTS=0
 OUTPUT_DIR="${ROOT_DIR}/target/bundle"
 DOWNLOAD_CACHE="${HOME}/.cache/runtara-bundle-build"
 
@@ -40,6 +48,8 @@ DOWNLOAD_CACHE="${HOME}/.cache/runtara-bundle-build"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --skip-build)      SKIP_BUILD=1; shift ;;
+        --skip-frontend)   SKIP_FRONTEND=1; shift ;;
+        --skip-components) SKIP_COMPONENTS=1; shift ;;
         --output-dir)      OUTPUT_DIR="$2"; shift 2 ;;
         --output-dir=*)    OUTPUT_DIR="${1#*=}"; shift ;;
         --version)         RUNTARA_VERSION_OVERRIDE="$2"; shift 2 ;;
@@ -115,13 +125,13 @@ build_frontend() {
     local frontend_dir="${ROOT_DIR}/crates/runtara-server/frontend"
     local dist_index="${frontend_dir}/dist/index.html"
 
-    if [ "$SKIP_BUILD" = "1" ]; then
+    if [ "$SKIP_BUILD" = "1" ] || [ "$SKIP_FRONTEND" = "1" ]; then
         if [ ! -f "$dist_index" ]; then
             echo "Error: --skip-build but ${dist_index} not found" >&2
             echo "Run (cd ${frontend_dir} && npm ci && npm run build) first." >&2
             exit 1
         fi
-        info "Skipping frontend build (--skip-build), using existing ${dist_index}"
+        info "Skipping frontend build, using existing ${dist_index}"
         return
     fi
 
@@ -159,7 +169,7 @@ build_server() {
 # wit_bindgen::generate! macro) — no cargo-component needed.
 
 build_agent_components() {
-    if [ "$SKIP_BUILD" = "1" ]; then
+    if [ "$SKIP_BUILD" = "1" ] || [ "$SKIP_COMPONENTS" = "1" ]; then
         if ! find "${TARGET_DIR}/wasm32-wasip2/release" -maxdepth 1 \
                 -name 'runtara_agent_*.wasm' 2>/dev/null | grep -q .; then
             echo "Error: --skip-build but no built agent components found at \
@@ -172,7 +182,7 @@ ${TARGET_DIR}/wasm32-wasip2/release/runtara_agent_*.wasm" >&2
 ${TARGET_DIR}/wasm32-wasip2/release/runtara_workflow_*.wasm" >&2
             exit 1
         fi
-        info "Skipping agent component build (--skip-build)"
+        info "Skipping agent component build, using existing components"
         return
     fi
 


### PR DESCRIPTION
## What this is

CI runs a median of **25 minutes** and release **28**. Almost none of that is the compiler being slow. Two measured causes account for most of it, and neither needed a faster machine to fix.

## Cause 1 — the cache budget is 50% over the hard limit

15.0 GB of Actions caches against GitHub's 10 GB per-repo cap. Every surviving entry belonged to a *test* job (~900 MB each), plus one 1.3 GB `Linux-cargo-<sha>` that only its own run could ever read. Absent from the cache list entirely: `v0-rust-build-*`, `v0-rust-lint-*`, `wit-deps-*`, `wasm-tools-*`.

The `build` job's own history shows it, and the distribution is **bimodal, not noisy**:

```
cache hit   202 209 209 214 219 219 221 226 236          (9 runs)
            ·············· nothing at all ··············
cache miss  654 678 709 760 761 786 791 878 885 885
            899 910 913 920 937 963                      (16 runs)
```

A 36% hit rate, and no run has ever landed in the 418s gap. When the cache survives, the job already finishes in 202s. This PR makes that the normal case rather than the lucky one.

## Cause 2 — a workspace cache cannot serve per-crate test jobs

`build` compiles at `--workspace --features $GATE_FEATURES`. Each test job then asks for its own narrower set, which under `resolver = "2"` resolves features over that crate's subgraph — a different resolution, different fingerprints. Verified from the logs: `test-server` rebuilt **80 third-party crates** (wasmtime, cranelift, sqlx, openssl) immediately after restoring the 1.3 GB target dir `build` had produced minutes earlier in the same run.

So the per-SHA cache never helped anyone, and `needs: build` was buying the test jobs nothing but a place in a queue. Both are gone.

## Changes

| file | change |
|---|---|
| `ci.yml` | `concurrency` + `cancel-in-progress`; `CARGO_PROFILE_DEV_DEBUG=line-tables-only`; per-SHA `actions/cache` deleted; explicit `rust-cache` with `save-if: main` on all 11 Rust jobs; `needs: build` dropped from the 7 test jobs; prebuilt `wasm-tools` / `wit-deps` / `wasm-pack` |
| `release.yml` | new `frontend` + `components` jobs running in parallel, feeding `bundle` as artifacts; sccache → `rust-cache`; `concurrency` with `cancel-in-progress: false` |
| `build-bundle.yml` | same sccache fix, read-only cache |
| `build-bundle.sh` | `--skip-frontend` / `--skip-components`, each keeping the existing existence check |

### `line-tables-only`

Measured on a clean 8-vCPU/16 GB box, `--workspace --all-targets --features $GATE_FEATURES`:

| | cold build | target dir |
|---|---|---|
| `debug = true` (default) | 569s | 54 GB |
| `debug = "line-tables-only"` | **425s** | **19 GB** |

It keeps file and line numbers in panics and backtraces, dropping only the variable-level DWARF a debugger would attach for. Set as a workflow `env:` var rather than in `[profile.dev]`, so local builds keep full debug info. The 65% smaller target dir is what brings the cache steady state to ~3.2 GB.

### sccache is removed, not repaired

Its own post-step `--show-stats` has reported this on every release:

```
Cache hits                             0
Cache hits rate                     0.00 %
compile_requests                     168
requests_not_cacheable               140
not_cached      {"crate-type": 123, "missing input": 10}
```

Two faults stacked: wired as `CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER`, which only wraps the 52 workspace crates and never the 761 dependencies where the 388s actually goes; and its few writes were evicted by cause 1 before the next release could read them. Fixing it to `RUSTC_WRAPPER` would work, but it's a second cache mechanism competing for the same 10 GB budget with unpredictable size, and 123/168 of its requests were rejected on `crate-type` regardless. `rust-cache` is already used throughout `ci.yml`, is ~500 MB per platform, and covers exactly that dependency phase.

## Risk

**No `cargo test`, `clippy`, `build` or `fmt` command changed** — verified by grepping the diff. Features, service containers and `--test-threads=1` serialization are byte-identical, so this cannot change what passes or fails.

I dropped a `cargo-nextest` migration from my own plan after finding 21 doctests currently running (13 in `runtara-sdk`, 7 in `runtara-server`, 1 in `runtara-workflows`) that nextest does not run. That would have been a silent coverage regression of the same kind the comments in `ci.yml` already record twice.

Removing `needs: build` does mean a compile error now fails 7 jobs instead of skipping them — more runner minutes on a broken commit, faster feedback on a good one.

## Reviewing this

**The first runs will be slow, and that is expected.** `rust-cache` includes `CARGO_*` env vars in its key, so adding `CARGO_PROFILE_DEV_DEBUG` invalidates every existing cache. Sequence: first run on this branch cold, first run on `main` after merge cold and then writes the new caches, everything after that warm. Judge it on run three, not run one.

The 15 GB of now-dead caches keep counting against the cap until they age out (7 days). Purging them lets the new scheme start clean; I have not done that since it affects everyone's next runs.

## Expected

- **CI: ~505s.** Today's best case is already 670s while still paying every tax above.
- **Release: ~1024s (17 min), down from a 1706s median — a 41% cut, but still over 10 minutes.** I want to be explicit that my earlier estimate of ~713s was wrong: it subtracted the components and frontend costs as if parallelising made them vanish, when they only move, and `frontend` still gates the server build because `embed-ui` needs `dist` at compile time.

What remains in release is work, not waste: the `runtara-server` crate compile (378s, with a ~100s serial floor measured by an Amdahl fit across `-j2/-j4/-j8` at 226/166/133s), the smoke suite (174s), and per-job overhead. Getting release under 10 minutes needs larger runners or the crate split in SYN-651 — that is now measured rather than asserted.

Neither projection has been validated against a real run; a push is the only real test.

