### PR TITLE
Make lifecycle acknowledgments atomic and cancel parked instances without relaunch

### DIFF
--- a/crates/runtara-component-host/src/runtime_host.rs
+++ b/crates/runtara-component-host/src/runtime_host.rs
@@ -33,11 +33,11 @@ use crate::workflow::WorkflowState;
 
 /// Fully-qualified component import name of the runtime interface.
 ///
-/// Must match `runtara:workflow-runtime@0.1.0`'s `runtime` interface as
+/// Must match `runtara:workflow-runtime@0.2.0`'s `runtime` interface as
 /// emitted into the workflow world by `runtara-workflows::direct_wasm`
 /// (`emit_world_wit`) — the Spike-B integration test asserts a HostImport
 /// composition surfaces exactly this name.
-pub const RUNTIME_INTERFACE_NAME: &str = "runtara:workflow-runtime/runtime@0.1.0";
+pub use runtara_workflow_wit::RUNTIME_INTERFACE_NAME;
 
 /// Checkpoint id the guest runtime component uses for plain `durable-sleep`
 /// (see `runtara-workflow-runtime/src/lib.rs::durable_sleep`). The host glue
@@ -57,6 +57,9 @@ pub struct RuntimeSignalInfo {
     /// One of "cancel" | "pause" | "resume" | "shutdown".
     #[component(name = "signal-type")]
     pub signal_type: String,
+    /// Identity of the delivered lifecycle command.
+    #[component(name = "command-id")]
+    pub command_id: String,
     /// Signal payload bytes.
     pub payload: Vec<u8>,
     /// Checkpoint the signal targets, when scoped.
@@ -147,7 +150,11 @@ pub trait RuntimeHost: Send + Sync {
     ) -> Result<RuntimeCheckpointResult, String>;
     /// React to a pending signal reported by a checkpoint result; true when a
     /// stop-like signal was handled and the guest should return.
-    async fn handle_checkpoint_signal(&self, signal_type: String) -> Result<bool, String>;
+    async fn handle_checkpoint_signal(
+        &self,
+        signal_type: String,
+        command_id: String,
+    ) -> Result<bool, String>;
     /// Record a retry attempt (write-only audit trail).
     async fn record_retry_attempt(
         &self,
@@ -368,9 +375,14 @@ pub fn add_runtime_to_linker(linker: &mut Linker<WorkflowState>) -> anyhow::Resu
 
     inst.func_wrap_async(
         "handle-checkpoint-signal",
-        |mut store: StoreContextMut<'_, WorkflowState>, (signal_type,): (String,)| {
+        |mut store: StoreContextMut<'_, WorkflowState>,
+         (signal_type, command_id): (String, String)| {
             let host = require_host(&mut store);
-            Box::new(async move { Ok((host?.handle_checkpoint_signal(signal_type).await,)) })
+            Box::new(async move {
+                Ok((host?
+                    .handle_checkpoint_signal(signal_type, command_id)
+                    .await,))
+            })
         },
     )?;
 

--- a/crates/runtara-core/src/instance_handlers/checkpoint.rs
+++ b/crates/runtara-core/src/instance_handlers/checkpoint.rs
@@ -160,6 +160,7 @@ async fn get_pending_signal(
         .get_pending_signal(instance_id)
         .await?
         .map(|signal| Signal {
+            command_id: signal.command_id,
             instance_id: instance_id.to_string(),
             signal_type: SignalType::from(signal.signal_type).into(),
             payload: signal.payload.unwrap_or_default(),

--- a/crates/runtara-core/src/instance_handlers/mock_persistence.rs
+++ b/crates/runtara-core/src/instance_handlers/mock_persistence.rs
@@ -406,6 +406,15 @@ impl Persistence for MockPersistence {
         Ok(true)
     }
 
+    async fn cancel_suspended_instances(
+        &self,
+        _instance_id: Option<&str>,
+        _limit: i64,
+    ) -> std::result::Result<Vec<crate::persistence::CancelledInstance>, crate::error::CoreError>
+    {
+        Ok(Vec::new())
+    }
+
     async fn insert_custom_signal(
         &self,
         _instance_id: &str,

--- a/crates/runtara-core/src/instance_handlers/mock_persistence.rs
+++ b/crates/runtara-core/src/instance_handlers/mock_persistence.rs
@@ -169,6 +169,7 @@ pub fn make_checkpoint(instance_id: &str, checkpoint_id: &str, state: &[u8]) -> 
 /// Build an unacknowledged `SignalRecord` with no payload.
 pub fn make_signal(instance_id: &str, signal_type: crate::domain::SignalType) -> SignalRecord {
     SignalRecord {
+        command_id: uuid::Uuid::new_v4().to_string(),
         instance_id: instance_id.to_string(),
         signal_type,
         payload: None,
@@ -362,9 +363,47 @@ impl Persistence for MockPersistence {
         Ok(self.signals.lock().unwrap().get(instance_id).cloned())
     }
 
-    async fn acknowledge_signal(&self, instance_id: &str) -> std::result::Result<(), CoreError> {
-        self.signals.lock().unwrap().remove(instance_id);
-        Ok(())
+    async fn acknowledge_signal(
+        &self,
+        instance_id: &str,
+        command_id: &str,
+        signal_type: crate::domain::SignalType,
+    ) -> std::result::Result<bool, CoreError> {
+        use crate::domain::SignalType;
+        let mut instances = self.instances.lock().unwrap();
+        let mut signals = self.signals.lock().unwrap();
+        let Some(signal) = signals.get(instance_id) else {
+            return Ok(false);
+        };
+        if signal.command_id != command_id || signal.signal_type != signal_type {
+            return Ok(false);
+        }
+        let instance =
+            instances
+                .get_mut(instance_id)
+                .ok_or_else(|| CoreError::InstanceNotFound {
+                    instance_id: instance_id.into(),
+                })?;
+        if instance.status.is_terminal() && signal_type != SignalType::Cancel {
+            return Ok(false);
+        }
+        match signal_type {
+            SignalType::Cancel => {
+                instance.status = CoreInstanceStatus::Cancelled;
+                instance.finished_at = Some(Utc::now());
+                instance.sleep_until = None;
+            }
+            SignalType::Pause | SignalType::Shutdown => {
+                instance.status = CoreInstanceStatus::Suspended;
+                instance.finished_at = Some(Utc::now());
+                instance.sleep_until = (signal_type == SignalType::Shutdown).then(Utc::now);
+                instance.termination_reason =
+                    (signal_type == SignalType::Shutdown).then(|| "shutdown_requested".into());
+            }
+            SignalType::Resume => {}
+        }
+        signals.remove(instance_id);
+        Ok(true)
     }
 
     async fn insert_custom_signal(

--- a/crates/runtara-core/src/instance_handlers/signal.rs
+++ b/crates/runtara-core/src/instance_handlers/signal.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Signal handlers: polling and acknowledgement.
 
+#[cfg(test)]
 use crate::domain::InstanceStatus as CoreInstanceStatus;
 #[cfg(test)]
 use crate::domain::SignalType as CoreSignalType;
 
 use anyhow::Result;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, instrument};
 
 use super::state::InstanceHandlerState;
 use super::types::{
     CustomSignal, PollSignalsRequest, PollSignalsResponse, Signal, SignalAck, SignalType,
 };
-use crate::persistence::CompleteInstanceParams;
 
 /// Handle signal polling request.
 ///
@@ -49,6 +49,7 @@ pub async fn handle_poll_signals(
         let signal_type = SignalType::from(sig.signal_type);
 
         Signal {
+            command_id: sig.command_id,
             instance_id: request.instance_id.clone(),
             signal_type: signal_type.into(),
             payload: sig.payload.unwrap_or_default(),
@@ -74,94 +75,24 @@ pub async fn handle_poll_signals(
     })
 }
 
-/// Handle signal acknowledgement (fire-and-forget).
-///
-/// Applies the signal's status transition — a cancel ack also moves the
-/// instance to `cancelled` — and only then marks the signal acknowledged, so a
-/// transition that fails leaves the signal pending to be retried rather than
-/// consumed.
-#[instrument(skip(state, ack), fields(
-    instance_id = %ack.instance_id,
-    signal_type = ?ack.signal_type(),
-))]
-pub async fn handle_signal_ack(state: &InstanceHandlerState, ack: SignalAck) -> Result<()> {
-    debug!(
-        signal_type = ?ack.signal_type,
-        acknowledged = ack.acknowledged,
-        "Received signal acknowledgement"
-    );
-
-    if ack.acknowledged {
-        // Handle signal-specific side effects
-        match ack.signal_type() {
-            SignalType::SignalCancel => {
-                // Update instance status to cancelled with finished_at
-                state
-                    .persistence
-                    .complete_instance(CompleteInstanceParams::new(
-                        &ack.instance_id,
-                        CoreInstanceStatus::Cancelled,
-                    ))
-                    .await?;
-                info!("Instance cancelled");
-            }
-            SignalType::SignalPause => {
-                // Update instance status to suspended
-                state
-                    .persistence
-                    .update_instance_status(&ack.instance_id, CoreInstanceStatus::Suspended, None)
-                    .await?;
-                info!("Instance paused/suspended");
-            }
-            SignalType::SignalResume => {
-                // Instance should resume execution
-                debug!("Resume signal acknowledged");
-            }
-            SignalType::SignalShutdown => {
-                // Suspend with termination_reason so the instance can be resumed
-                // after restart. Retain "suspended" status so heartbeat-monitor
-                // recovery treats it as a normal suspension.
-                state
-                    .persistence
-                    .complete_instance(
-                        CompleteInstanceParams::new(
-                            &ack.instance_id,
-                            CoreInstanceStatus::Suspended,
-                        )
-                        .with_termination("shutdown_requested", None),
-                    )
-                    .await?;
-                // Mark the instance as immediately due for wake so the wake
-                // scheduler relaunches it after the server restarts. Drain
-                // pauses the scheduler, so this cannot fire mid-shutdown.
-                if let Err(e) = state
-                    .persistence
-                    .set_instance_sleep(&ack.instance_id, chrono::Utc::now())
-                    .await
-                {
-                    warn!(error = %e, "Failed to schedule post-restart wake for shutdown suspend");
-                }
-                info!("Instance suspended for shutdown");
-            }
-        }
-
-        // Acknowledge last, once the status transition above has landed.
-        // Acknowledging first consumes the signal whether or not the
-        // transition succeeded, and callers log-and-continue on the error, so
-        // a transient persistence failure would leave an instance that was told
-        // to cancel recorded as a clean success: the guest's next poll would
-        // no longer see the signal, and the end-of-run cancel backstop would
-        // find nothing to enforce. Acking here instead leaves an unhandled
-        // signal pending, which is what both of those retry paths key on.
-        state
-            .persistence
-            .acknowledge_signal(&ack.instance_id)
-            .await?;
-    } else {
-        warn!("Signal was not acknowledged by instance");
+/// Acknowledge the delivered command and its lifecycle transition atomically.
+/// False means the receipt is stale or the requested transition is no longer valid.
+#[instrument(skip(state, ack), fields(instance_id = %ack.instance_id, command_id = %ack.command_id))]
+pub async fn handle_signal_ack(state: &InstanceHandlerState, ack: SignalAck) -> Result<bool> {
+    if !ack.acknowledged {
+        return Ok(false);
     }
-
-    Ok(())
+    let signal_type = match ack.signal_type {
+        0 => crate::domain::SignalType::Cancel,
+        1 => crate::domain::SignalType::Pause,
+        2 => crate::domain::SignalType::Resume,
+        3 => crate::domain::SignalType::Shutdown,
+        _ => anyhow::bail!("Unknown lifecycle signal type: {}", ack.signal_type),
+    };
+    Ok(state
+        .persistence
+        .acknowledge_signal(&ack.instance_id, &ack.command_id, signal_type)
+        .await?)
 }
 
 #[cfg(test)]
@@ -310,6 +241,12 @@ mod tests {
         let state = InstanceHandlerState::new(persistence.clone());
 
         let request = SignalAck {
+            command_id: persistence
+                .get_pending_signal("inst-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
             instance_id: "inst-1".to_string(),
             signal_type: SignalType::SignalCancel as i32,
             acknowledged: true,
@@ -342,6 +279,12 @@ mod tests {
         let state = InstanceHandlerState::new(persistence.clone());
 
         let ack = SignalAck {
+            command_id: persistence
+                .get_pending_signal("inst-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
             instance_id: "inst-1".to_string(),
             signal_type: SignalType::SignalCancel as i32,
             acknowledged: true,
@@ -375,6 +318,12 @@ mod tests {
         let state = InstanceHandlerState::new(persistence.clone());
 
         let ack = SignalAck {
+            command_id: persistence
+                .get_pending_signal("inst-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
             instance_id: "inst-1".to_string(),
             signal_type: SignalType::SignalShutdown as i32,
             acknowledged: true,

--- a/crates/runtara-core/src/instance_handlers/types.rs
+++ b/crates/runtara-core/src/instance_handlers/types.rs
@@ -121,6 +121,8 @@ pub struct CheckpointRequest {
 /// Signal forwarded from core to instance.
 #[derive(Debug, Clone)]
 pub struct Signal {
+    /// Identity of the delivered lifecycle command.
+    pub command_id: String,
     /// Instance identifier.
     pub instance_id: String,
     /// Signal type as integer (see `SignalType` enum values).
@@ -266,6 +268,8 @@ pub struct PollSignalsResponse {
 
 /// Signal acknowledgement.
 pub struct SignalAck {
+    /// Identity of the delivered lifecycle command.
+    pub command_id: String,
     /// Instance identifier.
     pub instance_id: String,
     /// Signal type as integer (see `SignalType` enum values).

--- a/crates/runtara-core/src/persistence/conformance.rs
+++ b/crates/runtara-core/src/persistence/conformance.rs
@@ -1051,3 +1051,103 @@ pub async fn run_lifecycle_command_sequence<P: Persistence>(backend: &P) {
         Status::Cancelled
     );
 }
+
+/// Parked cancellation is atomic, repeatable, and recoverable without a deadline.
+pub async fn run_parked_cancellation_sequence<P: Persistence>(backend: &P) {
+    use crate::domain::{InstanceStatus as Status, SignalType as Kind};
+    for deadline in [None, Some(Utc::now() + Duration::hours(24))] {
+        let id = Uuid::new_v4().to_string();
+        backend
+            .register_instance(&id, "park-contract")
+            .await
+            .unwrap();
+        backend
+            .update_instance_status(&id, Status::Running, None)
+            .await
+            .unwrap();
+        backend.insert_signal(&id, Kind::Cancel, b"").await.unwrap();
+        assert!(
+            backend
+                .cancel_suspended_instances(Some(&id), 1)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a running guest retains its command"
+        );
+        assert!(backend.get_pending_signal(&id).await.unwrap().is_some());
+        // Model a cancel arriving just before the guest parks.
+        backend
+            .update_instance_status(&id, Status::Suspended, None)
+            .await
+            .unwrap();
+        if let Some(deadline) = deadline {
+            backend.set_instance_sleep(&id, deadline).await.unwrap();
+        }
+        let cancelled = backend
+            .cancel_suspended_instances(Some(&id), 1)
+            .await
+            .unwrap();
+        assert_eq!(cancelled.len(), 1);
+        assert_eq!(cancelled[0].instance_id, id);
+        assert_eq!(cancelled[0].tenant_id, "park-contract");
+        let instance = backend.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(instance.status, Status::Cancelled);
+        assert!(instance.finished_at.is_some());
+        assert!(instance.sleep_until.is_none());
+        assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+        assert!(
+            backend
+                .cancel_suspended_instances(Some(&id), 1)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        // A park or wake retry that lost the race cannot put its deadline back.
+        backend
+            .set_instance_sleep(&id, Utc::now() + Duration::hours(1))
+            .await
+            .unwrap();
+        assert!(
+            backend
+                .get_instance(&id)
+                .await
+                .unwrap()
+                .unwrap()
+                .sleep_until
+                .is_none()
+        );
+    }
+    let id = Uuid::new_v4().to_string();
+    backend
+        .register_instance(&id, "park-recovery")
+        .await
+        .unwrap();
+    backend
+        .update_instance_status(&id, Status::Suspended, None)
+        .await
+        .unwrap();
+    backend.insert_signal(&id, Kind::Pause, b"").await.unwrap();
+    assert!(
+        backend
+            .cancel_suspended_instances(Some(&id), 1)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    backend.insert_signal(&id, Kind::Cancel, b"").await.unwrap();
+    assert!(
+        backend
+            .cancel_suspended_instances(None, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let recovered = backend
+        .cancel_suspended_instances(None, 1000)
+        .await
+        .unwrap();
+    assert!(
+        recovered.iter().any(|instance| instance.instance_id == id),
+        "recovery discovers parked cancellation without a sleep deadline"
+    );
+}

--- a/crates/runtara-core/src/persistence/conformance.rs
+++ b/crates/runtara-core/src/persistence/conformance.rs
@@ -488,7 +488,7 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
         .expect("signal should be pending after insert");
     assert_eq!(pending.signal_type, CoreSignalType::Cancel);
     backend
-        .acknowledge_signal(&instance_id)
+        .acknowledge_signal(&instance_id, &pending.command_id, pending.signal_type)
         .await
         .expect("acknowledge_signal failed");
     // The ack consumes the signal: a second read must come back empty.
@@ -574,6 +574,12 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
     );
     // Bind the variant so the match remains type-checked when we add status-filtered cases.
     let _ = PairedRecordStatus::Running;
+
+    // Restore running for the independent sleep contract after cancellation.
+    backend
+        .update_instance_status(&instance_id, CoreInstanceStatus::Running, None)
+        .await
+        .unwrap();
 
     // --- sleep cycle --------------------------------------------------------
     // Verifies both the "not due yet" (running) and "due now" (suspended +
@@ -890,4 +896,158 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
 
     // --- health -------------------------------------------------------------
     assert!(backend.health_check().await.expect("health_check failed"));
+}
+
+/// Receipt identity, cancellation precedence, and idempotent lifecycle transitions.
+/// Run unchanged against each persistence implementation.
+pub async fn run_lifecycle_command_sequence<P: Persistence>(backend: &P) {
+    use crate::domain::{InstanceStatus as Status, SignalType as Kind};
+    let id = Uuid::new_v4().to_string();
+    backend
+        .register_instance(&id, "command-contract")
+        .await
+        .unwrap();
+    backend
+        .update_instance_status(&id, Status::Running, None)
+        .await
+        .unwrap();
+    backend
+        .insert_signal(&id, Kind::Pause, b"first")
+        .await
+        .unwrap();
+    let first = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    backend
+        .insert_signal(&id, Kind::Pause, b"replacement")
+        .await
+        .unwrap();
+    let second = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    assert_ne!(
+        first.command_id, second.command_id,
+        "same-kind commands need distinct receipts"
+    );
+    assert!(
+        !backend
+            .acknowledge_signal(&id, &first.command_id, Kind::Pause)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !backend
+            .acknowledge_signal(&id, &second.command_id, Kind::Cancel)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        Status::Running
+    );
+    assert_eq!(
+        backend
+            .get_pending_signal(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .command_id,
+        second.command_id
+    );
+    assert!(
+        backend
+            .acknowledge_signal(&id, &second.command_id, Kind::Pause)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        Status::Suspended
+    );
+    assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+    // A retry after resume must not apply the old pause again.
+    backend
+        .update_instance_status(&id, Status::Running, None)
+        .await
+        .unwrap();
+    assert!(
+        backend
+            .acknowledge_signal(&id, &second.command_id, Kind::Pause)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        Status::Running
+    );
+    let events = backend
+        .list_events(&id, &ListEventsFilter::default(), 100, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        events.len(),
+        1,
+        "pause and its retry record exactly one suspension event"
+    );
+    assert_eq!(events[0].event_type, crate::domain::EventType::Suspended);
+    backend
+        .insert_signal(&id, Kind::Shutdown, b"")
+        .await
+        .unwrap();
+    let shutdown = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    assert!(
+        backend
+            .acknowledge_signal(&id, &shutdown.command_id, Kind::Shutdown)
+            .await
+            .unwrap()
+    );
+    let suspended = backend.get_instance(&id).await.unwrap().unwrap();
+    assert_eq!(suspended.status, Status::Suspended);
+    assert_eq!(
+        suspended.termination_reason.as_deref(),
+        Some("shutdown_requested")
+    );
+    assert!(suspended.sleep_until.is_some());
+    backend
+        .insert_signal(&id, Kind::Cancel, b"cancel")
+        .await
+        .unwrap();
+    let cancel = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    for kind in [Kind::Pause, Kind::Shutdown, Kind::Resume, Kind::Cancel] {
+        backend.insert_signal(&id, kind, b"later").await.unwrap();
+        assert_eq!(
+            backend
+                .get_pending_signal(&id)
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
+            cancel.command_id
+        );
+    }
+    assert!(
+        !backend
+            .acknowledge_signal(&id, &shutdown.command_id, Kind::Shutdown)
+            .await
+            .unwrap()
+    );
+    assert!(
+        backend
+            .acknowledge_signal(&id, &cancel.command_id, Kind::Cancel)
+            .await
+            .unwrap()
+    );
+    let cancelled = backend.get_instance(&id).await.unwrap().unwrap();
+    assert_eq!(cancelled.status, Status::Cancelled);
+    assert!(cancelled.finished_at.is_some());
+    assert!(cancelled.sleep_until.is_none());
+    assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+    backend.insert_signal(&id, Kind::Pause, b"").await.unwrap();
+    let late = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    assert!(
+        !backend
+            .acknowledge_signal(&id, &late.command_id, Kind::Pause)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        Status::Cancelled
+    );
 }

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -297,9 +297,17 @@ impl Persistence for InMemoryPersistence {
         payload: &[u8],
     ) -> Result<(), CoreError> {
         let mut store = self.store.lock().unwrap();
+        store.instance_mut(instance_id)?;
+        if store.signals.get(instance_id).is_some_and(|signal| {
+            signal.acknowledged_at.is_none()
+                && signal.signal_type == crate::domain::SignalType::Cancel
+        }) {
+            return Ok(());
+        }
         store.signals.insert(
             instance_id.to_string(),
             SignalRecord {
+                command_id: uuid::Uuid::new_v4().to_string(),
                 instance_id: instance_id.to_string(),
                 signal_type,
                 payload: (!payload.is_empty()).then(|| payload.to_vec()),
@@ -324,12 +332,57 @@ impl Persistence for InMemoryPersistence {
             .cloned())
     }
 
-    async fn acknowledge_signal(&self, instance_id: &str) -> Result<(), CoreError> {
+    async fn acknowledge_signal(
+        &self,
+        instance_id: &str,
+        command_id: &str,
+        signal_type: crate::domain::SignalType,
+    ) -> Result<bool, CoreError> {
+        use crate::domain::SignalType;
         let mut store = self.store.lock().unwrap();
-        if let Some(signal) = store.signals.get_mut(instance_id) {
-            signal.acknowledged_at = Some(Utc::now());
+        let Some(signal) = store.signals.get(instance_id) else {
+            return Ok(false);
+        };
+        if signal.command_id != command_id || signal.signal_type != signal_type {
+            return Ok(false);
         }
-        Ok(())
+        if signal.acknowledged_at.is_some() {
+            return Ok(true);
+        }
+        let instance = store.instance_mut(instance_id)?;
+        if instance.status.is_terminal() && signal_type != SignalType::Cancel {
+            return Ok(false);
+        }
+        let now = Utc::now();
+        match signal_type {
+            SignalType::Cancel => {
+                instance.status = CoreInstanceStatus::Cancelled;
+                instance.finished_at = Some(now);
+                instance.sleep_until = None;
+            }
+            SignalType::Pause | SignalType::Shutdown => {
+                instance.status = CoreInstanceStatus::Suspended;
+                instance.finished_at = Some(now);
+                instance.sleep_until = (signal_type == SignalType::Shutdown).then_some(now);
+                instance.termination_reason =
+                    (signal_type == SignalType::Shutdown).then(|| "shutdown_requested".into());
+            }
+            SignalType::Resume => {}
+        }
+        if matches!(signal_type, SignalType::Pause | SignalType::Shutdown) {
+            let event_id = store.next_id();
+            store.events.push(EventRecord {
+                id: Some(event_id),
+                instance_id: instance_id.to_owned(),
+                event_type: crate::domain::EventType::Suspended,
+                checkpoint_id: None,
+                payload: None,
+                created_at: now,
+                subtype: None,
+            });
+        }
+        store.signals.get_mut(instance_id).unwrap().acknowledged_at = Some(now);
+        Ok(true)
     }
 
     async fn insert_custom_signal(
@@ -783,6 +836,7 @@ mod tests {
     async fn in_memory_backend_satisfies_the_conformance_sequence() {
         let backend = InMemoryPersistence::new();
         crate::persistence::conformance::run_conformance_sequence(&backend).await;
+        crate::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
     }
 
     fn foreign_vocabulary() -> EventVocabulary {

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -385,6 +385,46 @@ impl Persistence for InMemoryPersistence {
         Ok(true)
     }
 
+    async fn cancel_suspended_instances(
+        &self,
+        instance_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<crate::persistence::CancelledInstance>, CoreError> {
+        let mut store = self.store.lock().unwrap();
+        let mut candidates: Vec<_> = store
+            .instances
+            .values()
+            .filter(|instance| {
+                instance.status == CoreInstanceStatus::Suspended
+                    && instance_id.is_none_or(|id| id == instance.instance_id)
+                    && store
+                        .signals
+                        .get(&instance.instance_id)
+                        .is_some_and(|signal| {
+                            signal.signal_type == crate::domain::SignalType::Cancel
+                                && signal.acknowledged_at.is_none()
+                        })
+            })
+            .map(|instance| instance.instance_id.clone())
+            .collect();
+        candidates.sort();
+        candidates.truncate(limit.max(0) as usize);
+        let now = Utc::now();
+        let mut cancelled = Vec::new();
+        for id in candidates {
+            let instance = store.instances.get_mut(&id).unwrap();
+            instance.status = CoreInstanceStatus::Cancelled;
+            instance.finished_at = Some(now);
+            instance.sleep_until = None;
+            cancelled.push(crate::persistence::CancelledInstance {
+                instance_id: id.clone(),
+                tenant_id: instance.tenant_id.clone(),
+            });
+            store.signals.get_mut(&id).unwrap().acknowledged_at = Some(now);
+        }
+        Ok(cancelled)
+    }
+
     async fn insert_custom_signal(
         &self,
         instance_id: &str,
@@ -480,7 +520,8 @@ impl Persistence for InMemoryPersistence {
         sleep_until: DateTime<Utc>,
     ) -> Result<(), CoreError> {
         let mut store = self.store.lock().unwrap();
-        store.instance_mut(instance_id)?.sleep_until = Some(sleep_until);
+        let instance = store.instance_mut(instance_id)?;
+        instance.sleep_until = (!instance.status.is_terminal()).then_some(sleep_until);
         Ok(())
     }
 
@@ -837,6 +878,7 @@ mod tests {
         let backend = InMemoryPersistence::new();
         crate::persistence::conformance::run_conformance_sequence(&backend).await;
         crate::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
+        crate::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
     }
 
     fn foreign_vocabulary() -> EventVocabulary {

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -116,6 +116,15 @@ pub struct SignalRecord {
     pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
+/// Instance whose pending cancellation was applied without a running guest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CancelledInstance {
+    /// Cancelled instance identity.
+    pub instance_id: String,
+    /// Tenant to notify when releasing execution admission.
+    pub tenant_id: String,
+}
+
 /// Pending custom signal scoped to a specific checkpoint.
 #[derive(Debug, Clone)]
 pub struct CustomSignalRecord {
@@ -597,6 +606,17 @@ pub trait Persistence: Send + Sync {
         signal_type: SignalType,
     ) -> Result<bool, CoreError>;
 
+    /// Atomically cancel suspended instances with pending cancel commands, clear
+    /// their wake deadlines, and acknowledge those exact commands. Returns only
+    /// newly cancelled instances. Active runs and terminal instances are untouched.
+    /// `Some(id)` targets an API request; `None` recovers interrupted delivery in
+    /// bounded batches. Locked instances may be skipped for the next recovery pass.
+    async fn cancel_suspended_instances(
+        &self,
+        instance_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<CancelledInstance>, CoreError>;
+
     async fn insert_custom_signal(
         &self,
         instance_id: &str,
@@ -695,6 +715,8 @@ pub trait Persistence: Send + Sync {
     }
 
     /// Set the sleep_until timestamp for an instance.
+    /// Terminal instances retain no wake deadline, including when this write
+    /// races with cancellation or completion.
     async fn set_instance_sleep(
         &self,
         instance_id: &str,

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -102,6 +102,8 @@ pub struct EventRecord {
 /// Signal record from the persistence layer.
 #[derive(Debug, Clone)]
 pub struct SignalRecord {
+    /// Opaque identity of this command; replacements receive a fresh identity.
+    pub command_id: String,
     /// Instance this signal is for.
     pub instance_id: String,
     /// Type of signal (cancel, pause, resume).
@@ -568,6 +570,8 @@ pub trait Persistence: Send + Sync {
     /// duration into the interval between two writes.
     async fn insert_event(&self, event: &EventRecord) -> Result<(), CoreError>;
 
+    /// Store a fresh lifecycle command, replacing the previous slot. An unacknowledged
+    /// cancellation dominates subsequent commands and retains its identity and payload.
     async fn insert_signal(
         &self,
         instance_id: &str,
@@ -580,7 +584,18 @@ pub trait Persistence: Send + Sync {
         instance_id: &str,
     ) -> Result<Option<SignalRecord>, CoreError>;
 
-    async fn acknowledge_signal(&self, instance_id: &str) -> Result<(), CoreError>;
+    /// Atomically acknowledge exactly the delivered command and apply its lifecycle
+    /// transition and suspension event. Shutdown also schedules immediate wake.
+    /// Returns false for a replaced/missing command, a type mismatch, or a transition
+    /// that would revive a terminal instance. Repeating an accepted acknowledgment
+    /// returns true without applying its transition again. Cancel may override a
+    /// completed/failed run when the runner discovers an unhandled cancellation.
+    async fn acknowledge_signal(
+        &self,
+        instance_id: &str,
+        command_id: &str,
+        signal_type: SignalType,
+    ) -> Result<bool, CoreError>;
 
     async fn insert_custom_signal(
         &self,

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -1986,6 +1986,19 @@ pub async fn handle_send_signal(
         .insert_signal(instance_id, signal_type, &payload)
         .await?;
 
+    if signal_type == runtara_core::domain::SignalType::Cancel {
+        for cancelled in state
+            .persistence
+            .cancel_suspended_instances(Some(instance_id), 1)
+            .await?
+        {
+            state.lifecycle_observers.notify_instance_released(
+                cancelled.tenant_id,
+                cancelled.instance_id,
+                "cancelled",
+            );
+        }
+    }
     Ok(SendSignalOutcome::Delivered)
 }
 

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -1354,6 +1354,7 @@ async fn enforce_unacked_cancel(persistence: &Arc<dyn Persistence>, instance_id:
             if let Err(e) = handle_signal_ack(
                 &state,
                 SignalAck {
+                    command_id: signal.command_id,
                     instance_id: instance_id.to_string(),
                     signal_type: SignalType::SignalCancel as i32,
                     acknowledged: true,
@@ -2479,7 +2480,16 @@ mod tests {
             .await
             .unwrap();
         persistence
-            .acknowledge_signal(instance_id.as_str())
+            .acknowledge_signal(
+                instance_id.as_str(),
+                &persistence
+                    .get_pending_signal(instance_id.as_str())
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .command_id,
+                runtara_core::domain::SignalType::Cancel,
+            )
             .await
             .unwrap();
         persistence

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -1702,9 +1702,17 @@ impl Runner for EmbeddedWasmRunner {
                         warn!(instance_id = %instance_id, "Embedded workflow run cancelled");
                     }
                 }
-                // A park is not an ending — the wake scheduler owns it from
-                // here (and resolves a pending cancel itself).
-                if !matches!(&run.exit, InvokeExit::Suspended(_)) {
+                if matches!(&run.exit, InvokeExit::Suspended(_)) {
+                    // A cancel may arrive after the guest's last poll but before
+                    // it parks. Resolve it now; the scheduler recovers this if
+                    // the process stops before reaching this point.
+                    if let Err(error) = persistence
+                        .cancel_suspended_instances(Some(&instance_id), 1)
+                        .await
+                    {
+                        warn!(instance_id, %error, "Parked cancellation deferred to scheduler recovery");
+                    }
+                } else {
                     enforce_unacked_cancel(&persistence, &instance_id).await;
                 }
             } else if let Some(pre) = workflow.command() {

--- a/crates/runtara-environment/src/runtime_host.rs
+++ b/crates/runtara-environment/src/runtime_host.rs
@@ -223,12 +223,36 @@ impl PersistenceRuntimeHost {
             "Guest resumed from an interrupted sleep without polling signals; \
              cancelling host-side (workflow artifact predates the Delay poll site)"
         );
-        self.cancelled.store(true, Ordering::SeqCst);
         // The ack is what writes terminal status `cancelled`, exactly as it
         // would had the guest observed the signal itself. It runs BEFORE the
         // guest is stopped, so the terminal status is durable even if the trap
         // lands immediately.
-        self.ack_signal(SignalType::SignalCancel).await;
+        let accepted = async {
+            let Some(signal) = self
+                .state
+                .persistence
+                .get_pending_signal(&self.instance_id)
+                .await
+                .map_err(Self::err)?
+            else {
+                return Ok(false);
+            };
+            if signal.signal_type != runtara_core::domain::SignalType::Cancel {
+                return Ok(false);
+            }
+            self.ack_signal(SignalType::SignalCancel, &signal.command_id)
+                .await
+        }
+        .await;
+        match accepted {
+            Ok(true) => self.cancelled.store(true, Ordering::SeqCst),
+            Ok(false) => return,
+            Err(error) => {
+                self.sleep_interrupted.store(true, Ordering::SeqCst);
+                tracing::warn!(%error, "Failed to acknowledge interrupted sleep cancellation; will retry");
+                return;
+            }
+        }
         if let Some(cancel) = &self.cancel_token {
             cancel.store(true, Ordering::SeqCst);
         }
@@ -254,32 +278,19 @@ impl PersistenceRuntimeHost {
         self.sleep_interrupted.store(false, Ordering::SeqCst);
     }
 
-    /// Server-side signal acknowledgement — the status-transition half of the
-    /// SDK's `acknowledge_*` free functions (`handle_signal_ack` marks the
-    /// signal consumed and applies cancel/pause/shutdown side effects).
-    ///
-    /// Ack failures are logged and swallowed, NOT propagated — exact parity
-    /// with the SDK free functions (`registry.rs`), which `warn!` and continue
-    /// so a failed acknowledgement never turns a clean suspend/cancel into a
-    /// guest-visible runtime error.
-    async fn ack_signal(&self, signal_type: SignalType) {
-        if let Err(error) = handle_signal_ack(
+    /// Apply only the command the guest actually observed.
+    async fn ack_signal(&self, signal_type: SignalType, command_id: &str) -> Result<bool, String> {
+        handle_signal_ack(
             &self.state,
             SignalAck {
+                command_id: command_id.to_owned(),
                 instance_id: self.instance_id.clone(),
                 signal_type: signal_type as i32,
                 acknowledged: true,
             },
         )
         .await
-        {
-            tracing::warn!(
-                instance_id = %self.instance_id,
-                ?signal_type,
-                %error,
-                "failed to acknowledge signal (continuing, guest-parity)"
-            );
-        }
+        .map_err(Self::err)
     }
 
     /// The `sdk.suspended()` equivalent: record a suspended instance event
@@ -341,6 +352,7 @@ impl PersistenceRuntimeHost {
     fn runtime_signal(signal: Signal) -> RuntimeSignalInfo {
         RuntimeSignalInfo {
             signal_type: Self::signal_type_name(signal.signal_type).to_string(),
+            command_id: signal.command_id,
             payload: signal.payload,
             // The guest-protocol handlers never scope lifecycle signals to a
             // checkpoint; the composed runtime forwarded `None` here too.
@@ -395,8 +407,6 @@ impl RuntimeHost for PersistenceRuntimeHost {
 
     async fn breakpoint_pause(&self) -> Result<(), String> {
         self.escalate_if_cancel_ignored().await;
-        // Guest: acknowledge_pause() then sdk.suspended().
-        self.ack_signal(SignalType::SignalPause).await;
         self.suspended_event().await
     }
 
@@ -417,12 +427,14 @@ impl RuntimeHost for PersistenceRuntimeHost {
             return Ok(false);
         };
         if Self::signal_type_of(signal.signal_type) == Some(SignalType::SignalCancel) {
-            self.cancelled.store(true, Ordering::SeqCst);
-            self.ack_signal(SignalType::SignalCancel).await;
-            return Ok(true);
+            let accepted = self
+                .ack_signal(SignalType::SignalCancel, &signal.command_id)
+                .await?;
+            if accepted {
+                self.cancelled.store(true, Ordering::SeqCst);
+            }
+            return Ok(accepted);
         }
-        // Non-cancel signals are left pending (polling is non-destructive),
-        // exactly like the guest path that inspects only the cancel case.
         Ok(false)
     }
 
@@ -431,25 +443,11 @@ impl RuntimeHost for PersistenceRuntimeHost {
         let Some(signal) = self.poll_lifecycle_signal().await? else {
             return Ok(false);
         };
-        match Self::signal_type_of(signal.signal_type) {
-            Some(SignalType::SignalCancel) => {
-                self.cancelled.store(true, Ordering::SeqCst);
-                self.ack_signal(SignalType::SignalCancel).await;
-                Ok(true)
-            }
-            Some(SignalType::SignalPause) => {
-                self.ack_signal(SignalType::SignalPause).await;
-                self.suspended_event().await?;
-                Ok(true)
-            }
-            Some(SignalType::SignalShutdown) => {
-                self.cancelled.store(true, Ordering::SeqCst);
-                self.ack_signal(SignalType::SignalShutdown).await;
-                self.suspended_event().await?;
-                Ok(true)
-            }
-            Some(SignalType::SignalResume) | None => Ok(false),
-        }
+        self.handle_checkpoint_signal(
+            Self::signal_type_name(signal.signal_type).into(),
+            signal.command_id,
+        )
+        .await
     }
 
     async fn poll_custom_signal(&self, checkpoint_id: String) -> Result<Option<Vec<u8>>, String> {
@@ -509,28 +507,25 @@ impl RuntimeHost for PersistenceRuntimeHost {
         })
     }
 
-    async fn handle_checkpoint_signal(&self, signal_type: String) -> Result<bool, String> {
+    async fn handle_checkpoint_signal(
+        &self,
+        signal_type: String,
+        command_id: String,
+    ) -> Result<bool, String> {
         self.escalate_if_cancel_ignored().await;
-        // Mirrors the guest runtime's checkpoint_signal_action dispatch.
-        match signal_type.as_str() {
-            "cancel" => {
-                self.cancelled.store(true, Ordering::SeqCst);
-                self.ack_signal(SignalType::SignalCancel).await;
-                Ok(true)
-            }
-            "pause" => {
-                self.ack_signal(SignalType::SignalPause).await;
-                self.suspended_event().await?;
-                Ok(true)
-            }
-            "shutdown" => {
-                self.cancelled.store(true, Ordering::SeqCst);
-                self.ack_signal(SignalType::SignalShutdown).await;
-                self.suspended_event().await?;
-                Ok(true)
-            }
-            _ => Ok(false),
+        let kind = match signal_type.as_str() {
+            "cancel" => SignalType::SignalCancel,
+            "pause" => SignalType::SignalPause,
+            "shutdown" => SignalType::SignalShutdown,
+            _ => return Ok(false),
+        };
+        if !self.ack_signal(kind, &command_id).await? {
+            return Ok(false);
         }
+        if matches!(kind, SignalType::SignalCancel | SignalType::SignalShutdown) {
+            self.cancelled.store(true, Ordering::SeqCst);
+        }
+        Ok(true)
     }
 
     async fn record_retry_attempt(
@@ -836,7 +831,7 @@ mod tests {
         assert_eq!(pending.signal_type, "pause");
 
         assert!(
-            host.handle_checkpoint_signal(pending.signal_type)
+            host.handle_checkpoint_signal(pending.signal_type, pending.command_id)
                 .await
                 .unwrap()
         );
@@ -846,11 +841,82 @@ mod tests {
         // Unknown types are ignored (guest parity).
         assert!(
             !host
-                .handle_checkpoint_signal("resume".into())
+                .handle_checkpoint_signal("resume".into(), "unused".into())
                 .await
                 .unwrap()
         );
-        assert!(!host.handle_checkpoint_signal("bogus".into()).await.unwrap());
+        assert!(
+            !host
+                .handle_checkpoint_signal("bogus".into(), "unused".into())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn retried_checkpoint_ack_after_resume_does_not_suspend_again() {
+        let (p, host, id) = setup().await;
+        p.insert_signal(&id, CoreSignalType::Pause, b"")
+            .await
+            .unwrap();
+        let signal = p.get_pending_signal(&id).await.unwrap().unwrap();
+        assert!(
+            host.handle_checkpoint_signal("pause".into(), signal.command_id.clone())
+                .await
+                .unwrap()
+        );
+        p.update_instance_status(&id, CoreInstanceStatus::Running, None)
+            .await
+            .unwrap();
+        assert!(
+            host.handle_checkpoint_signal("pause".into(), signal.command_id)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            p.get_instance(&id).await.unwrap().unwrap().status,
+            CoreInstanceStatus::Running
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_checkpoint_receipt_does_not_suspend_or_consume_cancel() {
+        let (p, host, id) = setup().await;
+        p.insert_signal(&id, CoreSignalType::Pause, b"")
+            .await
+            .unwrap();
+        let old = host
+            .checkpoint("receipt".into(), b"state".to_vec())
+            .await
+            .unwrap()
+            .pending_signal
+            .unwrap();
+        p.insert_signal(&id, CoreSignalType::Cancel, b"")
+            .await
+            .unwrap();
+        assert!(
+            !host
+                .handle_checkpoint_signal(old.signal_type, old.command_id)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            p.get_instance(&id).await.unwrap().unwrap().status,
+            CoreInstanceStatus::Running
+        );
+        assert_eq!(
+            p.get_pending_signal(&id)
+                .await
+                .unwrap()
+                .unwrap()
+                .signal_type,
+            CoreSignalType::Cancel
+        );
+        assert!(host.check_signals().await.unwrap());
+        assert_eq!(
+            p.get_instance(&id).await.unwrap().unwrap().status,
+            CoreInstanceStatus::Cancelled
+        );
     }
 
     #[tokio::test]

--- a/crates/runtara-environment/src/wake_scheduler.rs
+++ b/crates/runtara-environment/src/wake_scheduler.rs
@@ -334,45 +334,17 @@ impl WakeScheduler {
         Ok(claimed)
     }
 
-    /// Whether a `cancel` signal is waiting for this instance.
-    ///
-    /// A read failure is reported as "no cancel": relaunching an instance that
-    /// turns out to be cancelled is recoverable (the guest observes the signal
-    /// at its next poll), whereas refusing to wake on a transient database
-    /// error would strand a healthy sleeper.
-    async fn cancel_pending(&self, instance_id: &str) -> bool {
-        match self.persistence.get_pending_signal(instance_id).await {
-            // `acknowledged_at` is re-checked even though `get_pending_signal`
-            // already filters on `acknowledged_at IS NULL`: defence in depth.
-            // Waking is destructive enough that a regression in that predicate
-            // must not silently re-cancel a handled run. The check is free.
-            Ok(Some(signal)) => {
-                signal.signal_type == runtara_core::domain::SignalType::Cancel
-                    && signal.acknowledged_at.is_none()
-            }
-            Ok(None) => false,
-            Err(e) => {
-                warn!(
-                    instance_id = %instance_id,
-                    error = %e,
-                    "Failed to read pending signals before wake; relaunching anyway"
-                );
-                false
-            }
-        }
-    }
-
-    /// Acknowledge the pending cancel and drive the instance to `cancelled`.
-    ///
-    /// Reuses core's ack path rather than writing the status directly, so a
-    /// cancel resolved here is indistinguishable from one a running guest
-    /// acknowledged: same signal acknowledgement, same terminal status.
-    async fn cancel_without_launch(&self, instance_id: &str) -> crate::error::Result<()> {
+    /// Apply the cancellation observed at wake without launching a guest.
+    async fn cancel_without_launch(
+        &self,
+        signal: runtara_core::persistence::SignalRecord,
+    ) -> crate::error::Result<bool> {
         let state = InstanceHandlerState::new(self.persistence.clone());
         handle_signal_ack(
             &state,
             SignalAck {
-                instance_id: instance_id.to_string(),
+                command_id: signal.command_id,
+                instance_id: signal.instance_id,
                 signal_type: SignalType::SignalCancel as i32,
                 acknowledged: true,
             },
@@ -456,12 +428,13 @@ impl WakeScheduler {
         // HIT that skips the poll sites entirely. Drive it to terminal here
         // instead of starting a process only to cancel it — the claim above
         // already took this row out of the wake candidate set.
-        if self.cancel_pending(&instance.instance_id).await {
-            info!(
-                instance_id = %instance.instance_id,
-                "Cancel signal pending at wake time; cancelling instead of relaunching"
-            );
-            self.cancel_without_launch(&instance.instance_id).await?;
+        if let Some(signal) = self
+            .persistence
+            .get_pending_signal(&instance.instance_id)
+            .await?
+            && signal.signal_type == runtara_core::domain::SignalType::Cancel
+            && self.cancel_without_launch(signal).await?
+        {
             self.lifecycle_observers.notify_instance_released(
                 instance.tenant_id.clone(),
                 instance.instance_id.clone(),

--- a/crates/runtara-environment/src/wake_scheduler.rs
+++ b/crates/runtara-environment/src/wake_scheduler.rs
@@ -12,9 +12,6 @@
 //! statement (`claim_sleeping_instances_due`), which is what makes overlapping
 //! polls safe.
 
-use runtara_core::instance_handlers::{
-    InstanceHandlerState, SignalAck, SignalType, handle_signal_ack,
-};
 use runtara_core::persistence::{CompleteInstanceParams, Persistence};
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -238,7 +235,7 @@ impl WakeScheduler {
 
     /// Claim a batch of due instances and wake them concurrently.
     ///
-    /// Returns how many were claimed, which [`WakeScheduler::run`] uses to
+    /// Returns how many were cancelled or claimed, which [`WakeScheduler::run`] uses to
     /// decide whether more work is waiting.
     async fn process_pending_wakes(self: Arc<Self>) -> crate::error::Result<usize> {
         // While draining, suspended instances are being stamped with
@@ -247,6 +244,19 @@ impl WakeScheduler {
         if self.drain.is_draining() {
             debug!("Draining; skipping wake processing");
             return Ok(0);
+        }
+
+        let cancelled = self
+            .persistence
+            .cancel_suspended_instances(None, self.config.batch_size)
+            .await?;
+        let cancelled_count = cancelled.len();
+        for instance in cancelled {
+            self.lifecycle_observers.notify_instance_released(
+                instance.tenant_id,
+                instance.instance_id,
+                "cancelled",
+            );
         }
 
         // Claims as it selects: back-to-back polls would otherwise keep
@@ -265,10 +275,10 @@ impl WakeScheduler {
 
         if sleeping_instances.is_empty() {
             debug!("No sleeping instances due for wake");
-            return Ok(0);
+            return Ok(cancelled_count);
         }
 
-        let claimed = sleeping_instances.len();
+        let claimed = sleeping_instances.len() + cancelled_count;
         info!(count = claimed, "Processing sleeping instances");
 
         // Relaunching is mostly CPU-bound, so a batch is worth spreading over
@@ -334,23 +344,14 @@ impl WakeScheduler {
         Ok(claimed)
     }
 
-    /// Apply the cancellation observed at wake without launching a guest.
-    async fn cancel_without_launch(
-        &self,
-        signal: runtara_core::persistence::SignalRecord,
-    ) -> crate::error::Result<bool> {
-        let state = InstanceHandlerState::new(self.persistence.clone());
-        handle_signal_ack(
-            &state,
-            SignalAck {
-                command_id: signal.command_id,
-                instance_id: signal.instance_id,
-                signal_type: SignalType::SignalCancel as i32,
-                acknowledged: true,
-            },
-        )
-        .await
-        .map_err(|e| crate::error::Error::Other(format!("Failed to cancel woken instance: {e}")))
+    /// Apply cancellation only while the instance is still parked. A concurrent
+    /// launch that wins the running transition must observe its pending command.
+    async fn cancel_without_launch(&self, instance_id: &str) -> crate::error::Result<bool> {
+        Ok(!self
+            .persistence
+            .cancel_suspended_instances(Some(instance_id), 1)
+            .await?
+            .is_empty())
     }
 
     /// Wake an already-claimed instance, releasing the claim if it fails.
@@ -428,13 +429,7 @@ impl WakeScheduler {
         // HIT that skips the poll sites entirely. Drive it to terminal here
         // instead of starting a process only to cancel it — the claim above
         // already took this row out of the wake candidate set.
-        if let Some(signal) = self
-            .persistence
-            .get_pending_signal(&instance.instance_id)
-            .await?
-            && signal.signal_type == runtara_core::domain::SignalType::Cancel
-            && self.cancel_without_launch(signal).await?
-        {
+        if self.cancel_without_launch(&instance.instance_id).await? {
             self.lifecycle_observers.notify_instance_released(
                 instance.tenant_id.clone(),
                 instance.instance_id.clone(),

--- a/crates/runtara-environment/tests/handlers_test.rs
+++ b/crates/runtara-environment/tests/handlers_test.rs
@@ -2211,3 +2211,47 @@ async fn scope_ancestry_uses_custom_event_subtypes() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn cancel_signal_terminalizes_a_parked_instance_without_a_guest() {
+    use runtara_core::domain::InstanceStatus;
+    use runtara_environment::handlers::{SendSignalOutcome, handle_send_signal};
+    let pool = get_test_pool().await;
+    let temp = tempfile::TempDir::new().unwrap();
+    let state = create_test_state(pool, temp.path().to_owned());
+    let id = Uuid::new_v4().to_string();
+    state
+        .persistence
+        .register_instance(&id, "parked-handler")
+        .await
+        .unwrap();
+    state
+        .persistence
+        .update_instance_status(&id, InstanceStatus::Suspended, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        handle_send_signal(&state, &id, "cancel", None)
+            .await
+            .unwrap(),
+        SendSignalOutcome::Delivered
+    );
+    assert_eq!(
+        state
+            .persistence
+            .get_instance(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        InstanceStatus::Cancelled
+    );
+    assert!(
+        state
+            .persistence
+            .get_pending_signal(&id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -376,8 +376,13 @@ impl Persistence for MockPersistence {
         Ok(None)
     }
 
-    async fn acknowledge_signal(&self, _instance_id: &str) -> Result<(), CoreError> {
-        Ok(())
+    async fn acknowledge_signal(
+        &self,
+        _instance_id: &str,
+        _command_id: &str,
+        _signal_type: runtara_core::domain::SignalType,
+    ) -> Result<bool, CoreError> {
+        Ok(false)
     }
 
     async fn insert_custom_signal(

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -385,6 +385,17 @@ impl Persistence for MockPersistence {
         Ok(false)
     }
 
+    async fn cancel_suspended_instances(
+        &self,
+        _instance_id: Option<&str>,
+        _limit: i64,
+    ) -> std::result::Result<
+        Vec<runtara_core::persistence::CancelledInstance>,
+        runtara_core::error::CoreError,
+    > {
+        Ok(Vec::new())
+    }
+
     async fn insert_custom_signal(
         &self,
         _instance_id: &str,

--- a/crates/runtara-environment/tests/launch_queue_test.rs
+++ b/crates/runtara-environment/tests/launch_queue_test.rs
@@ -1000,3 +1000,93 @@ async fn dispatcher_hands_off_a_durable_row_without_a_runner_waiter() {
 
     context.cleanup().await;
 }
+
+#[tokio::test]
+async fn parked_cancellation_and_launch_start_are_serialized() {
+    use runtara_core::{
+        domain::{InstanceStatus, SignalType},
+        persistence::Persistence,
+    };
+    let context = TestContext::new().await.expect("test database must start");
+    let repository = LaunchRepository::new(context.pool.clone());
+    let persistence = PostgresPersistence::new(context.pool.clone());
+    for turn in 0..12 {
+        let fixture = fixture(&context).await;
+        set_instance_status(&context.pool, &fixture.instance_id, "suspended").await;
+        let launch_id = Uuid::new_v4().to_string();
+        repository
+            .enqueue(request(
+                &fixture,
+                &launch_id,
+                LaunchKind::Wake,
+                Duration::from_secs(60),
+            ))
+            .await
+            .unwrap();
+        let claim = repository
+            .claim_ready("cancel-race", Duration::from_secs(60), 1)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(claim.launch_id, launch_id);
+        repository
+            .begin_start(&launch_id, "cancel-race", claim.attempt_count)
+            .await
+            .unwrap()
+            .unwrap();
+        persistence
+            .insert_signal(&fixture.instance_id, SignalType::Cancel, b"")
+            .await
+            .unwrap();
+        // Also force the cancellation-first ordering; the other iterations race.
+        if turn == 0 {
+            assert_eq!(
+                persistence
+                    .cancel_suspended_instances(Some(&fixture.instance_id), 1)
+                    .await
+                    .unwrap()
+                    .len(),
+                1
+            );
+        }
+        let (cancelled, started) = tokio::join!(
+            persistence.cancel_suspended_instances(Some(&fixture.instance_id), 1),
+            repository.mark_running(&launch_id, "cancel-race", claim.attempt_count),
+        );
+        let cancelled = cancelled.unwrap();
+        let instance = persistence
+            .get_instance(&fixture.instance_id)
+            .await
+            .unwrap()
+            .unwrap();
+        if turn == 0 || !cancelled.is_empty() {
+            assert_eq!(instance.status, InstanceStatus::Cancelled);
+            assert!(matches!(
+                started,
+                Err(LaunchQueueError::InstanceNoLongerPreStart { .. })
+            ));
+            assert!(
+                persistence
+                    .get_pending_signal(&fixture.instance_id)
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+        } else {
+            assert!(started.unwrap().is_some());
+            assert_eq!(instance.status, InstanceStatus::Running);
+            assert_eq!(
+                persistence
+                    .get_pending_signal(&fixture.instance_id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .signal_type,
+                SignalType::Cancel,
+                "a start that wins must retain the cancellation for its guest"
+            );
+        }
+        context.cleanup_tenant(&fixture.tenant_id).await;
+    }
+}

--- a/crates/runtara-environment/tests/wake_scheduler_test.rs
+++ b/crates/runtara-environment/tests/wake_scheduler_test.rs
@@ -858,3 +858,78 @@ async fn a_batch_is_woken_concurrently_and_stays_within_its_bound() {
     }
     cleanup_image(&pool, &image_id).await;
 }
+
+#[tokio::test]
+async fn scheduler_recovers_parked_cancellation_without_waiting_for_a_deadline() {
+    let pool = get_test_pool().await;
+    let image = create_test_image(&pool, "parked-recovery").await;
+    let no_deadline = park_due_instance(&pool, "parked-recovery", &image).await;
+    let future = park_due_instance(&pool, "parked-recovery", &image).await;
+    let persistence = Arc::new(PostgresPersistence::new(pool.clone()));
+    persistence
+        .clear_instance_sleep(&no_deadline)
+        .await
+        .unwrap();
+    persistence
+        .set_instance_sleep(&future, Utc::now() + chrono::Duration::hours(24))
+        .await
+        .unwrap();
+    for id in [&no_deadline, &future] {
+        // Only persist the request: model a crash before immediate application.
+        persistence
+            .insert_signal(id, runtara_core::domain::SignalType::Cancel, b"")
+            .await
+            .unwrap();
+    }
+    let scheduler = WakeScheduler::new(
+        pool.clone(),
+        persistence.clone(),
+        WakeSchedulerConfig {
+            poll_interval: Duration::from_millis(50),
+            batch_size: 10,
+            ..Default::default()
+        },
+    );
+    let shutdown = scheduler.shutdown_handle();
+    let task = tokio::spawn(scheduler.run());
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut done = false;
+    while std::time::Instant::now() < deadline {
+        done = true;
+        for id in [&no_deadline, &future] {
+            done &= persistence.get_instance(id).await.unwrap().unwrap().status
+                == CoreInstanceStatus::Cancelled;
+        }
+        if done {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    shutdown.notify_one();
+    task.await.unwrap();
+    assert!(
+        done,
+        "cancellation must not depend on a guest or a due timer"
+    );
+    for id in [&no_deadline, &future] {
+        assert!(persistence.get_pending_signal(id).await.unwrap().is_none());
+        assert!(
+            persistence
+                .get_instance(id)
+                .await
+                .unwrap()
+                .unwrap()
+                .sleep_until
+                .is_none()
+        );
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM instance_launches WHERE instance_id = $1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "recovery must not enqueue a new launch");
+        cleanup(&pool, id).await;
+    }
+    cleanup_image(&pool, &image).await;
+}

--- a/crates/runtara-sdk-macros/src/lib.rs
+++ b/crates/runtara-sdk-macros/src/lib.rs
@@ -286,18 +286,27 @@ fn generate_no_retry_wrapper(
                                 drop(__sdk_guard);
 
                                 // Check for pending pause/cancel/shutdown signals
-                                if checkpoint_result.should_cancel() {
+                                if checkpoint_result.should_cancel()
+                                    && ::runtara_sdk::acknowledge_cancellation(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                     // Acknowledge cancellation to core (sets status to "cancelled")
                                     // and trigger local cancellation flag
-                                    ::runtara_sdk::acknowledge_cancellation();
+
                                     // Return error immediately to stop execution
                                     return Err("Instance cancelled".to_string().into());
-                                } else if checkpoint_result.should_suspend_on_shutdown() {
+                                } else if checkpoint_result.should_suspend_on_shutdown()
+                                    && ::runtara_sdk::acknowledge_shutdown(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                     // Ack to core (status -> suspended, termination_reason="shutdown_requested")
                                     // and flip local cancellation flag so remaining cooperative work exits
-                                    ::runtara_sdk::acknowledge_shutdown();
+
                                     return Err("Instance suspended for shutdown".to_string().into());
-                                } else if checkpoint_result.should_pause() {
+                                } else if checkpoint_result.should_pause()
+                                    && ::runtara_sdk::acknowledge_pause(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                     // Return error to trigger exit; caller should call sdk.suspended()
                                     return Err("Instance paused".to_string().into());
                                 }
@@ -587,17 +596,26 @@ fn generate_retry_wrapper(
                                         drop(__sdk_guard);
 
                                         // Check for pending pause/cancel/shutdown signals
-                                        if checkpoint_result.should_cancel() {
+                                        if checkpoint_result.should_cancel()
+                                    && ::runtara_sdk::acknowledge_cancellation(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                             // Acknowledge cancellation to core (sets status to "cancelled")
                                             // and trigger local cancellation flag
-                                            ::runtara_sdk::acknowledge_cancellation();
+
                                             // Return error immediately to stop execution
                                             return Err("Instance cancelled".to_string().into());
-                                        } else if checkpoint_result.should_suspend_on_shutdown() {
+                                        } else if checkpoint_result.should_suspend_on_shutdown()
+                                    && ::runtara_sdk::acknowledge_shutdown(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                             // Ack to core (status -> suspended, termination_reason="shutdown_requested")
-                                            ::runtara_sdk::acknowledge_shutdown();
+
                                             return Err("Instance suspended for shutdown".to_string().into());
-                                        } else if checkpoint_result.should_pause() {
+                                        } else if checkpoint_result.should_pause()
+                                    && ::runtara_sdk::acknowledge_pause(
+                                        &checkpoint_result.pending_signal.as_ref().unwrap().command_id
+                                    ).map_err(|error| error.to_string())? {
                                             // Return error to trigger exit; caller should call sdk.suspended()
                                             return Err("Instance paused".to_string().into());
                                         }

--- a/crates/runtara-sdk/src/backend/embedded.rs
+++ b/crates/runtara-sdk/src/backend/embedded.rs
@@ -63,14 +63,7 @@ impl EmbeddedBackend {
         }
     }
 
-    /// Fetch the instance-wide pending lifecycle signal (cancel/pause/shutdown)
-    /// from core persistence and acknowledge it.
-    ///
-    /// This is what lets an embedded guest suspend *cleanly* at a checkpoint
-    /// boundary on a drain/pause/cancel, instead of being force-stopped at the
-    /// shutdown grace deadline. The signal is acknowledged on read so it is not
-    /// redelivered after the instance relaunches (otherwise a recovered
-    /// instance would immediately re-suspend on the same stale signal).
+    /// Read the current lifecycle command without consuming its receipt.
     fn take_pending_lifecycle_signal(&self) -> Result<Option<Signal>> {
         let Some(record) = self
             .rt
@@ -85,12 +78,8 @@ impl EmbeddedBackend {
             CoreSignalType::Resume => SignalType::Resume,
             CoreSignalType::Shutdown => SignalType::Shutdown,
         };
-        // Acknowledge (idempotent: only clears an unacknowledged signal) so the
-        // signal is consumed once.
-        let _ = self
-            .rt
-            .block_on(self.persistence.acknowledge_signal(&self.instance_id));
         Ok(Some(Signal {
+            command_id: record.command_id,
             signal_type,
             payload: record.payload.unwrap_or_default(),
             checkpoint_id: None,
@@ -116,7 +105,7 @@ impl SdkBackend for EmbeddedBackend {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(instance_id = %self.instance_id)))]
-    fn register(&self, _checkpoint_id: Option<&str>) -> Result<()> {
+    fn register(&self, checkpoint_id: Option<&str>) -> Result<()> {
         self.rt
             .block_on(
                 self.persistence
@@ -431,15 +420,40 @@ impl SdkBackend for EmbeddedBackend {
 
     fn poll_signals(
         &self,
-        _checkpoint_id: Option<&str>,
+        checkpoint_id: Option<&str>,
     ) -> Result<(Option<Signal>, Option<CustomSignal>)> {
-        // Signals not supported in embedded mode
-        Ok((None, None))
+        let signal = self.take_pending_lifecycle_signal()?;
+        let custom = match checkpoint_id {
+            Some(id) => self
+                .rt
+                .block_on(
+                    self.persistence
+                        .take_pending_custom_signal(&self.instance_id, id),
+                )
+                .map_err(|e| SdkError::Internal(e.to_string()))?
+                .map(|signal| CustomSignal {
+                    checkpoint_id: signal.checkpoint_id,
+                    payload: signal.payload.unwrap_or_default(),
+                }),
+            None => None,
+        };
+        Ok((signal, custom))
     }
 
-    fn acknowledge_signal(&self, _signal_type: SignalType) -> Result<()> {
-        // No-op in embedded mode
-        Ok(())
+    fn acknowledge_signal(&self, command_id: &str, signal_type: SignalType) -> Result<bool> {
+        let signal_type = match signal_type {
+            SignalType::Cancel => CoreSignalType::Cancel,
+            SignalType::Pause => CoreSignalType::Pause,
+            SignalType::Resume => CoreSignalType::Resume,
+            SignalType::Shutdown => CoreSignalType::Shutdown,
+        };
+        self.rt
+            .block_on(self.persistence.acknowledge_signal(
+                &self.instance_id,
+                command_id,
+                signal_type,
+            ))
+            .map_err(|e| SdkError::Internal(e.to_string()))
     }
 
     fn get_instance_status(&self, instance_id: &str) -> Result<StatusResponse> {
@@ -792,8 +806,13 @@ mod tests {
             Ok(None)
         }
 
-        async fn acknowledge_signal(&self, _instance_id: &str) -> CoreResult<()> {
-            Ok(())
+        async fn acknowledge_signal(
+            &self,
+            _instance_id: &str,
+            _command_id: &str,
+            _signal_type: runtara_core::domain::SignalType,
+        ) -> CoreResult<bool> {
+            Ok(false)
         }
 
         async fn insert_custom_signal(

--- a/crates/runtara-sdk/src/backend/embedded.rs
+++ b/crates/runtara-sdk/src/backend/embedded.rs
@@ -815,6 +815,17 @@ mod tests {
             Ok(false)
         }
 
+        async fn cancel_suspended_instances(
+            &self,
+            _instance_id: Option<&str>,
+            _limit: i64,
+        ) -> std::result::Result<
+            Vec<runtara_core::persistence::CancelledInstance>,
+            runtara_core::error::CoreError,
+        > {
+            Ok(Vec::new())
+        }
+
         async fn insert_custom_signal(
             &self,
             _instance_id: &str,

--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -299,6 +299,7 @@ struct CheckpointResp {
 
 #[derive(Deserialize)]
 struct SignalResp {
+    command_id: String,
     signal_type: String,
     #[serde(default)]
     payload: Option<String>, // base64
@@ -339,6 +340,7 @@ struct SleepBody {
 
 #[derive(Serialize)]
 struct SignalAckBody {
+    command_id: String,
     signal_type: String,
 }
 
@@ -445,6 +447,7 @@ fn encode_b64(data: &[u8]) -> String {
 
 fn parse_signal(resp: &SignalResp) -> Signal {
     Signal {
+        command_id: resp.command_id.clone(),
         signal_type: parse_signal_type(&resp.signal_type),
         payload: resp.payload.as_deref().map(decode_b64).unwrap_or_default(),
         checkpoint_id: None,
@@ -714,13 +717,14 @@ impl SdkBackend for HttpBackend {
         Ok((signal, custom))
     }
 
-    fn acknowledge_signal(&self, signal_type: SignalType) -> Result<()> {
+    fn acknowledge_signal(&self, command_id: &str, signal_type: SignalType) -> Result<bool> {
         let body = SignalAckBody {
+            command_id: command_id.to_owned(),
             signal_type: signal_type_str(&signal_type).to_string(),
         };
 
-        let _: SuccessResp = self.post(&self.url("signals/ack"), &body)?;
-        Ok(())
+        let response: SuccessResp = self.post(&self.url("signals/ack"), &body)?;
+        Ok(response.success)
     }
 
     fn get_instance_status(&self, instance_id: &str) -> Result<StatusResponse> {

--- a/crates/runtara-sdk/src/backend/mod.rs
+++ b/crates/runtara-sdk/src/backend/mod.rs
@@ -96,7 +96,7 @@ pub trait SdkBackend: Send + Sync {
     ) -> Result<(Option<Signal>, Option<CustomSignal>)>;
 
     /// Acknowledge a received signal.
-    fn acknowledge_signal(&self, signal_type: SignalType) -> Result<()>;
+    fn acknowledge_signal(&self, command_id: &str, signal_type: SignalType) -> Result<bool>;
 
     /// Get the status of another instance by ID.
     fn get_instance_status(&self, instance_id: &str) -> Result<StatusResponse>;

--- a/crates/runtara-sdk/src/client.rs
+++ b/crates/runtara-sdk/src/client.rs
@@ -363,6 +363,7 @@ impl RuntaraSdk {
 
         if let Some(custom) = custom {
             let sdk_signal = Signal {
+                command_id: String::new(),
                 signal_type: SignalType::Resume, // custom signals are scoped; type unused here
                 payload: custom.payload,
                 checkpoint_id: Some(custom.checkpoint_id),
@@ -388,10 +389,8 @@ impl RuntaraSdk {
 
     /// Acknowledge a received signal.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(instance_id = %self.backend.instance_id())))]
-    pub fn acknowledge_signal(&self, signal_type: SignalType) -> Result<()> {
-        self.backend.acknowledge_signal(signal_type)?;
-        debug!("Signal acknowledged");
-        Ok(())
+    pub fn acknowledge_signal(&self, command_id: &str, signal_type: SignalType) -> Result<bool> {
+        self.backend.acknowledge_signal(command_id, signal_type)
     }
 
     /// Check for cancellation and return error if cancelled.

--- a/crates/runtara-sdk/src/registry.rs
+++ b/crates/runtara-sdk/src/registry.rs
@@ -20,7 +20,7 @@
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::tracing_compat::{info, warn};
+use crate::tracing_compat::info;
 use once_cell::sync::OnceCell;
 
 use crate::RuntaraSdk;
@@ -176,111 +176,40 @@ pub fn reset_cancellation() {
     INSTANCE_CANCELLED.store(false, Ordering::SeqCst);
 }
 
-/// Acknowledge cancellation to runtara-core.
-///
-/// This should be called when the instance detects a cancel signal and is about
-/// to exit. It sends a SignalAck to the core, which will update the instance
-/// status to "cancelled" (rather than "failed").
-///
-/// This function is used by the `#[resilient]` macro when cancellation is detected.
-/// It triggers the local cancellation flag and sends the acknowledgment.
-///
-/// # Example
-///
-/// ```ignore
-/// // Detected cancel signal in checkpoint response
-/// if checkpoint_result.should_cancel() {
-///     acknowledge_cancellation();
-///     return Err("Instance cancelled".into());
-/// }
-/// ```
-#[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
-pub fn acknowledge_cancellation() {
-    use crate::types::SignalType;
-
-    // Trigger local cancellation flag first
-    trigger_cancellation();
-
-    // Send acknowledgment to core
-    if let Some(sdk_mutex) = SDK_INSTANCE.get() {
-        match sdk_mutex.lock() {
-            Ok(sdk_guard) => match sdk_guard.acknowledge_signal(SignalType::Cancel) {
-                Ok(()) => info!("Cancellation acknowledged to core"),
-                Err(e) => warn!(error = %e, "Failed to acknowledge cancellation signal"),
-            },
-            Err(e) => warn!(error = %e, "Failed to lock SDK for cancellation acknowledgment"),
-        }
+/// Acknowledge the exact cancellation returned by polling or checkpointing.
+pub fn acknowledge_cancellation(command_id: &str) -> crate::Result<bool> {
+    let accepted = acknowledge_command(command_id, crate::types::SignalType::Cancel)?;
+    if accepted {
+        trigger_cancellation();
     }
+    Ok(accepted)
 }
 
-/// Acknowledge a pause signal to runtara-core.
-///
-/// This must be called when the workflow suspends due to a pause signal.
-/// Without acknowledgment, the pause signal remains pending and will be
-/// detected again on resume, causing the workflow to suspend immediately
-/// in an infinite loop.
-///
-/// # Example
-///
-/// ```ignore
-/// // Detected pause signal in checkpoint response
-/// if checkpoint_result.should_pause() {
-///     acknowledge_pause();
-///     sdk.suspended()?;
-///     return Ok(());
-/// }
-/// ```
-#[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
-pub fn acknowledge_pause() {
-    use crate::types::SignalType;
-
-    // Send acknowledgment to core
-    if let Some(sdk_mutex) = SDK_INSTANCE.get() {
-        match sdk_mutex.lock() {
-            Ok(sdk_guard) => match sdk_guard.acknowledge_signal(SignalType::Pause) {
-                Ok(()) => info!("Pause acknowledged to core"),
-                Err(e) => warn!(error = %e, "Failed to acknowledge pause signal"),
-            },
-            Err(e) => warn!(error = %e, "Failed to lock SDK for pause acknowledgment"),
-        }
-    }
+/// Acknowledge the exact pause returned by polling or checkpointing.
+pub fn acknowledge_pause(command_id: &str) -> crate::Result<bool> {
+    acknowledge_command(command_id, crate::types::SignalType::Pause)
 }
 
-/// Acknowledge a shutdown signal to runtara-core.
-///
-/// The server has asked this instance to suspend at the next checkpoint
-/// boundary so it can be resumed after restart. This function:
-///
-/// 1. Flips the local cancellation flag so `is_cancelled()` / `with_cancellation()`
-///    short-circuit any in-flight cooperative work.
-/// 2. Sends a `Shutdown` signal ack to core, which transitions the instance
-///    to `suspended` with `termination_reason = "shutdown_requested"`.
-///
-/// # Example
-///
-/// ```ignore
-/// if checkpoint_result.should_suspend_on_shutdown() {
-///     acknowledge_shutdown();
-///     sdk.suspended()?;
-///     return Ok(());
-/// }
-/// ```
-#[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
-pub fn acknowledge_shutdown() {
-    use crate::types::SignalType;
-
-    // Flip the local flag so any remaining cooperative work exits.
-    trigger_cancellation();
-
-    if let Some(sdk_mutex) = SDK_INSTANCE.get() {
-        match sdk_mutex.lock() {
-            Ok(sdk_guard) => match sdk_guard.acknowledge_signal(SignalType::Shutdown) {
-                Ok(()) => info!("Shutdown acknowledged to core"),
-                Err(e) => warn!(error = %e, "Failed to acknowledge shutdown signal"),
-            },
-            Err(e) => warn!(error = %e, "Failed to lock SDK for shutdown acknowledgment"),
-        }
+/// Acknowledge the exact shutdown returned by polling or checkpointing.
+pub fn acknowledge_shutdown(command_id: &str) -> crate::Result<bool> {
+    let accepted = acknowledge_command(command_id, crate::types::SignalType::Shutdown)?;
+    if accepted {
+        trigger_cancellation();
     }
+    Ok(accepted)
+}
+
+fn acknowledge_command(
+    command_id: &str,
+    signal_type: crate::types::SignalType,
+) -> crate::Result<bool> {
+    let Some(sdk_mutex) = SDK_INSTANCE.get() else {
+        return Ok(true);
+    };
+    let sdk = sdk_mutex
+        .lock()
+        .map_err(|e| crate::SdkError::Internal(e.to_string()))?;
+    sdk.acknowledge_signal(command_id, signal_type)
 }
 
 #[cfg(test)]

--- a/crates/runtara-sdk/src/types.rs
+++ b/crates/runtara-sdk/src/types.rs
@@ -38,6 +38,8 @@ pub enum SignalType {
 /// A signal received from runtara-core.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signal {
+    /// Opaque receipt for this lifecycle command.
+    pub command_id: String,
     /// The type of signal
     pub signal_type: SignalType,
     /// Signal-specific payload data
@@ -239,6 +241,7 @@ mod tests {
     #[test]
     fn test_signal_creation() {
         let signal = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Cancel,
             payload: vec![1, 2, 3],
             checkpoint_id: Some("checkpoint-1".to_string()),
@@ -252,6 +255,7 @@ mod tests {
     #[test]
     fn test_signal_without_checkpoint() {
         let signal = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Pause,
             payload: vec![],
             checkpoint_id: None,
@@ -265,6 +269,7 @@ mod tests {
     #[test]
     fn test_signal_clone() {
         let signal = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Resume,
             payload: vec![42],
             checkpoint_id: Some("cp".to_string()),
@@ -277,6 +282,7 @@ mod tests {
     #[test]
     fn test_signal_debug() {
         let signal = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Cancel,
             payload: vec![1],
             checkpoint_id: None,
@@ -321,6 +327,7 @@ mod tests {
             found: false,
             state: vec![],
             pending_signal: Some(Signal {
+                command_id: "test-command".into(),
                 signal_type: SignalType::Pause,
                 payload: vec![],
                 checkpoint_id: None,
@@ -339,6 +346,7 @@ mod tests {
             found: false,
             state: vec![],
             pending_signal: Some(Signal {
+                command_id: "test-command".into(),
                 signal_type: SignalType::Cancel,
                 payload: vec![],
                 checkpoint_id: None,
@@ -357,6 +365,7 @@ mod tests {
             found: false,
             state: vec![],
             pending_signal: Some(Signal {
+                command_id: "test-command".into(),
                 signal_type: SignalType::Resume,
                 payload: vec![],
                 checkpoint_id: None,
@@ -412,6 +421,7 @@ mod tests {
             found: true,
             state: vec![1, 2, 3],
             pending_signal: Some(Signal {
+                command_id: "test-command".into(),
                 signal_type: SignalType::Pause,
                 payload: vec![4],
                 checkpoint_id: Some("cp".to_string()),

--- a/crates/runtara-sdk/tests/cancellation_test.rs
+++ b/crates/runtara-sdk/tests/cancellation_test.rs
@@ -389,7 +389,7 @@ fn test_acknowledge_cancellation_no_registry() {
     runtara_sdk::reset_cancellation();
 
     // This should not panic even if no SDK is registered
-    runtara_sdk::acknowledge_cancellation();
+    runtara_sdk::acknowledge_cancellation("test-command").unwrap();
 
     // It flips the local flag before trying to reach core, so the ack is
     // observable even with no SDK registered.
@@ -407,7 +407,7 @@ fn test_acknowledge_cancellation_triggers_token() {
     assert!(!runtara_sdk::is_cancelled(), "reset clears the flag");
 
     // Call acknowledge_cancellation - this should trigger local cancellation
-    runtara_sdk::acknowledge_cancellation();
+    runtara_sdk::acknowledge_cancellation("test-command").unwrap();
 
     assert!(
         runtara_sdk::is_cancelled(),
@@ -425,9 +425,9 @@ fn test_acknowledge_cancellation_idempotent() {
     runtara_sdk::reset_cancellation();
 
     // Call multiple times - should not panic
-    runtara_sdk::acknowledge_cancellation();
-    runtara_sdk::acknowledge_cancellation();
-    runtara_sdk::acknowledge_cancellation();
+    runtara_sdk::acknowledge_cancellation("test-command").unwrap();
+    runtara_sdk::acknowledge_cancellation("test-command").unwrap();
+    runtara_sdk::acknowledge_cancellation("test-command").unwrap();
 
     // Repeated acks land on the same terminal state.
     assert!(runtara_sdk::is_cancelled());
@@ -509,7 +509,7 @@ fn test_acknowledge_pause_no_registry() {
     runtara_sdk::reset_cancellation();
 
     // This should not panic even if no SDK is registered
-    runtara_sdk::acknowledge_pause();
+    runtara_sdk::acknowledge_pause("test-command").unwrap();
 
     // Verify we can still call other functions
     assert!(!runtara_sdk::is_cancelled());
@@ -522,9 +522,9 @@ fn test_acknowledge_pause_idempotent() {
     runtara_sdk::reset_cancellation();
 
     // Call multiple times - should not panic
-    runtara_sdk::acknowledge_pause();
-    runtara_sdk::acknowledge_pause();
-    runtara_sdk::acknowledge_pause();
+    runtara_sdk::acknowledge_pause("test-command").unwrap();
+    runtara_sdk::acknowledge_pause("test-command").unwrap();
+    runtara_sdk::acknowledge_pause("test-command").unwrap();
 
     // Should still work after multiple calls
     assert!(!runtara_sdk::is_cancelled());
@@ -539,7 +539,7 @@ fn test_acknowledge_pause_does_not_cancel() {
     assert!(!runtara_sdk::is_cancelled());
 
     // Acknowledge pause
-    runtara_sdk::acknowledge_pause();
+    runtara_sdk::acknowledge_pause("test-command").unwrap();
 
     // The key invariant: unlike acknowledge_cancellation, a pause ack must not
     // touch the cancellation flag.

--- a/crates/runtara-server/src/api/handlers/workflows.rs
+++ b/crates/runtara-server/src/api/handlers/workflows.rs
@@ -2344,9 +2344,7 @@ pub async fn stop_instance_handler(
         Ok(StopOutcome::Stopped { previous_status }) => {
             let response = ApiResponse::success_with_message(
                 format!(
-                    "Cancellation requested for instance {} (was: {}). \
-                     The instance stops at its next signal checkpoint and \
-                     lands on status `cancelled`.",
+                    "Cancellation requested for instance {} (was: {}).",
                     instance_id, previous_status
                 ),
                 serde_json::Value::Null,

--- a/crates/runtara-server/src/core_runtime/http_server.rs
+++ b/crates/runtara-server/src/core_runtime/http_server.rs
@@ -90,6 +90,7 @@ pub struct CheckpointResponse {
 /// Signal information
 #[derive(Debug, Serialize)]
 pub struct SignalInfo {
+    pub command_id: String,
     pub signal_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<String>,
@@ -138,6 +139,7 @@ pub struct SleepRequest {
 /// Signal acknowledgement request
 #[derive(Debug, Deserialize)]
 pub struct SignalAckRequest {
+    pub command_id: String,
     pub signal_type: String,
 }
 
@@ -343,6 +345,7 @@ async fn checkpoint_handler(
     match instance_handlers::handle_checkpoint(&state, request).await {
         Ok(resp) => {
             let signal = resp.pending_signal.map(|s| SignalInfo {
+                command_id: s.command_id,
                 signal_type: signal_type_to_string(s.signal_type),
                 payload: if s.payload.is_empty() {
                     None
@@ -389,6 +392,7 @@ async fn poll_signals_handler(
     match instance_handlers::handle_poll_signals(&state, request).await {
         Ok(resp) => {
             let signal = resp.signal.map(|s| SignalInfo {
+                command_id: s.command_id,
                 signal_type: signal_type_to_string(s.signal_type),
                 payload: if s.payload.is_empty() {
                     None
@@ -648,13 +652,14 @@ async fn signal_ack_handler(
     };
 
     let ack = HandlerSignalAck {
+        command_id: body.command_id,
         instance_id,
         signal_type,
         acknowledged: true,
     };
 
     match instance_handlers::handle_signal_ack(&state, ack).await {
-        Ok(()) => Json(SuccessResponse { success: true }).into_response(),
+        Ok(success) => Json(SuccessResponse { success }).into_response(),
         Err(e) => core_error_response("SIGNAL_ACK_ERROR", "Signal ack error", e),
     }
 }

--- a/crates/runtara-server/src/core_runtime/mod.rs
+++ b/crates/runtara-server/src/core_runtime/mod.rs
@@ -537,8 +537,13 @@ mod tests {
             Ok(None)
         }
 
-        async fn acknowledge_signal(&self, _instance_id: &str) -> Result<(), CoreError> {
-            Ok(())
+        async fn acknowledge_signal(
+            &self,
+            _instance_id: &str,
+            _command_id: &str,
+            _signal_type: runtara_core::domain::SignalType,
+        ) -> Result<bool, CoreError> {
+            Ok(false)
         }
 
         async fn insert_custom_signal(

--- a/crates/runtara-server/src/core_runtime/mod.rs
+++ b/crates/runtara-server/src/core_runtime/mod.rs
@@ -546,6 +546,17 @@ mod tests {
             Ok(false)
         }
 
+        async fn cancel_suspended_instances(
+            &self,
+            _instance_id: Option<&str>,
+            _limit: i64,
+        ) -> std::result::Result<
+            Vec<runtara_core::persistence::CancelledInstance>,
+            runtara_core::error::CoreError,
+        > {
+            Ok(Vec::new())
+        }
+
         async fn insert_custom_signal(
             &self,
             _instance_id: &str,

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -2084,18 +2084,6 @@ impl ExecutionEngine {
             ExecutionError::DatabaseError(format!("Failed to cancel instance: {}", e))
         })?;
 
-        if matches!(
-            runtara_status,
-            crate::runtime_client::InstanceStatus::Suspended
-        ) && let Err(e) = client.resume_instance(instance_id).await
-        {
-            warn!(
-                instance_id = %instance_id,
-                error = %e,
-                "Failed to resume suspended instance for cancellation"
-            );
-        }
-
         info!(
             instance_id = %instance_id,
             previous_status = %status_str,

--- a/crates/runtara-server/tests/core_instance_api.rs
+++ b/crates/runtara-server/tests/core_instance_api.rs
@@ -314,7 +314,7 @@ async fn typed_signals_round_trip_through_poll_checkpoint_and_ack() {
         assert_eq!(checkpoint["signal"], poll["signal"]);
         client
             .post(format!("{url}/signals/ack"))
-            .json(&json!({"signal_type": label}))
+            .json(&json!({"signal_type": label, "command_id": poll["signal"]["command_id"]}))
             .send()
             .await
             .unwrap()

--- a/crates/runtara-store-postgres/migrations/postgresql/020_lifecycle_command_identity.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/020_lifecycle_command_identity.sql
@@ -1,0 +1,3 @@
+-- A receipt identifies a command, even when the per-instance slot is replaced.
+ALTER TABLE pending_signals
+    ADD COLUMN command_id UUID NOT NULL DEFAULT gen_random_uuid();

--- a/crates/runtara-store-postgres/migrations/postgresql/021_index_pending_cancellations.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/021_index_pending_cancellations.sql
@@ -1,0 +1,4 @@
+-- Recovery polls pending cancellations independently of sleep deadlines.
+-- Keep that scan bounded by pending work rather than retained command history.
+CREATE INDEX idx_pending_cancellations ON pending_signals (instance_id)
+    WHERE signal_type = 'cancel' AND acknowledged_at IS NULL;

--- a/crates/runtara-store-postgres/src/backend.rs
+++ b/crates/runtara-store-postgres/src/backend.rs
@@ -658,6 +658,57 @@ impl Persistence for PostgresPersistence {
         Ok(true)
     }
 
+    async fn cancel_suspended_instances(
+        &self,
+        instance_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<runtara_core::persistence::CancelledInstance>, CoreError> {
+        // Lock instances first, as in explicit acknowledgment. The command ID
+        // joins both writes so a replaced/handled receipt cannot cancel a run.
+        // One statement commits status, deadline clearing and receipt together.
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            r#"
+            WITH candidates AS MATERIALIZED (
+                SELECT i.instance_id, s.command_id
+                FROM instances i JOIN pending_signals s USING (instance_id)
+                WHERE i.status = 'suspended'
+                  AND s.signal_type = 'cancel' AND s.acknowledged_at IS NULL
+                  AND ($1::text IS NULL OR i.instance_id = $1)
+                ORDER BY i.instance_id
+                LIMIT $2
+                FOR UPDATE OF i SKIP LOCKED
+            ), acknowledged AS (
+                UPDATE pending_signals s SET acknowledged_at = NOW()
+                FROM candidates c
+                WHERE s.instance_id = c.instance_id AND s.command_id = c.command_id
+                  AND s.signal_type = 'cancel' AND s.acknowledged_at IS NULL
+                RETURNING s.instance_id
+            )
+            UPDATE instances i
+            SET status = 'cancelled', finished_at = NOW(), sleep_until = NULL
+            FROM acknowledged a
+            WHERE i.instance_id = a.instance_id
+            RETURNING i.instance_id, i.tenant_id
+        "#,
+        )
+        .bind(instance_id)
+        .bind(limit.max(0))
+        .fetch_all(&self.pool)
+        .await
+        .db()?;
+        let mut cancelled = Vec::new();
+        for (instance_id, tenant_id) in rows {
+            if let Some(sink) = &self.metrics_sink {
+                report_completion(sink.as_ref(), &self.pool, &instance_id).await;
+            }
+            cancelled.push(runtara_core::persistence::CancelledInstance {
+                instance_id,
+                tenant_id,
+            });
+        }
+        Ok(cancelled)
+    }
+
     async fn insert_custom_signal(
         &self,
         instance_id: &str,

--- a/crates/runtara-store-postgres/src/backend.rs
+++ b/crates/runtara-store-postgres/src/backend.rs
@@ -348,7 +348,7 @@ async fn insert_event(pool: &PgPool, event: &EventRecord) -> Result<(), CoreErro
 // ============================================================================
 
 /// Insert or update a pending signal.
-/// Uses ON CONFLICT to replace existing signal for the same instance.
+/// Replaces the previous command unless an unacknowledged cancellation dominates.
 async fn insert_signal(
     pool: &PgPool,
     instance_id: &str,
@@ -369,7 +369,10 @@ async fn insert_signal(
         SET signal_type = EXCLUDED.signal_type,
             payload = EXCLUDED.payload,
             created_at = NOW(),
-            acknowledged_at = NULL
+            acknowledged_at = NULL,
+            command_id = gen_random_uuid()
+        WHERE pending_signals.acknowledged_at IS NOT NULL
+           OR pending_signals.signal_type <> 'cancel'
         "#,
     )
     .bind(instance_id)
@@ -414,9 +417,9 @@ async fn insert_custom_signal(
     Ok(())
 }
 
-// `get_pending_signal`, `acknowledge_signal`, `take_pending_custom_signal`
+// `get_pending_signal`, `take_pending_custom_signal`
 // are migrated to the shared layer:
-// see PostgresPersistence::op_get_pending_signal / op_acknowledge_signal /
+// see PostgresPersistence::op_get_pending_signal /
 // op_take_pending_custom_signal (crate::ops_common::ops::signals).
 
 // Health, sleep, and active-count operations are migrated to the shared layer:
@@ -583,8 +586,76 @@ impl Persistence for PostgresPersistence {
         Self::op_get_pending_signal(&self.pool, instance_id).await
     }
 
-    async fn acknowledge_signal(&self, instance_id: &str) -> Result<(), CoreError> {
-        Self::op_acknowledge_signal(&self.pool, instance_id).await
+    async fn acknowledge_signal(
+        &self,
+        instance_id: &str,
+        command_id: &str,
+        signal_type: CoreSignalType,
+    ) -> Result<bool, CoreError> {
+        // Lock the instance before its command. Lifecycle transitions and future
+        // parked cancellation use this ordering too.
+        let mut tx = self.pool.begin().await.db()?;
+        let status: Option<String> = sqlx::query_scalar(
+            "SELECT status::text FROM instances WHERE instance_id = $1 FOR UPDATE",
+        )
+        .bind(instance_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .db()?;
+        let Some(status) = status else {
+            return Err(CoreError::InstanceNotFound {
+                instance_id: instance_id.into(),
+            });
+        };
+        let command: Option<(String, String, Option<DateTime<Utc>>)> = sqlx::query_as(
+            "SELECT command_id::text, signal_type::text, acknowledged_at FROM pending_signals WHERE instance_id = $1 FOR UPDATE"
+        ).bind(instance_id).fetch_optional(&mut *tx).await.db()?;
+        let Some((stored_id, stored_type, acknowledged_at)) = command else {
+            return Ok(false);
+        };
+        if stored_id != command_id
+            || stored_type != crate::encoding::signal_type_to_str(signal_type)
+        {
+            return Ok(false);
+        }
+        if acknowledged_at.is_some() {
+            return Ok(true);
+        }
+        if is_reportable_terminal_status(&status) && signal_type != CoreSignalType::Cancel {
+            return Ok(false);
+        }
+        match signal_type {
+            CoreSignalType::Cancel => {
+                sqlx::query("UPDATE instances SET status = 'cancelled', finished_at = NOW(), sleep_until = NULL WHERE instance_id = $1")
+                    .bind(instance_id).execute(&mut *tx).await.db()?;
+            }
+            CoreSignalType::Pause | CoreSignalType::Shutdown => {
+                let shutdown = signal_type == CoreSignalType::Shutdown;
+                sqlx::query("UPDATE instances SET status = 'suspended', finished_at = NOW(), termination_reason = CASE WHEN $2 THEN 'shutdown_requested'::termination_reason ELSE NULL END, sleep_until = CASE WHEN $2 THEN NOW() ELSE NULL END WHERE instance_id = $1")
+                    .bind(instance_id).bind(shutdown).execute(&mut *tx).await.db()?;
+            }
+            CoreSignalType::Resume => {}
+        }
+        if matches!(
+            signal_type,
+            CoreSignalType::Pause | CoreSignalType::Shutdown
+        ) {
+            sqlx::query("INSERT INTO instance_events (instance_id, event_type, created_at) VALUES ($1, 'suspended', NOW())")
+                .bind(instance_id).execute(&mut *tx).await.db()?;
+        }
+        sqlx::query("UPDATE pending_signals SET acknowledged_at = NOW() WHERE instance_id = $1")
+            .bind(instance_id)
+            .execute(&mut *tx)
+            .await
+            .db()?;
+        tx.commit().await.db()?;
+        if signal_type == CoreSignalType::Cancel
+            && !is_reportable_terminal_status(&status)
+            && let Some(sink) = &self.metrics_sink
+        {
+            report_completion(sink.as_ref(), &self.pool, instance_id).await;
+        }
+        Ok(true)
     }
 
     async fn insert_custom_signal(
@@ -1441,9 +1512,22 @@ mod tests {
         insert_signal(&pool, &instance_id.to_string(), CoreSignalType::Cancel, b"")
             .await
             .unwrap();
-        PostgresPersistence::op_acknowledge_signal(&pool, &instance_id.to_string())
+        let backend = PostgresPersistence::new(pool.clone());
+        let signal = backend
+            .get_pending_signal(&instance_id.to_string())
             .await
+            .unwrap()
             .unwrap();
+        assert!(
+            backend
+                .acknowledge_signal(
+                    &instance_id.to_string(),
+                    &signal.command_id,
+                    signal.signal_type
+                )
+                .await
+                .unwrap()
+        );
 
         // Should no longer return as pending
         let signal = PostgresPersistence::op_get_pending_signal(&pool, &instance_id.to_string())

--- a/crates/runtara-store-postgres/src/dialect/mod.rs
+++ b/crates/runtara-store-postgres/src/dialect/mod.rs
@@ -128,9 +128,6 @@ pub(crate) trait Dialect: Send + Sync + 'static {
     /// re-suspend a relaunched instance on a signal it already handled.
     fn sql_get_pending_signal() -> &'static str;
 
-    /// SQL for acknowledging a pending signal (bind: instance_id).
-    fn sql_acknowledge_signal() -> &'static str;
-
     /// SQL for `health_check`. Must return a single `BIGINT` (i64)
     /// column so the shared op can decode it as `(i64,)`, which is why the
     /// literal carries a `::bigint` cast — `SELECT 1` on its own produces a

--- a/crates/runtara-store-postgres/src/dialect/postgres.rs
+++ b/crates/runtara-store-postgres/src/dialect/postgres.rs
@@ -113,14 +113,8 @@ impl Dialect for PostgresDialect {
     }
 
     fn sql_get_pending_signal() -> &'static str {
-        "SELECT instance_id, signal_type::text as signal_type, payload, created_at, acknowledged_at \
+        "SELECT instance_id, command_id::text as command_id, signal_type::text as signal_type, payload, created_at, acknowledged_at \
          FROM pending_signals \
-         WHERE instance_id = $1 AND acknowledged_at IS NULL"
-    }
-
-    fn sql_acknowledge_signal() -> &'static str {
-        "UPDATE pending_signals \
-         SET acknowledged_at = NOW() \
          WHERE instance_id = $1 AND acknowledged_at IS NULL"
     }
 

--- a/crates/runtara-store-postgres/src/ops_common/ops/signals.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/signals.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! Signal-family operations.
 //!
-//! Hosts: `get_pending_signal`, `acknowledge_signal`,
+//! Hosts: `get_pending_signal`,
 //! `take_pending_custom_signal`.
 //!
 //! Not hosted here: `insert_signal` / `insert_custom_signal` stay inline
@@ -44,26 +44,6 @@ macro_rules! impl_signal_ops {
                         details: e.to_string(),
                     })?;
                 Ok(record.map(|r| r.0))
-            }
-
-            /// UPDATE `acknowledged_at = NOW()` for the pending signal.
-            /// Non-error if no pending row exists (by design — acks are
-            /// idempotent).
-            pub(crate) async fn op_acknowledge_signal(
-                pool: &$Pool,
-                instance_id: &str,
-            ) -> ::core::result::Result<(), ::runtara_core::error::CoreError> {
-                use crate::dialect::Dialect;
-                let sql = <$Dialect>::sql_acknowledge_signal();
-                ::sqlx::query(sql)
-                    .bind(instance_id)
-                    .execute(pool)
-                    .await
-                    .map_err(|e| ::runtara_core::error::CoreError::PersistenceError {
-                        operation: "acknowledge_signal".into(),
-                        details: e.to_string(),
-                    })?;
-                Ok(())
             }
 
             /// Read (non-destructively) the pending custom signal for

--- a/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
@@ -28,7 +28,7 @@ macro_rules! impl_sleep_ops {
                 let p1 = <$Dialect>::placeholder(1);
                 let p2 = <$Dialect>::placeholder(2);
                 let sql = format!(
-                    "UPDATE instances SET sleep_until = {p2} WHERE instance_id = {p1}"
+                    "UPDATE instances SET sleep_until = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN NULL ELSE {p2} END WHERE instance_id = {p1}"
                 );
                 let result = ::sqlx::query(&sql)
                     .bind(instance_id)

--- a/crates/runtara-store-postgres/src/rows.rs
+++ b/crates/runtara-store-postgres/src/rows.rs
@@ -87,6 +87,7 @@ pub struct SignalRow(pub SignalRecord);
 impl<'r> FromRow<'r, PgRow> for SignalRow {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         Ok(Self(SignalRecord {
+            command_id: row.try_get("command_id")?,
             instance_id: row.try_get("instance_id")?,
             signal_type: crate::encoding::signal_type_from_str(
                 &row.try_get::<String, _>("signal_type")?,

--- a/crates/runtara-store-postgres/tests/conformance.rs
+++ b/crates/runtara-store-postgres/tests/conformance.rs
@@ -33,6 +33,7 @@ async fn postgres_backend_passes_conformance_sequence() {
     let backend = PostgresPersistence::new(pool);
     run_conformance_sequence(&backend).await;
     runtara_core::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
+    runtara_core::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
 }
 
 /// Obtain a Postgres pool. Prefers `TEST_RUNTARA_DATABASE_URL` (for CI and
@@ -238,5 +239,62 @@ async fn command_ack_rolls_back_transition_when_receipt_write_fails() {
             .acknowledge_signal(&id, &signal.command_id, SignalType::Shutdown)
             .await
             .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn parked_cancellation_rolls_back_ack_when_transition_fails() {
+    use runtara_core::{
+        domain::{InstanceStatus, SignalType},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool.clone());
+    let id = uuid::Uuid::new_v4().to_string();
+    backend.register_instance(&id, "park-atomic").await.unwrap();
+    backend
+        .update_instance_status(&id, InstanceStatus::Suspended, None)
+        .await
+        .unwrap();
+    let deadline = chrono::Utc::now() + chrono::Duration::hours(24);
+    backend.set_instance_sleep(&id, deadline).await.unwrap();
+    backend
+        .insert_signal(&id, SignalType::Cancel, b"")
+        .await
+        .unwrap();
+    let receipt = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    let constraint = format!("park_ack_failure_{}", uuid::Uuid::new_v4().simple());
+    sqlx::query(&format!("ALTER TABLE instances ADD CONSTRAINT {constraint} CHECK (instance_id <> '{id}' OR status <> 'cancelled')"))
+        .execute(&pool).await.unwrap();
+    let result = backend.cancel_suspended_instances(Some(&id), 1).await;
+    sqlx::query(&format!(
+        "ALTER TABLE instances DROP CONSTRAINT {constraint}"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert!(result.is_err());
+    let instance = backend.get_instance(&id).await.unwrap().unwrap();
+    assert_eq!(instance.status, InstanceStatus::Suspended);
+    assert_eq!(
+        instance.sleep_until.unwrap().timestamp_millis(),
+        deadline.timestamp_millis()
+    );
+    assert_eq!(
+        backend
+            .get_pending_signal(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .command_id,
+        receipt.command_id
+    );
+    assert_eq!(
+        backend
+            .cancel_suspended_instances(Some(&id), 1)
+            .await
+            .unwrap()
+            .len(),
+        1
     );
 }

--- a/crates/runtara-store-postgres/tests/conformance.rs
+++ b/crates/runtara-store-postgres/tests/conformance.rs
@@ -32,6 +32,7 @@ async fn postgres_backend_passes_conformance_sequence() {
     let (pool, _container) = postgres_test_pool().await;
     let backend = PostgresPersistence::new(pool);
     run_conformance_sequence(&backend).await;
+    runtara_core::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
 }
 
 /// Obtain a Postgres pool. Prefers `TEST_RUNTARA_DATABASE_URL` (for CI and
@@ -127,14 +128,30 @@ async fn domain_values_match_the_existing_postgres_schema() {
         SignalType::Shutdown,
     ] {
         backend
+            .update_instance_status(&id, InstanceStatus::Running, None)
+            .await
+            .unwrap();
+        backend
             .insert_signal(&id, signal_type, b"payload")
             .await
             .unwrap();
         let signal = backend.get_pending_signal(&id).await.unwrap().unwrap();
         assert_eq!(signal.signal_type, signal_type);
         assert_eq!(signal.payload.as_deref(), Some(b"payload".as_slice()));
-        backend.acknowledge_signal(&id).await.unwrap();
+        let receipt = backend.get_pending_signal(&id).await.unwrap().unwrap();
+        backend
+            .acknowledge_signal(&id, &receipt.command_id, receipt.signal_type)
+            .await
+            .unwrap();
     }
+    backend
+        .delete_instances_batch(std::slice::from_ref(&id))
+        .await
+        .unwrap();
+    backend
+        .register_instance(&id, "typed-contract")
+        .await
+        .unwrap();
     for event_type in [
         EventType::Started,
         EventType::Progress,
@@ -166,4 +183,60 @@ async fn domain_values_match_the_existing_postgres_schema() {
         assert_eq!(backend.count_events(&id, &filter).await.unwrap(), 1);
     }
     backend.delete_instances_batch(&[id]).await.unwrap();
+}
+
+#[tokio::test]
+async fn command_ack_rolls_back_transition_when_receipt_write_fails() {
+    use runtara_core::{
+        domain::{InstanceStatus, SignalType},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool.clone());
+    let id = uuid::Uuid::new_v4().to_string();
+    backend.register_instance(&id, "atomic-ack").await.unwrap();
+    backend
+        .update_instance_status(&id, InstanceStatus::Running, None)
+        .await
+        .unwrap();
+    backend
+        .insert_signal(&id, SignalType::Shutdown, b"")
+        .await
+        .unwrap();
+    let signal = backend.get_pending_signal(&id).await.unwrap().unwrap();
+    // Fail the second write after the status and wake deadline have been updated.
+    // The constraint is scoped to this test's UUID and removed before asserting.
+    let constraint = format!("ack_failure_{}", uuid::Uuid::new_v4().simple());
+    sqlx::query(&format!("ALTER TABLE pending_signals ADD CONSTRAINT {constraint} CHECK (instance_id <> '{id}' OR acknowledged_at IS NULL)"))
+        .execute(&pool).await.unwrap();
+    let result = backend
+        .acknowledge_signal(&id, &signal.command_id, SignalType::Shutdown)
+        .await;
+    sqlx::query(&format!(
+        "ALTER TABLE pending_signals DROP CONSTRAINT {constraint}"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert!(result.is_err());
+    let instance = backend.get_instance(&id).await.unwrap().unwrap();
+    assert_eq!(instance.status, InstanceStatus::Running);
+    assert!(instance.finished_at.is_none());
+    assert!(instance.sleep_until.is_none());
+    assert!(instance.termination_reason.is_none());
+    assert_eq!(
+        backend
+            .get_pending_signal(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .command_id,
+        signal.command_id
+    );
+    assert!(
+        backend
+            .acknowledge_signal(&id, &signal.command_id, SignalType::Shutdown)
+            .await
+            .unwrap()
+    );
 }

--- a/crates/runtara-workflow-runtime/src/lib.rs
+++ b/crates/runtara-workflow-runtime/src/lib.rs
@@ -58,6 +58,7 @@ fn with_sdk_mut<T>(op: impl FnOnce(&mut RuntaraSdk) -> Result<T, String>) -> Res
     op(&mut guard)
 }
 
+#[cfg(test)]
 fn signal_is_cancel(signal: Option<Signal>) -> bool {
     signal.is_some_and(|signal| signal.signal_type == SignalType::Cancel)
 }
@@ -72,6 +73,7 @@ enum CheckpointSignalAction {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeSignalInfo {
     pub signal_type: String,
+    pub command_id: String,
     pub payload: Vec<u8>,
     pub checkpoint_id: Option<String>,
 }
@@ -111,6 +113,7 @@ fn checkpoint_signal_action(signal_type: &str) -> Option<CheckpointSignalAction>
 fn runtime_signal(signal: Signal) -> RuntimeSignalInfo {
     RuntimeSignalInfo {
         signal_type: signal_type_name(signal.signal_type).to_string(),
+        command_id: signal.command_id,
         payload: signal.payload,
         checkpoint_id: signal.checkpoint_id,
     }
@@ -162,7 +165,6 @@ pub fn debug_mode_enabled() -> Result<bool, String> {
 }
 
 pub fn breakpoint_pause() -> Result<(), String> {
-    runtara_sdk::acknowledge_pause();
     let _ = with_sdk(|sdk| sdk.suspended().map_err(sdk_error));
     Ok(())
 }
@@ -175,38 +177,22 @@ pub fn is_cancelled() -> Result<bool, String> {
     if runtara_sdk::is_cancelled() {
         return Ok(true);
     }
-
-    let cancelled = with_sdk_mut(|sdk| sdk.poll_signal().map(signal_is_cancel).map_err(sdk_error))?;
-
-    if cancelled {
-        runtara_sdk::acknowledge_cancellation();
+    let signal = with_sdk_mut(|sdk| sdk.poll_signal().map_err(sdk_error))?;
+    match signal {
+        Some(signal) if signal.signal_type == SignalType::Cancel => {
+            runtara_sdk::acknowledge_cancellation(&signal.command_id).map_err(sdk_error)
+        }
+        _ => Ok(false),
     }
-
-    Ok(cancelled)
 }
 
 pub fn check_signals() -> Result<bool, String> {
     let signal = with_sdk_mut(|sdk| sdk.poll_signal().map_err(sdk_error))?;
-    let Some(signal) = signal else {
-        return Ok(false);
-    };
-
-    match signal.signal_type {
-        SignalType::Cancel => {
-            runtara_sdk::acknowledge_cancellation();
-            Ok(true)
+    match signal {
+        Some(signal) => {
+            handle_checkpoint_signal(signal_type_name(signal.signal_type), &signal.command_id)
         }
-        SignalType::Pause => {
-            runtara_sdk::acknowledge_pause();
-            with_sdk(|sdk| sdk.suspended().map_err(sdk_error))?;
-            Ok(true)
-        }
-        SignalType::Shutdown => {
-            runtara_sdk::acknowledge_shutdown();
-            with_sdk(|sdk| sdk.suspended().map_err(sdk_error))?;
-            Ok(true)
-        }
-        SignalType::Resume => Ok(false),
+        None => Ok(false),
     }
 }
 
@@ -243,24 +229,15 @@ pub fn checkpoint(checkpoint_id: &str, state: &[u8]) -> Result<RuntimeCheckpoint
     })
 }
 
-pub fn handle_checkpoint_signal(signal_type: &str) -> Result<bool, String> {
-    match checkpoint_signal_action(signal_type) {
-        Some(CheckpointSignalAction::Cancel) => {
-            runtara_sdk::acknowledge_cancellation();
-            Ok(true)
-        }
-        Some(CheckpointSignalAction::Pause) => {
-            runtara_sdk::acknowledge_pause();
-            with_sdk(|sdk| sdk.suspended().map_err(sdk_error))?;
-            Ok(true)
-        }
-        Some(CheckpointSignalAction::Shutdown) => {
-            runtara_sdk::acknowledge_shutdown();
-            with_sdk(|sdk| sdk.suspended().map_err(sdk_error))?;
-            Ok(true)
-        }
-        None => Ok(false),
+pub fn handle_checkpoint_signal(signal_type: &str, command_id: &str) -> Result<bool, String> {
+    let accepted = match checkpoint_signal_action(signal_type) {
+        Some(CheckpointSignalAction::Cancel) => runtara_sdk::acknowledge_cancellation(command_id),
+        Some(CheckpointSignalAction::Pause) => runtara_sdk::acknowledge_pause(command_id),
+        Some(CheckpointSignalAction::Shutdown) => runtara_sdk::acknowledge_shutdown(command_id),
+        None => return Ok(false),
     }
+    .map_err(sdk_error)?;
+    Ok(accepted)
 }
 
 pub fn record_retry_attempt(
@@ -292,6 +269,7 @@ mod component {
     fn signal_info(signal: super::RuntimeSignalInfo) -> SignalInfo {
         SignalInfo {
             signal_type: signal.signal_type,
+            command_id: signal.command_id,
             payload: signal.payload,
             checkpoint_id: signal.checkpoint_id,
         }
@@ -378,8 +356,11 @@ mod component {
             super::checkpoint(&checkpoint_id, &state).map(checkpoint_result)
         }
 
-        fn handle_checkpoint_signal(signal_type: String) -> Result<bool, String> {
-            super::handle_checkpoint_signal(&signal_type)
+        fn handle_checkpoint_signal(
+            signal_type: String,
+            command_id: String,
+        ) -> Result<bool, String> {
+            super::handle_checkpoint_signal(&signal_type, &command_id)
         }
 
         fn record_retry_attempt(
@@ -471,11 +452,13 @@ mod tests {
     #[test]
     fn only_cancel_signals_are_terminal_cancellation() {
         let pause = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Pause,
             payload: Vec::new(),
             checkpoint_id: None,
         };
         let cancel = Signal {
+            command_id: "test-command".into(),
             signal_type: SignalType::Cancel,
             payload: Vec::new(),
             checkpoint_id: None,
@@ -518,6 +501,7 @@ mod tests {
             found: true,
             state: br#"{"ok":true}"#.to_vec(),
             pending_signal: Some(Signal {
+                command_id: "test-command".into(),
                 signal_type: SignalType::Pause,
                 payload: b"pause-now".to_vec(),
                 checkpoint_id: Some("step-a".to_string()),

--- a/crates/runtara-workflow-wit/README.md
+++ b/crates/runtara-workflow-wit/README.md
@@ -7,9 +7,17 @@ This crate intentionally separates workflow semantics from runtime lifecycle:
 - `runtara:workflow-stdlib/json@0.1.0` owns reusable JSON semantics such as
   manifest initialization, source construction, mappings, conditions, switch
   routing, filtering, logging payloads, structured error payloads, and grouping.
-- `runtara:workflow-runtime/runtime@0.1.0` owns SDK/runtime lifecycle calls such
+- `runtara:workflow-runtime/runtime@0.2.0` owns SDK/runtime lifecycle calls such
   as input loading, completion, failure, events, cancellation, and durable
   sleep.
 
 Both are composed statically with workflow-logic and agent components into one
 final `workflow.wasm`.
+
+The runtime 0.2.0 contract adds `command-id` to lifecycle signals and requires it
+when acknowledging a checkpoint signal. Recompile workflow artifacts and rebuild
+the shared runtime component when upgrading from 0.1.0. The instance HTTP API
+likewise requires the `command_id` returned by polling or checkpointing in
+`POST /api/v1/instances/{instance_id}/signals/ack`; `success: false` means the
+receipt is stale and no lifecycle transition was applied. Retrying an accepted
+receipt succeeds without applying the transition again.

--- a/crates/runtara-workflow-wit/src/lib.rs
+++ b/crates/runtara-workflow-wit/src/lib.rs
@@ -9,7 +9,10 @@ pub const WORKFLOW_WIT_VERSION: &str = "0.1.0";
 pub const STDLIB_PACKAGE: &str = "runtara:workflow-stdlib@0.1.0";
 
 /// WIT package name for the runtime/SDK lifecycle component.
-pub const RUNTIME_PACKAGE: &str = "runtara:workflow-runtime@0.1.0";
+pub const RUNTIME_PACKAGE: &str = "runtara:workflow-runtime@0.2.0";
+
+/// Runtime interface imported by compiled workflows and implemented by the host.
+pub const RUNTIME_INTERFACE_NAME: &str = "runtara:workflow-runtime/runtime@0.2.0";
 
 /// WIT package name for safe runtime connection resolution.
 pub const CONNECTION_RESOLVER_PACKAGE: &str = "runtara:connection-resolver@0.1.0";
@@ -35,7 +38,7 @@ pub const LIFECYCLE_INTERFACE_NAME_V1: &str = "runtara:workflow-lifecycle/lifecy
 /// WIT text for `runtara:workflow-stdlib@0.1.0`.
 pub const STDLIB_WIT: &str = include_str!("../wit/stdlib/runtara-workflow-stdlib.wit");
 
-/// WIT text for `runtara:workflow-runtime@0.1.0`.
+/// WIT text for `runtara:workflow-runtime@0.2.0`.
 pub const RUNTIME_WIT: &str = include_str!("../wit/runtime/runtara-workflow-runtime.wit");
 
 /// WIT text for `runtara:connection-resolver@0.1.0`.

--- a/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
+++ b/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
@@ -4,11 +4,12 @@
 // loading persisted input, completing/failing instances, event emission,
 // cancellation, heartbeat, and durable sleep.
 
-package runtara:workflow-runtime@0.1.0;
+package runtara:workflow-runtime@0.2.0;
 
 interface runtime {
     record signal-info {
         signal-type: string,
+        command-id: string,
         payload: list<u8>,
         checkpoint-id: option<string>,
     }
@@ -69,6 +70,7 @@ interface runtime {
 
     handle-checkpoint-signal: func(
         signal-type: string,
+        command-id: string,
     ) -> result<bool, string>;
 
     record-retry-attempt: func(

--- a/crates/runtara-workflows/src/direct_wasm/compile.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile.rs
@@ -61,8 +61,8 @@ use std::time::Instant;
 
 use runtara_dsl::ExecutionGraph;
 use runtara_workflow_wit::{
-    ABI_WIT, CONNECTION_RESOLVER_WIT, LIFECYCLE_INTERFACE_NAME, LIFECYCLE_WIT, RUNTIME_WIT,
-    STDLIB_WIT, WORKFLOW_WIT_VERSION,
+    ABI_WIT, CONNECTION_RESOLVER_WIT, LIFECYCLE_INTERFACE_NAME, LIFECYCLE_WIT,
+    RUNTIME_INTERFACE_NAME, RUNTIME_WIT, STDLIB_WIT, WORKFLOW_WIT_VERSION,
 };
 use sha2::{Digest, Sha256};
 use wasm_encoder::{CustomSection, Encode, Function as WasmFunction, Instruction, Section};
@@ -165,6 +165,8 @@ const DIRECT_CHECKPOINT_FOUND_OFFSET: u64 = 4;
 const DIRECT_CHECKPOINT_PENDING_SIGNAL_TAG_OFFSET: u64 = 16;
 const DIRECT_CHECKPOINT_SIGNAL_TYPE_PTR_OFFSET: u64 = 20;
 const DIRECT_CHECKPOINT_SIGNAL_TYPE_LEN_OFFSET: u64 = 24;
+const DIRECT_CHECKPOINT_COMMAND_ID_PTR_OFFSET: u64 = 28;
+const DIRECT_CHECKPOINT_COMMAND_ID_LEN_OFFSET: u64 = 32;
 /// Fixed 8-byte scratch slot in the reserved 256-byte low-memory region (past
 /// the retptr scratch at 0 and the agent-args scratch at 128, below the static
 /// data base at 256). Used to marshal a `WaitForSignal` absolute timeout
@@ -1461,9 +1463,7 @@ fn build_direct_component_resolve_configured(
              import runtara:workflow-stdlib/json@{WORKFLOW_WIT_VERSION};\n"
     );
     if !omit_runtime {
-        workflow_wit.push_str(&format!(
-            "    import runtara:workflow-runtime/runtime@{WORKFLOW_WIT_VERSION};\n"
-        ));
+        workflow_wit.push_str(&format!("    import {RUNTIME_INTERFACE_NAME};\n"));
     }
     if has_connections {
         workflow_wit.push_str("    import runtara:connection-resolver/resolver@0.1.0;\n");

--- a/crates/runtara-workflows/src/direct_wasm/compile/checkpoint.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/checkpoint.rs
@@ -17,6 +17,7 @@ use super::abi::{
     push_retptr_i32_load, push_retptr_u8_load, return_if_retptr_error,
 };
 use super::{
+    DIRECT_CHECKPOINT_COMMAND_ID_LEN_OFFSET, DIRECT_CHECKPOINT_COMMAND_ID_PTR_OFFSET,
     DIRECT_CHECKPOINT_PENDING_SIGNAL_TAG_OFFSET, DIRECT_CHECKPOINT_SIGNAL_TYPE_LEN_OFFSET,
     DIRECT_CHECKPOINT_SIGNAL_TYPE_PTR_OFFSET, DIRECT_RET_BOOL_OK_OFFSET, DirectCoreFunctionIndices,
 };
@@ -85,6 +86,8 @@ fn emit_checkpoint_signal_handling(body: &mut WasmFunction, indices: &DirectCore
     body.instruction(&Instruction::If(BlockType::Empty));
     push_retptr_i32_load(body, DIRECT_CHECKPOINT_SIGNAL_TYPE_PTR_OFFSET);
     push_retptr_i32_load(body, DIRECT_CHECKPOINT_SIGNAL_TYPE_LEN_OFFSET);
+    push_retptr_i32_load(body, DIRECT_CHECKPOINT_COMMAND_ID_PTR_OFFSET);
+    push_retptr_i32_load(body, DIRECT_CHECKPOINT_COMMAND_ID_LEN_OFFSET);
     push_retptr_arg(body);
     body.instruction(&Instruction::Call(indices.runtime_handle_checkpoint_signal));
     return_if_retptr_error(body, indices);

--- a/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
@@ -773,7 +773,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "debug-mode-enabled",
         ),
     );
@@ -789,7 +789,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "checkpoint",
         ),
         breakpoint_key_position,
@@ -807,7 +807,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "custom-event",
         ),
         breakpoint_event_position,
@@ -816,7 +816,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "breakpoint-pause",
         ),
         custom_event_position,
@@ -1218,7 +1218,7 @@ fn direct_compile_exports_wasi_cli_run_and_imports_components() {
                     saw_runtime_import |= import
                         .name
                         .0
-                        .contains("runtara:workflow-runtime/runtime@0.1.0");
+                        .contains("runtara:workflow-runtime/runtime@0.2.0");
                 }
             }
             Payload::ComponentExportSection(reader) => {
@@ -1449,22 +1449,22 @@ fn direct_core_run_lowers_embed_workflow_breakpoint_after_child_input_mapping() 
                                 stdlib_build_source_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
                             (
@@ -4468,7 +4468,7 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
         (
             "runtime.load-input",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "load-input",
             vec![WasmType::Pointer],
         ),
@@ -4663,21 +4663,21 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
         (
             "runtime.complete",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "complete",
             vec![WasmType::Pointer, WasmType::Length, WasmType::Pointer],
         ),
         (
             "runtime.fail",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "fail",
             vec![WasmType::Pointer, WasmType::Length, WasmType::Pointer],
         ),
         (
             "runtime.custom-event",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "custom-event",
             vec![
                 WasmType::Pointer,
@@ -4770,7 +4770,7 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "init-manifest") => {
                                 init_manifest_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "load-input") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "load-input") => {
                                 load_input_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "build-source") => {
@@ -4797,13 +4797,13 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "error") => {
                                 error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
                             _ => {}
@@ -4961,25 +4961,25 @@ fn direct_core_run_lowers_finish_breakpoint_after_output_mapping() {
                                 stdlib_apply_mapping_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
                                 runtime_complete_index = Some(next_function_index)
                             }
                             _ => {}
@@ -5187,7 +5187,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "debug-mode-enabled",
         ),
     );
@@ -5203,7 +5203,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "checkpoint",
         ),
     );
@@ -5223,7 +5223,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
     // static occurrence.
     let custom_event_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.1",
+        "cm32p2|runtara:workflow-runtime/runtime@0.2",
         "custom-event",
     );
     let custom_event_position =
@@ -5232,7 +5232,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.1",
+            "cm32p2|runtara:workflow-runtime/runtime@0.2",
             "breakpoint-pause",
         ),
     );
@@ -7085,7 +7085,7 @@ fn direct_core_run_emits_step_debug_events_when_tracking_enabled() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "init-manifest") => {
                                 init_manifest_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "load-input") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "load-input") => {
                                 load_input_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "build-source") => {
@@ -7094,13 +7094,13 @@ fn direct_core_run_emits_step_debug_events_when_tracking_enabled() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "step-debug-start") => {
@@ -7781,17 +7781,17 @@ fn direct_core_run_lowers_split_retry_helpers() {
     );
     let blocking_sleep_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.1",
+        "cm32p2|runtara:workflow-runtime/runtime@0.2",
         "blocking-sleep",
     );
     let durable_sleep_checkpoint_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.1",
+        "cm32p2|runtara:workflow-runtime/runtime@0.2",
         "durable-sleep-checkpoint",
     );
     let record_retry_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.1",
+        "cm32p2|runtara:workflow-runtime/runtime@0.2",
         "record-retry-attempt",
     );
 
@@ -8548,7 +8548,7 @@ fn direct_core_run_lowers_durable_delay_finish_through_stdlib_and_runtime() {
                                 delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "durable-sleep-checkpoint",
                             ) => durable_sleep_checkpoint_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay") => {
@@ -8689,29 +8689,29 @@ fn direct_core_run_lowers_delay_breakpoint_pause_before_sleep() {
                                 stdlib_build_source_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay-duration-ms") => {
                                 stdlib_delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "durable-sleep-checkpoint",
                             ) => runtime_durable_sleep_checkpoint_index = Some(next_function_index),
                             _ => {}
@@ -8832,10 +8832,10 @@ fn direct_core_run_lowers_non_durable_delay_finish_through_blocking_sleep() {
                                 delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "durable-sleep-checkpoint",
                             ) => durable_sleep_checkpoint_index = Some(next_function_index),
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "blocking-sleep") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "blocking-sleep") => {
                                 blocking_sleep_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay") => {
@@ -9004,29 +9004,29 @@ fn direct_core_run_lowers_wait_for_signal_finish_through_runtime_polling() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "instance-id") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "instance-id") => {
                                 runtime_instance_id_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "now-ms") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "now-ms") => {
                                 runtime_now_ms_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
                                 runtime_fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "check-signals") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "check-signals") => {
                                 runtime_check_signals_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "poll-custom-signal",
                             ) => runtime_poll_custom_signal_index = Some(next_function_index),
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "heartbeat") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "heartbeat") => {
                                 runtime_heartbeat_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "blocking-sleep") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "blocking-sleep") => {
                                 runtime_blocking_sleep_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9153,7 +9153,7 @@ fn direct_core_run_lowers_wait_for_signal_debug_events_with_tracking() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9270,25 +9270,25 @@ fn direct_core_run_lowers_wait_for_signal_breakpoint_pause() {
                     if matches!(import.ty, TypeRef::Func(_)) {
                         match (import.module, import.name) {
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.1",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "instance-id") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "instance-id") => {
                                 runtime_instance_id_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9527,7 +9527,7 @@ fn direct_core_run_wraps_wait_on_wait_error_before_runtime_fail() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "wait-on-wait-error") => {
                                 wait_on_wait_error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
                                 runtime_fail_index = Some(next_function_index)
                             }
                             _ => {}
@@ -10023,7 +10023,7 @@ fn direct_core_run_lowers_log_finish_through_stdlib_and_runtime() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "log") => {
                                 log_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
@@ -10172,13 +10172,13 @@ fn direct_core_run_lowers_error_through_stdlib_and_runtime() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "error") => {
                                 error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.1", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
                             _ => {}
@@ -10446,7 +10446,7 @@ fn direct_compile_writes_component_scaffold_sidecars() {
     assert_eq!(world_wit, result.component_artifacts.world_wit);
     assert_eq!(wac, result.component_artifacts.wac_source);
     assert!(world_wit.contains("import runtara:workflow-stdlib/json@0.1.0;"));
-    assert!(world_wit.contains("import runtara:workflow-runtime/runtime@0.1.0;"));
+    assert!(world_wit.contains("import runtara:workflow-runtime/runtime@0.2.0;"));
     assert!(world_wit.contains("export runtara:workflow-lifecycle/lifecycle@0.2.0;"));
     assert!(wac.contains("new runtara:workflow-stdlib"));
     // HostImport default: the runtime component is neither instantiated nor

--- a/crates/runtara-workflows/src/direct_wasm/component.rs
+++ b/crates/runtara-workflows/src/direct_wasm/component.rs
@@ -14,7 +14,8 @@
 //! names imports it never defines, and `wac` resolves them.
 
 use runtara_workflow_wit::{
-    LIFECYCLE_INTERFACE_NAME, RUNTIME_PACKAGE, STDLIB_PACKAGE, WORKFLOW_WIT_VERSION,
+    LIFECYCLE_INTERFACE_NAME, RUNTIME_INTERFACE_NAME, RUNTIME_PACKAGE, STDLIB_PACKAGE,
+    WORKFLOW_WIT_VERSION,
 };
 
 /// Package name used by direct-emitted workflow logic components.
@@ -322,9 +323,7 @@ fn emit_world_wit(
          \x20   import runtara:workflow-stdlib/json@{WORKFLOW_WIT_VERSION};\n",
     );
     if !omit_runtime {
-        out.push_str(&format!(
-            "    import runtara:workflow-runtime/runtime@{WORKFLOW_WIT_VERSION};\n"
-        ));
+        out.push_str(&format!("    import {RUNTIME_INTERFACE_NAME};\n"));
     }
     if has_connections {
         out.push_str("    import runtara:connection-resolver/resolver@0.1.0;\n");
@@ -446,7 +445,7 @@ mod tests {
         assert!(
             artifacts
                 .world_wit
-                .contains("import runtara:workflow-runtime/runtime@0.1.0;")
+                .contains("import runtara:workflow-runtime/runtime@0.2.0;")
         );
         // The Phase-5 default exports the invoke lifecycle; the legacy run
         // export remains reachable via the explicit CliRunHttp ABI.
@@ -510,7 +509,7 @@ package runtara:workflow@0.1.0;
 
 world workflow {
     import runtara:workflow-stdlib/json@0.1.0;
-    import runtara:workflow-runtime/runtime@0.1.0;
+    import runtara:workflow-runtime/runtime@0.2.0;
     import runtara:agent-crypto/capabilities@0.4.0;
     import runtara:agent-object-model/capabilities@0.4.0;
     export runtara:workflow-lifecycle/lifecycle@0.2.0;
@@ -659,7 +658,7 @@ world workflow {
         assert!(
             artifacts
                 .world_wit
-                .contains("import runtara:workflow-runtime/runtime@0.1.0;")
+                .contains("import runtara:workflow-runtime/runtime@0.2.0;")
         );
     }
 
@@ -701,7 +700,7 @@ world workflow {
                 },
                 DirectSharedComponentRequirement {
                     package: "runtara:workflow-runtime",
-                    package_with_version: "runtara:workflow-runtime@0.1.0",
+                    package_with_version: "runtara:workflow-runtime@0.2.0",
                     bundle_wasm_filename: "runtara_workflow_runtime.wasm",
                     bundle_meta_filename: "runtara_workflow_runtime.meta.json",
                     cas_wasm_filename: "runtara-workflow-runtime.wasm",

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -1627,7 +1627,11 @@ impl runtara_component_host::runtime_host::RuntimeHost for CapturingRuntimeHost 
             },
         )
     }
-    async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
+    async fn handle_checkpoint_signal(
+        &self,
+        _signal_type: String,
+        _command_id: String,
+    ) -> Result<bool, String> {
         Ok(false)
     }
     async fn record_retry_attempt(
@@ -2117,7 +2121,7 @@ fn direct_compose_host_import_binding_surfaces_runtime_as_component_import() {
     assert!(
         host_imports
             .iter()
-            .any(|name| name == "runtara:workflow-runtime/runtime@0.1.0"),
+            .any(|name| name == "runtara:workflow-runtime/runtime@0.2.0"),
         "host-import binding must surface the runtime interface; imports: {host_imports:?}"
     );
     assert!(
@@ -2131,6 +2135,8 @@ fn direct_compose_host_import_binding_surfaces_runtime_as_component_import() {
 /// the return channel — no HTTP anywhere.
 struct RecordingRuntimeHost {
     input: Vec<u8>,
+    pending_signal: Option<runtara_component_host::runtime_host::RuntimeSignalInfo>,
+    acknowledged_commands: Mutex<Vec<(String, String)>>,
     completed: Mutex<Option<Vec<u8>>>,
     failed: Mutex<Option<Vec<u8>>>,
     /// Total `runtime.complete` calls — a composed workflow-agent child must
@@ -2143,6 +2149,8 @@ impl RecordingRuntimeHost {
     fn new(input: &[u8]) -> Self {
         Self {
             input: input.to_vec(),
+            pending_signal: None,
+            acknowledged_commands: Mutex::new(Vec::new()),
             completed: Mutex::new(None),
             failed: Mutex::new(None),
             complete_calls: std::sync::atomic::AtomicU32::new(0),
@@ -2201,13 +2209,21 @@ impl runtara_component_host::runtime_host::RuntimeHost for RecordingRuntimeHost 
             runtara_component_host::runtime_host::RuntimeCheckpointResult {
                 found: false,
                 state: Vec::new(),
-                pending_signal: None,
+                pending_signal: self.pending_signal.clone(),
                 custom_signal: None,
             },
         )
     }
-    async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
-        Ok(false)
+    async fn handle_checkpoint_signal(
+        &self,
+        signal_type: String,
+        command_id: String,
+    ) -> Result<bool, String> {
+        self.acknowledged_commands
+            .lock()
+            .unwrap()
+            .push((signal_type, command_id));
+        Ok(true)
     }
     async fn record_retry_attempt(
         &self,
@@ -2367,7 +2383,11 @@ impl runtara_component_host::runtime_host::RuntimeHost for PersistingRuntimeHost
             },
         )
     }
-    async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
+    async fn handle_checkpoint_signal(
+        &self,
+        _signal_type: String,
+        _command_id: String,
+    ) -> Result<bool, String> {
         Ok(false)
     }
     async fn record_retry_attempt(
@@ -2473,6 +2493,66 @@ fn direct_wasm_execute_host_import_runtime_runs_without_http() {
     let output_json: Value = serde_json::from_slice(&output).expect("output is JSON");
     assert_eq!(output_json, serde_json::json!({ "result": "host-import" }));
     assert!(host.failed.lock().unwrap().is_none(), "no failure expected");
+}
+
+#[test]
+fn direct_wasm_checkpoint_ack_preserves_command_identity() {
+    let components_dir = direct_e2e_components_dir();
+    let result =
+        compile_invoke_abi_artifact(&components_dir, "command-identity-abi", AGENT_CACHED_REPLAY);
+
+    let mut host = RecordingRuntimeHost::new(br#"{"value":"command-identity"}"#);
+    host.pending_signal = Some(runtara_component_host::runtime_host::RuntimeSignalInfo {
+        signal_type: "pause".into(),
+        command_id: "receipt-39e0a768".into(),
+        payload: b"payload".to_vec(),
+        checkpoint_id: None,
+    });
+    let host = Arc::new(host);
+    let executor = embedded_executor();
+
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let run = runtime.block_on(async {
+        let pre = executor
+            .load_instance_pre(&result.wasm_path)
+            .await
+            .expect("load host-import artifact");
+        executor
+            .execute_invoke(
+                &pre,
+                runtara_component_host::WorkflowRunSpec {
+                    env: HashMap::new(),
+                    stderr: None,
+                    timeout: Duration::from_secs(60),
+                    cancel: None,
+                    limits: runtara_component_host::WorkflowLimits::default(),
+                    runtime: Some(host.clone()),
+                },
+                br#"{"value":"command-identity"}"#.to_vec(),
+            )
+            .await
+    });
+
+    assert!(
+        matches!(run.exit, runtara_component_host::InvokeExit::Suspended(_)),
+        "unexpected exit: {:?} (failed: {:?})",
+        run.exit,
+        host.failed
+            .lock()
+            .unwrap()
+            .as_deref()
+            .map(String::from_utf8_lossy),
+    );
+    assert_eq!(
+        *host.acknowledged_commands.lock().unwrap(),
+        vec![("pause".into(), "receipt-39e0a768".into())]
+    );
+    assert_eq!(
+        host.complete_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "accepted pause exits before workflow completion"
+    );
 }
 
 #[test]
@@ -6584,7 +6664,7 @@ fn direct_wasm_execute_agent_capabilities_keeps_runtime_for_durable_workflow() {
         compiled
             .component_artifacts
             .world_wit
-            .contains("import runtara:workflow-runtime/runtime@0.1.0;"),
+            .contains("import runtara:workflow-runtime/runtime@0.2.0;"),
         "durable agent must keep the runtime import:\n{}",
         compiled.component_artifacts.world_wit
     );
@@ -7421,7 +7501,11 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
             },
         )
     }
-    async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
+    async fn handle_checkpoint_signal(
+        &self,
+        _signal_type: String,
+        _command_id: String,
+    ) -> Result<bool, String> {
         Ok(false)
     }
     fn now_ms(&self) -> Result<u64, String> {
@@ -12467,7 +12551,11 @@ impl runtara_component_host::runtime_host::RuntimeHost for CancelDuringDelayHost
             },
         )
     }
-    async fn handle_checkpoint_signal(&self, _signal_type: String) -> Result<bool, String> {
+    async fn handle_checkpoint_signal(
+        &self,
+        _signal_type: String,
+        _command_id: String,
+    ) -> Result<bool, String> {
         Ok(true)
     }
     async fn record_retry_attempt(

--- a/e2e/test_core_persistence_contract.sh
+++ b/e2e/test_core_persistence_contract.sh
@@ -50,11 +50,11 @@ assert status["status"] == "completed" and status["output"] == output
 request(path + "/checkpoint", {"checkpoint_id": "after", "state": state}, expected=409)
 print("PASS checkpoint replay, heartbeat/custom events, completion and terminal guard")
 
-for label, expected in [("cancel", "cancelled"), ("pause", "suspended"), ("resume", "running"), ("shutdown", "suspended")]:
+for label in ["cancel", "pause", "resume", "shutdown"]:
     path = instance()
-    assert request(path + "/signals/ack", {"signal_type": label})["success"]
-    assert request(path + "/status")["status"] == expected
-print("PASS all lifecycle acknowledgement transitions")
+    assert not request(path + "/signals/ack", {"command_id": uuid.uuid4().hex, "signal_type": label})["success"]
+    assert request(path + "/status")["status"] == "running"
+print("PASS unobserved lifecycle receipts cannot change instance status")
 
 path = instance()
 request(path + "/events", {"event_type": "failed", "payload": base64.b64encode(b"expected failure").decode()})

--- a/e2e/test_lifecycle_command_identity.sh
+++ b/e2e/test_lifecycle_command_identity.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Against a running local server with AUTH_PROVIDER=local and matching TENANT_ID.
+# Creates uniquely identified instances through the instance API and sends
+# commands through the public API. No database access or external credentials.
+# Usage: SERVER_API_URL=http://127.0.0.1:7001 CORE_API_URL=http://127.0.0.1:8003 \
+#        TENANT_ID=local ./e2e/test_lifecycle_command_identity.sh
+set -euo pipefail
+python3 - <<'PY'
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+core = os.environ.get("CORE_API_URL", "http://127.0.0.1:8003").rstrip("/")
+server = os.environ.get("SERVER_API_URL", "http://127.0.0.1:7001").rstrip("/")
+tenant = os.environ.get("TENANT_ID", "local")
+
+def request(base, path, body=None, expected=200):
+    req = urllib.request.Request(base + path, data=None if body is None else json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    try:
+        response = urllib.request.urlopen(req, timeout=15)
+    except urllib.error.HTTPError as error:
+        response = error
+    raw = response.read().decode()
+    assert response.status == expected, (path, response.status, raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+def instance():
+    ident = str(uuid.uuid4())
+    request(core, f"/api/v1/instances/{ident}/register", {"tenant_id": tenant})
+    return ident
+
+def command(ident, action):
+    return request(server, f"/api/runtime/workflows/instances/{ident}/{action}", {})
+
+def poll(ident):
+    return request(core, f"/api/v1/instances/{ident}/signals").get("signal")
+
+def ack(ident, signal):
+    return request(core, f"/api/v1/instances/{ident}/signals/ack",
+                   {"command_id": signal["command_id"], "signal_type": signal["signal_type"]})["success"]
+
+def status(ident):
+    return request(core, f"/api/v1/instances/{ident}/status")["status"]
+
+ident = instance()
+command(ident, "pause")
+first = poll(ident)
+assert first["signal_type"] == "pause" and first["command_id"]
+assert poll(ident) == first, "polling must not acknowledge"
+for state in ["", base64.b64encode(b"checkpoint-state").decode()]:
+    cp = request(core, f"/api/v1/instances/{ident}/checkpoint", {"checkpoint_id": "receipt", "state": state})
+    assert cp["signal"] == first, "checkpoint and polling must deliver the same receipt"
+command(ident, "pause")
+second = poll(ident)
+assert second["command_id"] != first["command_id"], "same-kind replacement needs a new identity"
+assert not ack(ident, first)
+assert not ack(ident, {**second, "signal_type": "cancel"})
+request(core, f"/api/v1/instances/{ident}/signals/ack", {"signal_type": "pause"}, expected=422)
+assert status(ident) == "running" and poll(ident) == second
+assert ack(ident, second)
+assert status(ident) == "suspended" and poll(ident) is None
+assert ack(ident, second), "receipt retry must be idempotent"
+assert status(ident) == "suspended"
+print("PASS explicit receipt identity, checkpoint delivery, stale/type/idless rejection, atomic pause and repeat ACK")
+
+ident = instance()
+command(ident, "pause")
+old_pause = poll(ident)
+command(ident, "stop")
+cancel = poll(ident)
+assert cancel["signal_type"] == "cancel"
+command(ident, "pause")
+assert poll(ident) == cancel, "pending cancel must dominate a later pause"
+assert not ack(ident, old_pause)
+assert status(ident) == "running" and poll(ident) == cancel
+assert ack(ident, cancel)
+assert status(ident) == "cancelled" and poll(ident) is None
+assert not ack(ident, old_pause)
+request(core, f"/api/v1/instances/{ident}/events", {"event_type": "completed"})
+assert status(ident) == "cancelled", "late completion cannot undo cancellation"
+print("PASS pause/cancel interleaving, cancellation precedence and terminal guard")
+print("Lifecycle command identity E2E passed")
+PY

--- a/e2e/test_parked_instance_cancellation.sh
+++ b/e2e/test_parked_instance_cancellation.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Compile and run real parked workflows against an isolated local server.
+# Requires AUTH_PROVIDER=local, built agent components, and psql on PATH.
+# SERVER_API_URL / CORE_API_URL select the server; TENANT_ID must match it.
+# TEST_RUNTIME_DATABASE is mandatory. PGHOST/PGPORT/PGUSER select its PostgreSQL.
+# Database access is read-only and verifies that cancellation starts no new launch.
+set -euo pipefail
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+server = os.environ.get("SERVER_API_URL", "http://127.0.0.1:7001").rstrip("/")
+core = os.environ.get("CORE_API_URL", "http://127.0.0.1:8003").rstrip("/")
+pg_env = os.environ.copy()
+pg_env["PGDATABASE"] = os.environ["TEST_RUNTIME_DATABASE"]
+
+def request(base, path, body=None, expected=200):
+    req = urllib.request.Request(base + path, data=None if body is None else json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    try:
+        response = urllib.request.urlopen(req, timeout=120)
+    except urllib.error.HTTPError as error:
+        response = error
+    raw = response.read().decode()
+    if expected is not None:
+        assert response.status == expected, (path, response.status, raw)
+    return response.status, json.loads(raw)
+
+def api(path, body=None):
+    _, result = request(server, "/api/runtime" + path, body)
+    assert result.get("success", True), result
+    return result.get("data", result)
+
+def instance_state(ident):
+    ident = str(uuid.UUID(ident))
+    query = f"""SELECT json_build_object(
+        'status', status, 'reason', termination_reason, 'wake', sleep_until,
+        'launches', (SELECT count(*) FROM instance_launches WHERE instance_id = '{ident}'),
+        'pending', (SELECT count(*) FROM pending_signals WHERE instance_id = '{ident}' AND acknowledged_at IS NULL)
+    ) FROM instances WHERE instance_id = '{ident}'"""
+    raw = subprocess.check_output(["psql", "-X", "-A", "-t", "-c", query], env=pg_env, text=True).strip()
+    return json.loads(raw) if raw else {"status": "pending"}
+
+def await_state(ident, status, seconds=15):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        state = instance_state(ident)
+        if state["status"] == status:
+            return state
+        assert state["status"] not in ["failed", "completed"], state
+        time.sleep(0.1)
+    raise AssertionError(("state deadline", status, state))
+
+def execute(step):
+    workflow = api("/workflows/create", {"name": "park-cancel-" + uuid.uuid4().hex, "description": "Parked cancellation E2E"})["id"]
+    graph = {"name": "Park cancellation", "durable": True, "entryPoint": "park",
+             "steps": {"park": {"id": "park", **step}, "finish": {"stepType": "Finish", "id": "finish"}},
+             "executionPlan": [{"fromStep": "park", "toStep": "finish"}],
+             "variables": {}, "inputSchema": {}, "outputSchema": {}}
+    api(f"/workflows/{workflow}/update", {"executionGraph": graph})
+    versions = api(f"/workflows/{workflow}/versions")
+    version = max(v.get("version", v.get("versionNumber", 1)) for v in versions)
+    api(f"/workflows/{workflow}/versions/{version}/compile", {})
+    return api(f"/workflows/{workflow}/execute", {"inputs": {"data": {}}})["instanceId"]
+
+for label, step, reason in [
+    ("indefinite wait", {"stepType": "WaitForSignal", "pollIntervalMs": 500}, "waiting_signal"),
+    ("future delay", {"stepType": "Delay", "durationMs": {"valueType": "immediate", "value": 3600000}}, "sleeping"),
+]:
+    ident = execute(step)
+    parked = await_state(ident, "suspended")
+    assert parked["reason"] == reason, parked
+    assert (parked["wake"] is None) == (reason == "waiting_signal"), parked
+    api(f"/workflows/instances/{ident}/stop", {})
+    cancelled = await_state(ident, "cancelled", seconds=5)
+    assert cancelled["wake"] is None and cancelled["pending"] == 0, cancelled
+    assert cancelled["launches"] == parked["launches"], (parked, cancelled)
+    code, _ = request(server, f"/api/runtime/workflows/instances/{ident}/resume", {}, expected=None)
+    assert code >= 400, "cancelled instance cannot resume"
+    # A few scheduler ticks must not launch the cancelled workflow again.
+    time.sleep(3)
+    final = instance_state(ident)
+    assert final["status"] == "cancelled" and final["launches"] == parked["launches"], final
+    print(f"PASS {label}: cancelled, receipt acknowledged, wake cleared, no additional launch")
+print("Parked instance cancellation E2E passed")
+PY


### PR DESCRIPTION
## Description

Lifecycle acknowledgments previously identified only a signal type, so an old acknowledgment could apply to a replacement command. Each command now carries an opaque ID through polling, checkpoints, the SDK, HTTP, and WASM. Persistence validates the exact receipt and atomically commits its acknowledgment and lifecycle effects; stale receipts have no effect, accepted retries are idempotent, and pending cancellation takes precedence.

Cancelling a suspended workflow now acknowledges its command, marks it cancelled, and clears its wake deadline without launching a guest. Immediate delivery, post-park handling, and bounded scheduler recovery cover indefinite signal waits, future timers, and interrupted delivery. Cancellation and launch-start transitions serialize so a running guest retains its pending command if launch wins.

## Related Issue

No linked issue.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] Formatting and workspace Clippy passed
- [x] I have added tests that prove my fix/feature works
- [x] Relevant unit, database, component, workflow, and live-server E2E suites passed
- [x] I have updated the documentation

## Testing

- Core, SDK, SDK macros, PostgreSQL store, workflow runtime, and WIT tests; shared memory/PostgreSQL conformance including rollback injection.
- Full database-enabled environment suite, including cancellation racing launch start and recovery without a wake deadline.
- Server unit suite: 1,173 passed; instance HTTP API integration tests: 4 passed.
- Workflow unit suite: 548 passed; direct WASM integration suite: 174 passed. Component-host integration tests and exact command-ID round-trip through compiled WASM passed.
- Rebuilt agent components, runtime, standard library, and the local server.
- Ran `e2e/test_lifecycle_command_identity.sh`, `e2e/test_parked_instance_cancellation.sh`, and `e2e/test_core_persistence_contract.sh` against an isolated local server and PostgreSQL/Valkey. Parked E2E checks both indefinite waits and one-hour delays, including no extra launch and rejection of resume after cancellation.
- `cargo fmt --all -- --check` and workspace Clippy with `-D warnings`, including the affected integration-test feature gates, passed.

The complete CI feature matrix was not run locally.

## Additional Notes

**Upgrade requirements:** the workflow runtime interface advances from `0.1.0` to `0.2.0`. Rebuild the shared runtime and recompile workflow artifacts. HTTP signal acknowledgments now require the `command_id` returned by polling or checkpointing; SDK acknowledgment callers must also pass it and handle the acceptance result.

Forward migrations add command identity and an index for pending cancellation recovery. The work is split into two commits: command identity/atomic acknowledgment and parked-instance cancellation.
