### PR TITLE
Restore the edited migration and stop swallowing migration failures

### DIFF
--- a/crates/runtara-server/migrations/20260716000000_workflow_slug.sql
+++ b/crates/runtara-server/migrations/20260716000000_workflow_slug.sql
@@ -14,7 +14,7 @@ ALTER TABLE workflows ADD COLUMN IF NOT EXISTS slug TEXT;
 
 -- FULL unique index (not partial on deleted_at IS NULL): a soft-deleted
 -- workflow RESERVES its slug — a published capability id must never be
--- silently reusable by a different workflow (slug plan,
+-- silently reusable by a different workflow (docs/workflow-slug-plan.md,
 -- decision 4). Multiple NULLs are fine (not-yet-backfilled / legacy-deleted
 -- rows don't collide).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_tenant_slug

--- a/crates/runtara-server/migrations/README.md
+++ b/crates/runtara-server/migrations/README.md
@@ -1,0 +1,54 @@
+# Server migrations
+
+## An applied migration is immutable — comments included
+
+sqlx stores a checksum of every migration it applies. Changing a file that has
+already run makes it refuse *the entire remaining chain*, not just that file, so
+every migration added afterwards silently never applies.
+
+This has happened once. A commit tidying stale documentation links edited one
+comment line in `20260716000000_workflow_slug.sql`:
+
+```diff
+--- silently reusable by a different workflow (docs/workflow-slug-plan.md,
++-- silently reusable by a different workflow (slug plan,
+```
+
+That one line changed the file's checksum. Production had already applied the
+original, so from the next deploy onwards sqlx refused to migrate, and the three
+migrations added after it — including the `execution_outbox` table an every-250ms
+worker depends on — were never created. It went unnoticed for a week because the
+server logged a warning and started anyway.
+
+So: **never edit a migration that may have been applied anywhere.** Not the SQL,
+not the comments, not the whitespace. If a comment is wrong or names a document
+that no longer exists, leave it — the file is a historical record of what ran,
+not documentation to maintain. Correct it in a *new* migration, or in code.
+
+## If you have already broken a checksum
+
+Restore the file to its original bytes:
+
+```sh
+git log --follow --diff-filter=A -- crates/runtara-server/migrations/<file>   # find the adding commit
+git show <commit>:crates/runtara-server/migrations/<file> > crates/runtara-server/migrations/<file>
+shasum -a 384 crates/runtara-server/migrations/<file>                          # must match _sqlx_migrations
+```
+
+Compare against what the database stored:
+
+```sql
+SELECT version, description, encode(checksum, 'hex') FROM _sqlx_migrations ORDER BY version;
+```
+
+Editing `_sqlx_migrations.checksum` to match the new file also works, but hides
+the drift and has to be repeated in every environment. Restoring the file fixes
+all of them at once.
+
+## Failures are fatal
+
+Both migration paths (`main.rs` at startup and `run_server_migrations`) now abort
+rather than warn. A server that boots against a schema it does not expect answers
+health checks while failing exactly the requests the missing migration was for,
+which is what made the incident above invisible. `SKIP_MIGRATIONS=true` still
+starts without migrating, for deployments that mean it.

--- a/crates/runtara-server/src/main.rs
+++ b/crates/runtara-server/src/main.rs
@@ -66,17 +66,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Skipping database migrations (SKIP_MIGRATIONS=true)");
     } else {
         println!("Running database migrations...");
-        match sqlx::migrate!("./migrations")
+        // A failed migration is fatal. Booting anyway produces a server whose
+        // code expects tables the database does not have: it answers health
+        // checks, serves most requests, and fails only on whatever the missing
+        // migration was for -- which is how a checksum mismatch went unnoticed
+        // for a week while every migration behind it silently never applied.
+        // Deployments that genuinely need to start without migrating have
+        // SKIP_MIGRATIONS for that, and say so on purpose.
+        if let Err(e) = sqlx::migrate!("./migrations")
             .set_ignore_missing(true)
             .run(&pool)
             .await
         {
-            Ok(_) => println!("Migrations completed"),
-            Err(e) => {
-                eprintln!("Warning: Migration failed: {}", e);
-                println!("Continuing without migrations...");
-            }
+            eprintln!("Migration failed: {e}");
+            eprintln!(
+                "Refusing to start: the schema is not what this build expects. \
+                 If a migration was edited after being applied, restore its \
+                 original bytes -- an applied migration is immutable, comments \
+                 included. Set SKIP_MIGRATIONS=true to start anyway."
+            );
+            std::process::exit(1);
         }
+        println!("Migrations completed");
     }
 
     runtara_server::start(pool).await

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -1189,7 +1189,7 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to connect to object model database");
 
     // Run server migrations (workflows, api_keys, etc.) against the main pool
-    run_server_migrations(&pool).await;
+    run_server_migrations(&pool).await?;
 
     // Create ObjectStoreManager from the pool (single-database mode for now)
     let object_store_manager = Arc::new(
@@ -2933,7 +2933,7 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 /// These run against the main server pool (OBJECT_MODEL_DATABASE_URL) which holds
 /// all server-managed tables. Uses ignore_missing since this pool may share the
 /// _sqlx_migrations table with other migrators.
-async fn run_server_migrations(pool: &PgPool) {
+async fn run_server_migrations(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
     #[derive(Debug)]
     struct Migrations(Vec<sqlx::migrate::Migration>);
 
@@ -2958,20 +2958,21 @@ async fn run_server_migrations(pool: &PgPool) {
     println!("Running server migrations...");
     let source = sqlx::migrate!("./migrations");
     let migrations: Vec<sqlx::migrate::Migration> = source.iter().cloned().collect();
-    match sqlx::migrate::Migrator::new(Migrations(migrations)).await {
-        Ok(mut migrator) => {
-            migrator.set_ignore_missing(true);
-            if let Err(e) = migrator.run(pool).await {
-                eprintln!("⚠ Server migrations failed: {e}");
-                eprintln!("  Some features may not work until migrations are applied.");
-            } else {
-                println!("✓ Server migrations completed");
-            }
-        }
-        Err(e) => {
-            eprintln!("⚠ Failed to initialize server migrator: {e}");
-        }
-    }
+    let mut migrator = sqlx::migrate::Migrator::new(Migrations(migrations))
+        .await
+        .map_err(|e| format!("failed to initialize the server migrator: {e}"))?;
+    migrator.set_ignore_missing(true);
+    migrator.run(pool).await.map_err(|e| {
+        format!(
+            "server migrations failed: {e}. The schema is not what this build \
+             expects, so starting would leave features silently broken rather \
+             than visibly down. If a migration was edited after being applied, \
+             restore its original bytes -- an applied migration is immutable, \
+             comments included."
+        )
+    })?;
+    println!("✓ Server migrations completed");
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Production has applied no migrations since **27 Aug**. The `execution_outbox` errors are the first symptom loud enough to notice, not the problem.

## Root cause

`c3f7ced9` ("Remove references to non-existing documents") changed one comment line in `20260716000000_workflow_slug.sql`, a migration that had already been applied:

```diff
--- silently reusable by a different workflow (docs/workflow-slug-plan.md,
+-- silently reusable by a different workflow (slug plan,
```

sqlx checksums migration files and refuses **the entire remaining chain** when one changes. Checksums confirm it:

```
prod _sqlx_migrations : d9bac1808b927c64
file at HEAD          : 682cfff179d4cb0b   ← the comment edit
file as first added   : d9bac1808b927c64   ← what this PR restores
```

## Blast radius

`smo_runtime` is stuck at `20260813000000`. Three migrations never applied:

| Migration | |
|---|---|
| `20260826000000_drop_server_execution_tables` | missing |
| `20260902000000_workflow_compilation_track_events` | missing |
| `20260903000004_execution_outbox` | missing — the visible error |

So #217's durable execution intake has never worked in production. It stayed invisible because **any freshly created database applies the edited file cleanly** — CI, local dev and e2e all pass. Only long-lived databases that applied the original break.

## Why a week passed

Both migration paths logged and continued:

```rust
Err(e) => {
    eprintln!("Warning: Migration failed: {}", e);
    println!("Continuing without migrations...");   // ← boots anyway
}
```

That yields a server which answers health checks and serves most requests while failing exactly the ones the missing tables were for.

## The fix

1. **Restore the migration's original bytes.** Its checksum then matches what production already stored, and the three pending migrations apply on next boot. Fixes every environment at once, with no database surgery.
2. **Both migration paths now abort** instead of warning. `SKIP_MIGRATIONS=true` still starts without migrating, for deployments that mean it.
3. **`migrations/README.md`** records why an applied migration is immutable, comments included, and how to recover a broken checksum.

The restored comment names `docs/workflow-slug-plan.md`, which no longer exists. That is the trade, and the README states it: a migration is a record of what ran, not documentation to keep current.

## Verification

- **The restore was proven end to end by accident.** A local database sat at `20260813000000` — exactly production's version. Booting the server with the file restored applied all three pending migrations and created `execution_outbox` and `execution_requests`.
- **The fatal path was verified after a rebuild**, since `sqlx::migrate!` bakes migrations into the binary at compile time — editing the file post-build proves nothing. With drift compiled in, against a database holding the original checksum:

```
EXIT=1
Migration failed: migration 20260716000000 was previously applied but has been modified
Refusing to start: the schema is not what this build expects. ...
```

- `cargo clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean.

## Deploying this

A redeploy is enough — the restored file lets the three pending migrations apply on boot. Worth watching that boot: with failures now fatal, any *other* environment carrying a different drift will refuse to start rather than hide it. That is the intent, but it is better discovered on purpose than during a rollout.