### PR TITLE
Centralize lifecycle policy and clarify wake and signal contracts

### DIFF
--- a/crates/runtara-component-host/src/runtime_host.rs
+++ b/crates/runtara-component-host/src/runtime_host.rs
@@ -33,7 +33,7 @@ use crate::workflow::WorkflowState;
 
 /// Fully-qualified component import name of the runtime interface.
 ///
-/// Must match `runtara:workflow-runtime@0.2.0`'s `runtime` interface as
+/// Must match `runtara:workflow-runtime@0.3.0`'s `runtime` interface as
 /// emitted into the workflow world by `runtara-workflows::direct_wasm`
 /// (`emit_world_wit`) — the Spike-B integration test asserts a HostImport
 /// composition surfaces exactly this name.
@@ -73,7 +73,10 @@ pub struct RuntimeSignalInfo {
 )]
 #[component(record)]
 pub struct RuntimeCustomSignalInfo {
-    /// The signal id (checkpoint id) the payload targets.
+    /// Identity of this retained value, distinct from its checkpoint address.
+    #[component(name = "signal-id")]
+    pub signal_id: String,
+    /// Checkpoint/wait address the retained value targets.
     #[component(name = "checkpoint-id")]
     pub checkpoint_id: String,
     /// Signal payload bytes.

--- a/crates/runtara-core/README.md
+++ b/crates/runtara-core/README.md
@@ -71,16 +71,46 @@ guards. Parking only applies to running instances and commits its deadline with
 suspension metadata; a signal arriving before parking is checked by environment
 immediately afterward, while later arrivals can observe the suspended state.
 
-Custom-signal replay, explicit host resume, and guest component interfaces keep
-their existing contracts. Core's host dependencies are not added to WASM guests.
+## Commands, wake causes, and custom values
+
+Guests receive lifecycle commands `cancel`, `pause`, and `shutdown`. Resume is
+an explicit host operation that queues a launch; it is never delivered through
+signal polling or checkpoints. `WakeReason` records timer, custom-signal,
+manual-resume, or recovery causes in host scheduling state. Claims and retries
+preserve the cause, and cancellation clears obsolete wake intent. Enqueuing a
+new wake/resume generation clears its old deadline in the queue transaction;
+reconciliation releases a parked predecessor before the handoff.
+
+Custom signals are retained slots keyed by `(instance_id, checkpoint_id)`.
+`put_custom_signal` replaces the value and returns a fresh `signal_id` for every
+successful write, including identical retries. `get_custom_signal` is
+non-destructive: repeated reads return the current ID and payload until another
+write replaces them. There is no queue, history, or implicit deduplication.
+Completed workflow checkpoints provide replay caching independently of this slot.
+The checkpoint ID addresses the slot; the signal ID identifies a particular write.
+
+The submission API accepts `checkpointId` and returns both `checkpointId` and
+`signalId`. Legacy request fields `signalId` and `signal_id` remain address
+aliases. Existing DSL/debug and pending-input `signalId` fields also remain
+checkpoint addresses; they are not value identities.
 
 ## Adapter migration
 
-Backend implementers must supply `apply_lifecycle_command` and `park_instance`,
-returning the core policy's typed `Decision`. The existing `acknowledge_signal`
-method is a boolean compatibility wrapper: applied and already-applied receipts
-both return true. HTTP acknowledgment responses and WIT runtime `0.2.0` are
-unchanged by this refactor; no new schema migration is required.
+Backend implementers must supply `apply_lifecycle_command`, `park_instance`, and
+`schedule_wake`. Lifecycle operations return core's typed `Decision`;
+`acknowledge_signal` remains a boolean wrapper accepting applied and repeated
+receipts. `set_instance_sleep` is a timer convenience for `schedule_wake`.
+Custom-value methods are now `put_custom_signal` and `get_custom_signal`.
+
+Apply PostgreSQL migrations 022–024 before starting upgraded hosts. They retire
+pending guest resume commands without changing instance state, add custom-value
+identities, and add wake causes. The historical PostgreSQL `resume` enum label
+remains for migration compatibility; current readers ignore it. Wire numeric
+command value `2` is retired; `0`, `1`, and `3` retain their meanings.
+
+WIT runtime `0.3.0` adds `signal-id` to custom-signal-info. Rebuild shared components
+and recompile workflow artifacts. HTTP/SDK custom-signal records require the new
+identity field, so upgrade server and clients together.
 
 Persistence records, status filters, completion parameters, event filters, and lifecycle signal operations now use `domain` enums. Stored event types include `Started` and legacy `Progress`, in addition to incoming instance events. PostgreSQL encoding and checked decoding live in `runtara-store-postgres::encoding`; core's database string mappers have been removed.
 

--- a/crates/runtara-core/README.md
+++ b/crates/runtara-core/README.md
@@ -34,6 +34,7 @@ That host depends on `runtara-core`, `runtara-store-postgres`, `sqlx`, and `anyh
 ## Contracts
 
 - `domain` defines typed instance statuses, lifecycle signals, and timeline events. Storage encodings and wire spellings belong to adapters.
+- `lifecycle` defines pure command replacement, acknowledgment, parked cancellation, parking, and interruption policy.
 - `persistence` defines records, queries, conditional updates, wake claims, and retention obligations through `Persistence`.
 - `instance_handlers` implements registration, checkpoints, sleep, events, and signal delivery over that trait.
 - `error` provides storage-neutral errors and transport-independent classifications.
@@ -44,7 +45,42 @@ Event subtypes and payload keys are opaque producer-defined strings. `EventVocab
 
 The `test-support` feature exposes an in-memory backend, handler mocks, and a shared conformance suite. Backend implementations should run that suite against their own store; tests in core need no external services.
 
+## Lifecycle policy
+
+Core owns transition decisions; persistence implementations own atomic application;
+environment owns execution, launch scheduling, and recovery. Call policy functions
+against state read under the backend's lock or transaction, then apply all effects
+before releasing it. Do not read, decide, and write in separate operations.
+
+`Decision` distinguishes `Rejected`, `AlreadyApplied`, and `Applied(Transition)`.
+`Change::Keep`, `Clear`, and `Set` distinguish preserving metadata from removing or
+replacing it. Backends encode those values, use one operation timestamp, persist
+status/deadlines/events/acknowledgment together, and report newly applied completion
+metrics after committing. Repeated receipts produce no durable effects.
+
+PostgreSQL locks instances before commands, ordered by instance ID for batches.
+Recovery uses bounded candidate selection with `SKIP LOCKED`, re-evaluates policy
+against locked commands, and applies equal effects with batched writes in one
+transaction. Candidate-query predicates are an optimization; they do not replace
+policy evaluation. Memory evaluates and applies the same policy under one mutex.
+
+A matching cancellation acknowledgment retains the existing ability to override
+completed/failed status when cancellation was not honored. Parked cancellation
+only applies to suspended instances. These are distinct operations with distinct
+guards. Parking only applies to running instances and commits its deadline with
+suspension metadata; a signal arriving before parking is checked by environment
+immediately afterward, while later arrivals can observe the suspended state.
+
+Custom-signal replay, explicit host resume, and guest component interfaces keep
+their existing contracts. Core's host dependencies are not added to WASM guests.
+
 ## Adapter migration
+
+Backend implementers must supply `apply_lifecycle_command` and `park_instance`,
+returning the core policy's typed `Decision`. The existing `acknowledge_signal`
+method is a boolean compatibility wrapper: applied and already-applied receipts
+both return true. HTTP acknowledgment responses and WIT runtime `0.2.0` are
+unchanged by this refactor; no new schema migration is required.
 
 Persistence records, status filters, completion parameters, event filters, and lifecycle signal operations now use `domain` enums. Stored event types include `Started` and legacy `Progress`, in addition to incoming instance events. PostgreSQL encoding and checked decoding live in `runtara-store-postgres::encoding`; core's database string mappers have been removed.
 

--- a/crates/runtara-core/src/domain.rs
+++ b/crates/runtara-core/src/domain.rs
@@ -36,10 +36,22 @@ pub enum SignalType {
     Cancel,
     /// Pause execution.
     Pause,
-    /// Resume execution.
-    Resume,
     /// Suspend for a server restart.
     Shutdown,
+}
+
+/// Host-side cause of a wake or explicit resume. These are scheduling metadata,
+/// never commands delivered to the guest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WakeReason {
+    /// A durable timer or signal timeout elapsed.
+    Timer,
+    /// A custom value arrived at a waiting checkpoint address.
+    CustomSignal,
+    /// An operator requested the explicit host resume operation.
+    ManualResume,
+    /// Execution is being recovered after shutdown or host failure.
+    Recovery,
 }
 
 /// An event in an instance's persisted timeline.

--- a/crates/runtara-core/src/instance_handlers/checkpoint.rs
+++ b/crates/runtara-core/src/instance_handlers/checkpoint.rs
@@ -59,9 +59,10 @@ pub async fn handle_checkpoint(
             get_pending_signal(state.persistence.as_ref(), &request.instance_id).await?;
         let custom_signal = state
             .persistence
-            .take_pending_custom_signal(&request.instance_id, &request.checkpoint_id)
+            .get_custom_signal(&request.instance_id, &request.checkpoint_id)
             .await?
             .map(|sig| CustomSignal {
+                signal_id: sig.signal_id,
                 checkpoint_id: request.checkpoint_id.clone(),
                 payload: sig.payload.unwrap_or_default(),
             });
@@ -105,9 +106,10 @@ pub async fn handle_checkpoint(
         get_pending_signal(state.persistence.as_ref(), &request.instance_id).await?;
     let custom_signal = state
         .persistence
-        .take_pending_custom_signal(&request.instance_id, &request.checkpoint_id)
+        .get_custom_signal(&request.instance_id, &request.checkpoint_id)
         .await?
         .map(|sig| CustomSignal {
+            signal_id: sig.signal_id,
             checkpoint_id: request.checkpoint_id.clone(),
             payload: sig.payload.unwrap_or_default(),
         });
@@ -311,7 +313,7 @@ pub async fn handle_sleep(
 }
 
 /// Signals that end a sleep early. Cancel and shutdown both terminate the run,
-/// so burning the rest of the clock serves nobody; pause and resume are handled
+/// so burning the rest of the clock serves nobody; pause is handled
 /// at the guest's own poll sites and leave the sleep alone.
 fn interrupts_sleep(signal: &Signal) -> bool {
     SignalType::try_from_i32(signal.signal_type)
@@ -455,6 +457,7 @@ mod tests {
     #[tokio::test]
     async fn test_checkpoint_returns_custom_signal() {
         let custom_signal = CustomSignalRecord {
+            signal_id: "test-signal-value".into(),
             instance_id: "inst-1".to_string(),
             checkpoint_id: "cp-1".to_string(),
             payload: Some(b"custom payload".to_vec()),

--- a/crates/runtara-core/src/instance_handlers/checkpoint.rs
+++ b/crates/runtara-core/src/instance_handlers/checkpoint.rs
@@ -314,8 +314,8 @@ pub async fn handle_sleep(
 /// so burning the rest of the clock serves nobody; pause and resume are handled
 /// at the guest's own poll sites and leave the sleep alone.
 fn interrupts_sleep(signal: &Signal) -> bool {
-    signal.signal_type == i32::from(SignalType::SignalCancel)
-        || signal.signal_type == i32::from(SignalType::SignalShutdown)
+    SignalType::try_from_i32(signal.signal_type)
+        .is_some_and(|kind| crate::lifecycle::interrupts_sleep(kind.into()))
 }
 
 /// Record a heartbeat for a sleeping instance.

--- a/crates/runtara-core/src/instance_handlers/mock_persistence.rs
+++ b/crates/runtara-core/src/instance_handlers/mock_persistence.rs
@@ -363,20 +363,20 @@ impl Persistence for MockPersistence {
         Ok(self.signals.lock().unwrap().get(instance_id).cloned())
     }
 
-    async fn acknowledge_signal(
+    async fn apply_lifecycle_command(
         &self,
         instance_id: &str,
         command_id: &str,
         signal_type: crate::domain::SignalType,
-    ) -> std::result::Result<bool, CoreError> {
+    ) -> std::result::Result<crate::lifecycle::Decision, CoreError> {
         use crate::domain::SignalType;
         let mut instances = self.instances.lock().unwrap();
         let mut signals = self.signals.lock().unwrap();
         let Some(signal) = signals.get(instance_id) else {
-            return Ok(false);
+            return Ok(crate::lifecycle::Decision::Rejected);
         };
         if signal.command_id != command_id || signal.signal_type != signal_type {
-            return Ok(false);
+            return Ok(crate::lifecycle::Decision::Rejected);
         }
         let instance =
             instances
@@ -385,8 +385,16 @@ impl Persistence for MockPersistence {
                     instance_id: instance_id.into(),
                 })?;
         if instance.status.is_terminal() && signal_type != SignalType::Cancel {
-            return Ok(false);
+            return Ok(crate::lifecycle::Decision::Rejected);
         }
+        let decision = crate::lifecycle::acknowledge(
+            instance.status,
+            Some(signal.command()),
+            crate::lifecycle::Receipt {
+                id: command_id,
+                kind: signal_type,
+            },
+        );
         match signal_type {
             SignalType::Cancel => {
                 instance.status = CoreInstanceStatus::Cancelled;
@@ -403,7 +411,15 @@ impl Persistence for MockPersistence {
             SignalType::Resume => {}
         }
         signals.remove(instance_id);
-        Ok(true)
+        Ok(decision)
+    }
+
+    async fn park_instance(
+        &self,
+        _instance_id: &str,
+        _request: crate::lifecycle::ParkRequest,
+    ) -> std::result::Result<crate::lifecycle::Decision, crate::error::CoreError> {
+        Ok(crate::lifecycle::Decision::Rejected)
     }
 
     async fn cancel_suspended_instances(

--- a/crates/runtara-core/src/instance_handlers/mock_persistence.rs
+++ b/crates/runtara-core/src/instance_handlers/mock_persistence.rs
@@ -149,6 +149,7 @@ pub fn make_instance(
         output: None,
         error: None,
         sleep_until: None,
+        wake_reason: None,
         termination_reason: None,
         exit_code: None,
         recovery_attempts: 0,
@@ -408,7 +409,6 @@ impl Persistence for MockPersistence {
                 instance.termination_reason =
                     (signal_type == SignalType::Shutdown).then(|| "shutdown_requested".into());
             }
-            SignalType::Resume => {}
         }
         signals.remove(instance_id);
         Ok(decision)
@@ -431,16 +431,16 @@ impl Persistence for MockPersistence {
         Ok(Vec::new())
     }
 
-    async fn insert_custom_signal(
+    async fn put_custom_signal(
         &self,
         _instance_id: &str,
         _checkpoint_id: &str,
         _payload: &[u8],
-    ) -> std::result::Result<(), CoreError> {
-        Ok(())
+    ) -> std::result::Result<String, CoreError> {
+        Ok("mock-custom-signal".into())
     }
 
-    async fn take_pending_custom_signal(
+    async fn get_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
@@ -483,10 +483,11 @@ impl Persistence for MockPersistence {
         Ok(self.active_instance_count.lock().unwrap().unwrap_or(0))
     }
 
-    async fn set_instance_sleep(
+    async fn schedule_wake(
         &self,
         instance_id: &str,
         sleep_until: DateTime<Utc>,
+        _reason: crate::domain::WakeReason,
     ) -> std::result::Result<(), CoreError> {
         if let Some(inst) = self.instances.lock().unwrap().get_mut(instance_id) {
             inst.sleep_until = Some(sleep_until);

--- a/crates/runtara-core/src/instance_handlers/mod.rs
+++ b/crates/runtara-core/src/instance_handlers/mod.rs
@@ -39,7 +39,7 @@ pub mod mock_persistence;
 pub use self::checkpoint::{handle_checkpoint, handle_get_checkpoint, handle_sleep};
 pub use self::event::{handle_instance_event, handle_retry_attempt};
 pub use self::registration::handle_register_instance;
-pub use self::signal::{handle_poll_signals, handle_signal_ack};
+pub use self::signal::{handle_poll_signals, handle_signal_ack, handle_signal_ack_decision};
 pub use self::state::{InstanceEventObserver, InstanceHandlerState};
 pub use self::status::handle_get_instance_status;
 pub use self::types::*;

--- a/crates/runtara-core/src/instance_handlers/signal.rs
+++ b/crates/runtara-core/src/instance_handlers/signal.rs
@@ -17,8 +17,8 @@ use super::types::{
 
 /// Handle signal polling request.
 ///
-/// Returns the oldest pending signal for the instance, if any.
-/// Signals are: cancel, pause, resume.
+/// Returns the current pending command without consuming it.
+/// Commands are cancel, pause, resume, and shutdown.
 ///
 /// Note: The checkpoint response also includes pending signals for efficiency.
 /// This endpoint is for explicit polling when not checkpointing.
@@ -79,19 +79,22 @@ pub async fn handle_poll_signals(
 /// False means the receipt is stale or the requested transition is no longer valid.
 #[instrument(skip(state, ack), fields(instance_id = %ack.instance_id, command_id = %ack.command_id))]
 pub async fn handle_signal_ack(state: &InstanceHandlerState, ack: SignalAck) -> Result<bool> {
+    Ok(handle_signal_ack_decision(state, ack).await?.accepted())
+}
+
+/// Acknowledge a command while retaining its typed lifecycle disposition.
+pub async fn handle_signal_ack_decision(
+    state: &InstanceHandlerState,
+    ack: SignalAck,
+) -> Result<crate::lifecycle::Decision> {
     if !ack.acknowledged {
-        return Ok(false);
+        return Ok(crate::lifecycle::Decision::Rejected);
     }
-    let signal_type = match ack.signal_type {
-        0 => crate::domain::SignalType::Cancel,
-        1 => crate::domain::SignalType::Pause,
-        2 => crate::domain::SignalType::Resume,
-        3 => crate::domain::SignalType::Shutdown,
-        _ => anyhow::bail!("Unknown lifecycle signal type: {}", ack.signal_type),
-    };
+    let signal_type = SignalType::try_from_i32(ack.signal_type)
+        .ok_or_else(|| anyhow::anyhow!("Unknown lifecycle signal type: {}", ack.signal_type))?;
     Ok(state
         .persistence
-        .acknowledge_signal(&ack.instance_id, &ack.command_id, signal_type)
+        .apply_lifecycle_command(&ack.instance_id, &ack.command_id, signal_type.into())
         .await?)
 }
 

--- a/crates/runtara-core/src/instance_handlers/signal.rs
+++ b/crates/runtara-core/src/instance_handlers/signal.rs
@@ -18,7 +18,7 @@ use super::types::{
 /// Handle signal polling request.
 ///
 /// Returns the current pending command without consuming it.
-/// Commands are cancel, pause, resume, and shutdown.
+/// Commands are cancel, pause, and shutdown.
 ///
 /// Note: The checkpoint response also includes pending signals for efficiency.
 /// This endpoint is for explicit polling when not checkpointing.
@@ -39,7 +39,7 @@ pub async fn handle_poll_signals(
     let custom = if let Some(checkpoint_id) = request.checkpoint_id.as_deref() {
         state
             .persistence
-            .take_pending_custom_signal(&request.instance_id, checkpoint_id)
+            .get_custom_signal(&request.instance_id, checkpoint_id)
             .await?
     } else {
         None
@@ -57,6 +57,7 @@ pub async fn handle_poll_signals(
     });
 
     let custom_signal = custom.map(|sig| CustomSignal {
+        signal_id: sig.signal_id,
         checkpoint_id: sig.checkpoint_id,
         payload: sig.payload.unwrap_or_default(),
     });
@@ -107,13 +108,48 @@ mod tests {
     use crate::persistence::Persistence;
 
     #[tokio::test]
+    async fn retired_resume_value_cannot_acknowledge_a_command() {
+        let backend = Arc::new(crate::persistence::memory::InMemoryPersistence::new());
+        backend.register_instance("retired", "test").await.unwrap();
+        backend
+            .insert_signal("retired", crate::domain::SignalType::Pause, b"")
+            .await
+            .unwrap();
+        let command = backend
+            .get_pending_signal("retired")
+            .await
+            .unwrap()
+            .unwrap();
+        let state = InstanceHandlerState::new(backend.clone());
+        let result = handle_signal_ack(
+            &state,
+            SignalAck {
+                instance_id: "retired".into(),
+                command_id: command.command_id.clone(),
+                signal_type: 2,
+                acknowledged: true,
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            backend
+                .get_pending_signal("retired")
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
+            command.command_id
+        );
+    }
+
+    #[tokio::test]
     async fn checkpoint_and_poll_deliver_every_signal_identically() {
         use crate::domain::{InstanceStatus, SignalType as StoredSignal};
         use crate::instance_handlers::{CheckpointRequest, handle_checkpoint};
         for signal_type in [
             StoredSignal::Cancel,
             StoredSignal::Pause,
-            StoredSignal::Resume,
             StoredSignal::Shutdown,
         ] {
             let persistence = Arc::new(
@@ -215,7 +251,7 @@ mod tests {
                     "tenant-1",
                     CoreInstanceStatus::Running,
                 ))
-                .with_signal(make_signal("inst-1", CoreSignalType::Pause)),
+                .with_signal(make_signal("inst-1", crate::domain::SignalType::Pause)),
         );
         let state = InstanceHandlerState::new(persistence);
 

--- a/crates/runtara-core/src/instance_handlers/types.rs
+++ b/crates/runtara-core/src/instance_handlers/types.rs
@@ -13,8 +13,6 @@ pub enum SignalType {
     SignalCancel = 0,
     /// Pause execution (checkpoint and wait).
     SignalPause = 1,
-    /// Resume paused execution.
-    SignalResume = 2,
     /// Server draining: suspend at next checkpoint so the instance can be
     /// resumed after restart. Behaves like a cancel from the SDK's perspective
     /// but transitions the instance to `suspended + termination_reason="shutdown_requested"`
@@ -28,7 +26,6 @@ impl SignalType {
         match value {
             0 => Some(Self::SignalCancel),
             1 => Some(Self::SignalPause),
-            2 => Some(Self::SignalResume),
             3 => Some(Self::SignalShutdown),
             _ => None,
         }
@@ -40,7 +37,6 @@ impl From<SignalType> for CoreSignalType {
         match value {
             SignalType::SignalCancel => Self::Cancel,
             SignalType::SignalPause => Self::Pause,
-            SignalType::SignalResume => Self::Resume,
             SignalType::SignalShutdown => Self::Shutdown,
         }
     }
@@ -158,6 +154,8 @@ pub struct Signal {
 /// Custom signal targeted at a specific checkpoint_id.
 #[derive(Debug, Clone)]
 pub struct CustomSignal {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    pub signal_id: String,
     /// Checkpoint ID this signal targets.
     pub checkpoint_id: String,
     /// Signal payload bytes.
@@ -170,7 +168,7 @@ pub struct CheckpointResponse {
     pub found: bool,
     /// Existing checkpoint state if found, empty if new.
     pub state: Vec<u8>,
-    /// Pending instance-wide signal (cancel/pause/resume).
+    /// Pending instance-wide signal (cancel/pause/shutdown).
     pub pending_signal: Option<Signal>,
     /// Pending checkpoint-scoped custom signal.
     pub custom_signal: Option<CustomSignal>,
@@ -303,15 +301,9 @@ pub struct SignalAck {
 }
 
 impl SignalAck {
-    /// Get the signal type as an enum.
-    pub fn signal_type(&self) -> SignalType {
-        match self.signal_type {
-            0 => SignalType::SignalCancel,
-            1 => SignalType::SignalPause,
-            2 => SignalType::SignalResume,
-            3 => SignalType::SignalShutdown,
-            _ => SignalType::SignalCancel,
-        }
+    /// Decode a supported lifecycle command; numeric value 2 is retired.
+    pub fn signal_type(&self) -> Option<SignalType> {
+        SignalType::try_from_i32(self.signal_type)
     }
 }
 
@@ -393,7 +385,6 @@ impl From<CoreSignalType> for SignalType {
         match value {
             CoreSignalType::Cancel => Self::SignalCancel,
             CoreSignalType::Pause => Self::SignalPause,
-            CoreSignalType::Resume => Self::SignalResume,
             CoreSignalType::Shutdown => Self::SignalShutdown,
         }
     }

--- a/crates/runtara-core/src/instance_handlers/types.rs
+++ b/crates/runtara-core/src/instance_handlers/types.rs
@@ -22,6 +22,30 @@ pub enum SignalType {
     SignalShutdown = 3,
 }
 
+impl SignalType {
+    /// Decode a protocol command, rejecting unknown numeric values.
+    pub fn try_from_i32(value: i32) -> Option<Self> {
+        match value {
+            0 => Some(Self::SignalCancel),
+            1 => Some(Self::SignalPause),
+            2 => Some(Self::SignalResume),
+            3 => Some(Self::SignalShutdown),
+            _ => None,
+        }
+    }
+}
+
+impl From<SignalType> for CoreSignalType {
+    fn from(value: SignalType) -> Self {
+        match value {
+            SignalType::SignalCancel => Self::Cancel,
+            SignalType::SignalPause => Self::Pause,
+            SignalType::SignalResume => Self::Resume,
+            SignalType::SignalShutdown => Self::Shutdown,
+        }
+    }
+}
+
 impl From<SignalType> for i32 {
     fn from(s: SignalType) -> i32 {
         s as i32

--- a/crates/runtara-core/src/lib.rs
+++ b/crates/runtara-core/src/lib.rs
@@ -157,6 +157,9 @@
 /// Execution domain types independent of storage and transport.
 pub mod domain;
 
+/// Pure lifecycle policy shared by storage backends and execution hosts.
+pub mod lifecycle;
+
 /// Persistence layer for instances, checkpoints, events, and signals.
 pub mod persistence;
 

--- a/crates/runtara-core/src/lib.rs
+++ b/crates/runtara-core/src/lib.rs
@@ -70,7 +70,7 @@
 //! | `Sleep` | Durable sleep - persists a wake deadline |
 //! | `InstanceEvent` | Fire-and-forget events (heartbeat, completed, failed, suspended) |
 //! | `GetInstanceStatus` | Query instance status |
-//! | `PollSignals` | Poll for pending cancel/pause/resume signals |
+//! | `PollSignals` | Poll for pending cancel/pause/shutdown signals |
 //! | `SignalAck` | Acknowledge receipt of a signal |
 //!
 //! ## Checkpoint Semantics

--- a/crates/runtara-core/src/lifecycle.rs
+++ b/crates/runtara-core/src/lifecycle.rs
@@ -1,0 +1,364 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Pure lifecycle decisions. Backends evaluate these against locked state and
+//! persist the resulting effects atomically; hosts perform execution actions.
+
+use crate::domain::{EventType, InstanceStatus, SignalType};
+
+/// An explicit field update. Keeping a value is different from clearing it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Change<T> {
+    /// Preserve the stored value.
+    Keep,
+    /// Remove the stored value.
+    Clear,
+    /// Replace the stored value.
+    Set(T),
+}
+
+/// Domain reasons for suspending execution. Adapters own their encodings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuspensionReason {
+    /// Server shutdown requested a restartable suspension.
+    Shutdown,
+    /// Execution awaits a timer.
+    Sleeping,
+    /// Execution awaits a durable custom signal.
+    WaitingSignal,
+}
+
+/// A requested wake time, resolved by the backend's transaction clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WakeDeadline {
+    /// Make the instance eligible for immediate wake.
+    Now,
+}
+
+/// The identity and disposition of a stored lifecycle command.
+#[derive(Debug, Clone, Copy)]
+pub struct Command<'a> {
+    /// Opaque command identity.
+    pub id: &'a str,
+    /// Command kind.
+    pub kind: SignalType,
+    /// Whether this command has already been applied.
+    pub acknowledged: bool,
+}
+
+/// The exact command observed by a caller.
+#[derive(Debug, Clone, Copy)]
+pub struct Receipt<'a> {
+    /// Observed command identity.
+    pub id: &'a str,
+    /// Observed command kind.
+    pub kind: SignalType,
+}
+
+/// Durable effects of a newly accepted lifecycle operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Transition {
+    /// New status, or no status change.
+    pub status: Option<InstanceStatus>,
+    /// Set finished_at to the transaction timestamp.
+    pub finish_now: bool,
+    /// Suspension reason update.
+    pub reason: Change<SuspensionReason>,
+    /// Wake deadline update.
+    pub wake: Change<WakeDeadline>,
+    /// Timeline event to append in the same operation.
+    pub event: Option<EventType>,
+    /// Acknowledge the locked command in the same operation.
+    pub acknowledge: bool,
+    /// Report a newly terminal instance after committing.
+    pub report_completion: bool,
+}
+
+/// Result of evaluating an operation against the current stored state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// The operation is stale, mismatched, missing, or invalid for this state.
+    Rejected,
+    /// The exact receipt was already applied; do not repeat durable effects.
+    AlreadyApplied,
+    /// Apply these effects atomically.
+    Applied(Transition),
+}
+
+impl Decision {
+    /// Compatibility acknowledgment result exposed by transport adapters.
+    pub fn accepted(self) -> bool {
+        !matches!(self, Self::Rejected)
+    }
+}
+
+/// Whether a new command may replace the existing slot. Pending cancellation
+/// dominates every later command, including another cancel.
+pub fn may_replace_command(stored: Option<Command<'_>>) -> bool {
+    !stored.is_some_and(|command| command.kind == SignalType::Cancel && !command.acknowledged)
+}
+
+/// Validate a receipt and decide its durable effects. For compatibility a
+/// matching cancellation can override completed/failed status, including when
+/// the runner discovers an unhandled cancel after execution exits.
+pub fn acknowledge(
+    status: InstanceStatus,
+    stored: Option<Command<'_>>,
+    receipt: Receipt<'_>,
+) -> Decision {
+    let Some(command) = stored else {
+        return Decision::Rejected;
+    };
+    if command.id != receipt.id || command.kind != receipt.kind {
+        return Decision::Rejected;
+    }
+    if command.acknowledged {
+        return Decision::AlreadyApplied;
+    }
+    if status.is_terminal() && command.kind != SignalType::Cancel {
+        return Decision::Rejected;
+    }
+    let mut effects = Transition {
+        status: None,
+        finish_now: false,
+        reason: Change::Keep,
+        wake: Change::Keep,
+        event: None,
+        acknowledge: true,
+        report_completion: false,
+    };
+    match command.kind {
+        SignalType::Cancel => {
+            effects.status = Some(InstanceStatus::Cancelled);
+            effects.finish_now = true;
+            effects.wake = Change::Clear;
+            effects.report_completion = !status.is_terminal();
+        }
+        SignalType::Pause | SignalType::Shutdown => {
+            effects.status = Some(InstanceStatus::Suspended);
+            effects.finish_now = true;
+            effects.event = Some(EventType::Suspended);
+            if command.kind == SignalType::Shutdown {
+                effects.reason = Change::Set(SuspensionReason::Shutdown);
+                effects.wake = Change::Set(WakeDeadline::Now);
+            } else {
+                effects.reason = Change::Clear;
+                effects.wake = Change::Clear;
+            }
+        }
+        SignalType::Resume => {}
+    }
+    Decision::Applied(effects)
+}
+
+/// Apply a pending cancel only while parked. Running guests keep their command;
+/// terminal instances are untouched. Recovery never replays an accepted receipt.
+pub fn cancel_parked(status: InstanceStatus, stored: Option<Command<'_>>) -> Decision {
+    let Some(command) = stored else {
+        return Decision::Rejected;
+    };
+    if status != InstanceStatus::Suspended
+        || command.kind != SignalType::Cancel
+        || command.acknowledged
+    {
+        return Decision::Rejected;
+    }
+    acknowledge(
+        status,
+        Some(command),
+        Receipt {
+            id: command.id,
+            kind: command.kind,
+        },
+    )
+}
+
+/// Action performed locally after a successful command acknowledgment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionAction {
+    /// No local execution change (legacy resume command).
+    Continue,
+    /// Yield execution until explicitly resumed.
+    Pause,
+    /// End the current execution, including restartable shutdown.
+    Stop,
+}
+
+/// Interpret a command for the executing host. Durable effects must be accepted
+/// before this action is performed.
+pub fn execution_action(kind: SignalType) -> ExecutionAction {
+    match kind {
+        SignalType::Cancel | SignalType::Shutdown => ExecutionAction::Stop,
+        SignalType::Pause => ExecutionAction::Pause,
+        SignalType::Resume => ExecutionAction::Continue,
+    }
+}
+
+/// Whether an in-process sleep should return early to deliver this command.
+pub fn interrupts_sleep(kind: SignalType) -> bool {
+    execution_action(kind) == ExecutionAction::Stop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const STATUSES: [InstanceStatus; 6] = [
+        InstanceStatus::Pending,
+        InstanceStatus::Running,
+        InstanceStatus::Suspended,
+        InstanceStatus::Completed,
+        InstanceStatus::Failed,
+        InstanceStatus::Cancelled,
+    ];
+    const KINDS: [SignalType; 4] = [
+        SignalType::Cancel,
+        SignalType::Pause,
+        SignalType::Resume,
+        SignalType::Shutdown,
+    ];
+    fn command(kind: SignalType, acknowledged: bool) -> Command<'static> {
+        Command {
+            id: "current",
+            kind,
+            acknowledged,
+        }
+    }
+    fn receipt(kind: SignalType) -> Receipt<'static> {
+        Receipt {
+            id: "current",
+            kind,
+        }
+    }
+
+    #[test]
+    fn acknowledgment_state_matrix() {
+        for status in STATUSES {
+            for kind in KINDS {
+                let decision = acknowledge(status, Some(command(kind, false)), receipt(kind));
+                let terminal = matches!(
+                    status,
+                    InstanceStatus::Completed | InstanceStatus::Failed | InstanceStatus::Cancelled
+                );
+                if terminal && kind != SignalType::Cancel {
+                    assert_eq!(decision, Decision::Rejected);
+                    continue;
+                }
+                let Decision::Applied(effects) = decision else {
+                    panic!("{status:?} {kind:?}")
+                };
+                let expected = match kind {
+                    SignalType::Cancel => (
+                        Some(InstanceStatus::Cancelled),
+                        true,
+                        Change::Keep,
+                        Change::Clear,
+                        None,
+                        !terminal,
+                    ),
+                    SignalType::Pause => (
+                        Some(InstanceStatus::Suspended),
+                        true,
+                        Change::Clear,
+                        Change::Clear,
+                        Some(EventType::Suspended),
+                        false,
+                    ),
+                    SignalType::Shutdown => (
+                        Some(InstanceStatus::Suspended),
+                        true,
+                        Change::Set(SuspensionReason::Shutdown),
+                        Change::Set(WakeDeadline::Now),
+                        Some(EventType::Suspended),
+                        false,
+                    ),
+                    SignalType::Resume => (None, false, Change::Keep, Change::Keep, None, false),
+                };
+                assert_eq!(
+                    (
+                        effects.status,
+                        effects.finish_now,
+                        effects.reason,
+                        effects.wake,
+                        effects.event,
+                        effects.report_completion
+                    ),
+                    expected
+                );
+                assert!(effects.acknowledge);
+            }
+        }
+    }
+
+    #[test]
+    fn stale_and_repeated_receipts_never_apply_effects() {
+        for status in STATUSES {
+            for kind in KINDS {
+                assert_eq!(acknowledge(status, None, receipt(kind)), Decision::Rejected);
+                assert_eq!(
+                    acknowledge(status, Some(command(kind, true)), receipt(kind)),
+                    Decision::AlreadyApplied
+                );
+                assert_eq!(
+                    acknowledge(
+                        status,
+                        Some(command(kind, false)),
+                        Receipt { id: "old", kind }
+                    ),
+                    Decision::Rejected
+                );
+                for other in KINDS {
+                    if other != kind {
+                        assert_eq!(
+                            acknowledge(status, Some(command(kind, true)), receipt(other)),
+                            Decision::Rejected
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn only_pending_cancellation_blocks_replacement() {
+        assert!(may_replace_command(None));
+        for kind in KINDS {
+            assert!(may_replace_command(Some(command(kind, true))));
+            assert_eq!(
+                may_replace_command(Some(command(kind, false))),
+                kind != SignalType::Cancel
+            );
+        }
+    }
+
+    #[test]
+    fn parked_cancellation_does_not_consume_commands_for_active_or_terminal_instances() {
+        for status in STATUSES {
+            for kind in KINDS {
+                assert_eq!(
+                    matches!(
+                        cancel_parked(status, Some(command(kind, false))),
+                        Decision::Applied(_)
+                    ),
+                    status == InstanceStatus::Suspended && kind == SignalType::Cancel
+                );
+                assert_eq!(
+                    cancel_parked(status, Some(command(kind, true))),
+                    Decision::Rejected
+                );
+            }
+            assert_eq!(cancel_parked(status, None), Decision::Rejected);
+        }
+    }
+
+    #[test]
+    fn execution_and_sleep_actions() {
+        for (kind, action, interrupts) in [
+            (SignalType::Cancel, ExecutionAction::Stop, true),
+            (SignalType::Shutdown, ExecutionAction::Stop, true),
+            (SignalType::Pause, ExecutionAction::Pause, false),
+            (SignalType::Resume, ExecutionAction::Continue, false),
+        ] {
+            assert_eq!(execution_action(kind), action);
+            assert_eq!(interrupts_sleep(kind), interrupts);
+        }
+    }
+}

--- a/crates/runtara-core/src/lifecycle.rs
+++ b/crates/runtara-core/src/lifecycle.rs
@@ -3,7 +3,7 @@
 //! Pure lifecycle decisions. Backends evaluate these against locked state and
 //! persist the resulting effects atomically; hosts perform execution actions.
 
-use crate::domain::{EventType, InstanceStatus, SignalType};
+use crate::domain::{EventType, InstanceStatus, SignalType, WakeReason};
 
 /// An explicit field update. Keeping a value is different from clearing it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +69,8 @@ pub struct Transition {
     pub reason: Change<SuspensionReason>,
     /// Wake deadline update.
     pub wake: Change<WakeDeadline>,
+    /// Host scheduling cause, separate from the command being acknowledged.
+    pub wake_reason: Change<WakeReason>,
     /// Timeline event to append in the same operation.
     pub event: Option<EventType>,
     /// Acknowledge the locked command in the same operation.
@@ -127,6 +129,7 @@ pub fn acknowledge(
         clear_result: false,
         reason: Change::Keep,
         wake: Change::Keep,
+        wake_reason: Change::Keep,
         event: None,
         acknowledge: true,
         report_completion: false,
@@ -136,6 +139,7 @@ pub fn acknowledge(
             effects.status = Some(InstanceStatus::Cancelled);
             effects.finish_now = true;
             effects.wake = Change::Clear;
+            effects.wake_reason = Change::Clear;
             effects.report_completion = !status.is_terminal();
         }
         SignalType::Pause | SignalType::Shutdown => {
@@ -145,12 +149,13 @@ pub fn acknowledge(
             if command.kind == SignalType::Shutdown {
                 effects.reason = Change::Set(SuspensionReason::Shutdown);
                 effects.wake = Change::Set(WakeDeadline::Now);
+                effects.wake_reason = Change::Set(WakeReason::Recovery);
             } else {
                 effects.reason = Change::Clear;
                 effects.wake = Change::Clear;
+                effects.wake_reason = Change::Clear;
             }
         }
-        SignalType::Resume => {}
     }
     Decision::Applied(effects)
 }
@@ -213,6 +218,11 @@ pub fn park(status: InstanceStatus, request: ParkRequest) -> Decision {
         wake: request.deadline.map_or(Change::Keep, |deadline| {
             Change::Set(WakeDeadline::At(deadline))
         }),
+        wake_reason: if request.deadline.is_some() {
+            Change::Set(WakeReason::Timer)
+        } else {
+            Change::Keep
+        },
         event: None,
         acknowledge: false,
         report_completion: false,
@@ -222,8 +232,6 @@ pub fn park(status: InstanceStatus, request: ParkRequest) -> Decision {
 /// Action performed locally after a successful command acknowledgment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionAction {
-    /// No local execution change (legacy resume command).
-    Continue,
     /// Yield execution until explicitly resumed.
     Pause,
     /// End the current execution, including restartable shutdown.
@@ -236,7 +244,6 @@ pub fn execution_action(kind: SignalType) -> ExecutionAction {
     match kind {
         SignalType::Cancel | SignalType::Shutdown => ExecutionAction::Stop,
         SignalType::Pause => ExecutionAction::Pause,
-        SignalType::Resume => ExecutionAction::Continue,
     }
 }
 
@@ -256,12 +263,7 @@ mod tests {
         InstanceStatus::Failed,
         InstanceStatus::Cancelled,
     ];
-    const KINDS: [SignalType; 4] = [
-        SignalType::Cancel,
-        SignalType::Pause,
-        SignalType::Resume,
-        SignalType::Shutdown,
-    ];
+    const KINDS: [SignalType; 3] = [SignalType::Cancel, SignalType::Pause, SignalType::Shutdown];
     fn command(kind: SignalType, acknowledged: bool) -> Command<'static> {
         Command {
             id: "current",
@@ -317,7 +319,6 @@ mod tests {
                         Some(EventType::Suspended),
                         false,
                     ),
-                    SignalType::Resume => (None, false, Change::Keep, Change::Keep, None, false),
                 };
                 assert_eq!(
                     (
@@ -443,7 +444,6 @@ mod tests {
             (SignalType::Cancel, ExecutionAction::Stop, true),
             (SignalType::Shutdown, ExecutionAction::Stop, true),
             (SignalType::Pause, ExecutionAction::Pause, false),
-            (SignalType::Resume, ExecutionAction::Continue, false),
         ] {
             assert_eq!(execution_action(kind), action);
             assert_eq!(interrupts_sleep(kind), interrupts);

--- a/crates/runtara-core/src/lifecycle.rs
+++ b/crates/runtara-core/src/lifecycle.rs
@@ -32,6 +32,8 @@ pub enum SuspensionReason {
 pub enum WakeDeadline {
     /// Make the instance eligible for immediate wake.
     Now,
+    /// A host-provided durable timer deadline.
+    At(chrono::DateTime<chrono::Utc>),
 }
 
 /// The identity and disposition of a stored lifecycle command.
@@ -61,6 +63,8 @@ pub struct Transition {
     pub status: Option<InstanceStatus>,
     /// Set finished_at to the transaction timestamp.
     pub finish_now: bool,
+    /// Clear output and error from the previous execution outcome.
+    pub clear_result: bool,
     /// Suspension reason update.
     pub reason: Change<SuspensionReason>,
     /// Wake deadline update.
@@ -120,6 +124,7 @@ pub fn acknowledge(
     let mut effects = Transition {
         status: None,
         finish_now: false,
+        clear_result: false,
         reason: Change::Keep,
         wake: Change::Keep,
         event: None,
@@ -170,6 +175,48 @@ pub fn cancel_parked(status: InstanceStatus, stored: Option<Command<'_>>) -> Dec
             kind: command.kind,
         },
     )
+}
+
+/// Kind of durable guest suspension; component-specific wake decoding belongs
+/// to the host rather than this policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParkReason {
+    /// Waiting for a timer.
+    Timer,
+    /// Waiting for a custom signal, optionally with a timeout.
+    Signal,
+}
+
+/// A durable suspension requested by an exiting guest.
+#[derive(Debug, Clone, Copy)]
+pub struct ParkRequest {
+    /// Why execution is parking.
+    pub reason: ParkReason,
+    /// Earliest requested timer or signal timeout.
+    pub deadline: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Park only a currently running instance. Preserve unrelated termination
+/// metadata and emit no additional event, matching the invoke suspension path.
+pub fn park(status: InstanceStatus, request: ParkRequest) -> Decision {
+    if status != InstanceStatus::Running {
+        return Decision::Rejected;
+    }
+    Decision::Applied(Transition {
+        status: Some(InstanceStatus::Suspended),
+        finish_now: true,
+        clear_result: true,
+        reason: Change::Set(match request.reason {
+            ParkReason::Timer => SuspensionReason::Sleeping,
+            ParkReason::Signal => SuspensionReason::WaitingSignal,
+        }),
+        wake: request.deadline.map_or(Change::Keep, |deadline| {
+            Change::Set(WakeDeadline::At(deadline))
+        }),
+        event: None,
+        acknowledge: false,
+        report_completion: false,
+    })
 }
 
 /// Action performed locally after a successful command acknowledgment.
@@ -346,6 +393,47 @@ mod tests {
                 );
             }
             assert_eq!(cancel_parked(status, None), Decision::Rejected);
+        }
+    }
+
+    #[test]
+    fn parking_requires_running_and_preserves_unrelated_fields() {
+        let deadline = chrono::DateTime::from_timestamp(1_800_000_000, 0).unwrap();
+        for status in STATUSES {
+            for reason in [ParkReason::Timer, ParkReason::Signal] {
+                for wake in [None, Some(deadline)] {
+                    let decision = park(
+                        status,
+                        ParkRequest {
+                            reason,
+                            deadline: wake,
+                        },
+                    );
+                    if status != InstanceStatus::Running {
+                        assert_eq!(decision, Decision::Rejected);
+                        continue;
+                    }
+                    let Decision::Applied(effects) = decision else {
+                        panic!("running must park")
+                    };
+                    assert_eq!(effects.status, Some(InstanceStatus::Suspended));
+                    assert!(effects.finish_now && effects.clear_result);
+                    assert!(!effects.acknowledge && !effects.report_completion);
+                    assert_eq!(effects.event, None);
+                    assert_eq!(
+                        effects.reason,
+                        Change::Set(if reason == ParkReason::Timer {
+                            SuspensionReason::Sleeping
+                        } else {
+                            SuspensionReason::WaitingSignal
+                        })
+                    );
+                    assert_eq!(
+                        effects.wake,
+                        wake.map_or(Change::Keep, |d| Change::Set(WakeDeadline::At(d)))
+                    );
+                }
+            }
         }
     }
 

--- a/crates/runtara-core/src/persistence/conformance.rs
+++ b/crates/runtara-core/src/persistence/conformance.rs
@@ -1151,3 +1151,192 @@ pub async fn run_parked_cancellation_sequence<P: Persistence>(backend: &P) {
         "recovery discovers parked cancellation without a sleep deadline"
     );
 }
+
+/// Observable lifecycle matrix shared by every backend. Expected values are
+/// specified independently of the pure policy implementation.
+pub async fn run_lifecycle_policy_matrix<P: Persistence>(backend: &P) {
+    use crate::{
+        domain::{InstanceStatus as S, SignalType as K},
+        lifecycle::{Decision, ParkReason, ParkRequest},
+    };
+    let statuses = [
+        S::Pending,
+        S::Running,
+        S::Suspended,
+        S::Completed,
+        S::Failed,
+        S::Cancelled,
+    ];
+    let kinds = [K::Cancel, K::Pause, K::Resume, K::Shutdown];
+    for status in statuses {
+        for kind in kinds {
+            let id = Uuid::new_v4().to_string();
+            backend
+                .register_instance(&id, "policy-matrix")
+                .await
+                .unwrap();
+            backend
+                .complete_instance(
+                    CompleteInstanceParams::new(&id, status)
+                        .with_output(b"previous-output")
+                        .with_error("previous-error")
+                        .with_termination("crashed", Some(91))
+                        .with_checkpoint("previous-checkpoint"),
+                )
+                .await
+                .unwrap();
+            backend.insert_signal(&id, kind, b"payload").await.unwrap();
+            let command = backend.get_pending_signal(&id).await.unwrap().unwrap();
+            let before = backend.get_instance(&id).await.unwrap().unwrap();
+            let decision = backend
+                .apply_lifecycle_command(&id, &command.command_id, kind)
+                .await
+                .unwrap();
+            let rejects =
+                matches!(status, S::Completed | S::Failed | S::Cancelled) && kind != K::Cancel;
+            if rejects {
+                assert_eq!(decision, Decision::Rejected);
+            } else {
+                assert!(matches!(decision, Decision::Applied(_)));
+            }
+            let after = backend.get_instance(&id).await.unwrap().unwrap();
+            let expected_status = if rejects {
+                status
+            } else {
+                match kind {
+                    K::Cancel => S::Cancelled,
+                    K::Pause | K::Shutdown => S::Suspended,
+                    K::Resume => status,
+                }
+            };
+            assert_eq!(after.status, expected_status, "{status:?} + {kind:?}");
+            let reason = if rejects {
+                Some("crashed")
+            } else {
+                match kind {
+                    K::Pause => None,
+                    K::Shutdown => Some("shutdown_requested"),
+                    _ => Some("crashed"),
+                }
+            };
+            assert_eq!(after.termination_reason.as_deref(), reason);
+            assert_eq!(after.output, before.output);
+            assert_eq!(after.error, before.error);
+            assert_eq!(after.exit_code, before.exit_code);
+            assert_eq!(after.checkpoint_id, before.checkpoint_id);
+            assert_eq!(after.sleep_until.is_some(), !rejects && kind == K::Shutdown);
+            let event_count = backend
+                .count_events(&id, &ListEventsFilter::default())
+                .await
+                .unwrap();
+            assert_eq!(
+                event_count,
+                i64::from(!rejects && matches!(kind, K::Pause | K::Shutdown))
+            );
+            if !rejects {
+                assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+                assert_eq!(
+                    backend
+                        .apply_lifecycle_command(&id, &command.command_id, kind)
+                        .await
+                        .unwrap(),
+                    Decision::AlreadyApplied
+                );
+                let repeated = backend.get_instance(&id).await.unwrap().unwrap();
+                assert_eq!(repeated.finished_at, after.finished_at);
+                assert_eq!(repeated.sleep_until, after.sleep_until);
+                assert_eq!(
+                    backend
+                        .count_events(&id, &ListEventsFilter::default())
+                        .await
+                        .unwrap(),
+                    event_count
+                );
+            } else {
+                assert_eq!(
+                    backend
+                        .get_pending_signal(&id)
+                        .await
+                        .unwrap()
+                        .unwrap()
+                        .command_id,
+                    command.command_id
+                );
+            }
+            backend.delete_instances_batch(&[id]).await.unwrap();
+        }
+        for reason in [ParkReason::Timer, ParkReason::Signal] {
+            for with_deadline in [false, true] {
+                let id = Uuid::new_v4().to_string();
+                backend
+                    .register_instance(&id, "park-policy-matrix")
+                    .await
+                    .unwrap();
+                backend
+                    .complete_instance(
+                        CompleteInstanceParams::new(&id, status)
+                            .with_output(b"old-result")
+                            .with_error("old-error")
+                            .with_termination("crashed", Some(91))
+                            .with_checkpoint("saved"),
+                    )
+                    .await
+                    .unwrap();
+                backend.insert_signal(&id, K::Cancel, b"").await.unwrap();
+                let receipt = backend.get_pending_signal(&id).await.unwrap().unwrap();
+                let before = backend.get_instance(&id).await.unwrap().unwrap();
+                let deadline = with_deadline.then(|| Utc::now() + Duration::hours(1));
+                let result = backend
+                    .park_instance(&id, ParkRequest { reason, deadline })
+                    .await
+                    .unwrap();
+                let after = backend.get_instance(&id).await.unwrap().unwrap();
+                if status == S::Running {
+                    assert!(matches!(result, Decision::Applied(_)));
+                    assert_eq!(after.status, S::Suspended);
+                    assert_eq!(
+                        after.termination_reason.as_deref(),
+                        Some(if reason == ParkReason::Timer {
+                            "sleeping"
+                        } else {
+                            "waiting_signal"
+                        })
+                    );
+                    assert_eq!(
+                        after.sleep_until.map(|d| d.timestamp_millis()),
+                        deadline.map(|d| d.timestamp_millis())
+                    );
+                    assert!(after.finished_at.is_some());
+                    assert!(after.output.is_none() && after.error.is_none());
+                } else {
+                    assert_eq!(result, Decision::Rejected);
+                    assert_eq!(after.status, before.status);
+                    assert_eq!(after.finished_at, before.finished_at);
+                    assert_eq!(after.termination_reason, before.termination_reason);
+                    assert_eq!(after.sleep_until, before.sleep_until);
+                    assert_eq!(after.output, before.output);
+                    assert_eq!(after.error, before.error);
+                }
+                assert_eq!(after.checkpoint_id, before.checkpoint_id);
+                assert_eq!(after.exit_code, before.exit_code);
+                assert_eq!(
+                    backend
+                        .get_pending_signal(&id)
+                        .await
+                        .unwrap()
+                        .unwrap()
+                        .command_id,
+                    receipt.command_id
+                );
+                assert_eq!(
+                    backend
+                        .count_events(&id, &ListEventsFilter::default())
+                        .await
+                        .unwrap(),
+                    0
+                );
+                backend.delete_instances_batch(&[id]).await.unwrap();
+            }
+        }
+    }
+}

--- a/crates/runtara-core/src/persistence/conformance.rs
+++ b/crates/runtara-core/src/persistence/conformance.rs
@@ -519,26 +519,57 @@ pub async fn run_conformance_sequence<P: Persistence>(backend: &P) {
 
     // --- custom checkpoint signals -----------------------------------------
     let custom_payload = br#"{"wait-key":"payment"}"#.to_vec();
-    backend
-        .insert_custom_signal(&instance_id, checkpoint_id, &custom_payload)
+    let first_signal_id = backend
+        .put_custom_signal(&instance_id, checkpoint_id, &custom_payload)
         .await
-        .expect("insert_custom_signal failed");
+        .expect("put_custom_signal failed");
     let taken = backend
-        .take_pending_custom_signal(&instance_id, checkpoint_id)
+        .get_custom_signal(&instance_id, checkpoint_id)
         .await
-        .expect("take_pending_custom_signal failed")
+        .expect("get_custom_signal failed")
         .expect("custom signal should be readable");
     assert_eq!(taken.checkpoint_id, checkpoint_id);
     // Reads are non-destructive: a replayed WaitForSignal re-reads the same
     // signal after a drain/resume, so a second read returns the row again
     // rather than None. Instance deletion reclaims the signal.
     let taken_again = backend
-        .take_pending_custom_signal(&instance_id, checkpoint_id)
+        .get_custom_signal(&instance_id, checkpoint_id)
         .await
-        .expect("take_pending_custom_signal second call failed")
+        .expect("get_custom_signal second call failed")
         .expect("custom signal must remain re-readable (non-destructive)");
     assert_eq!(taken_again.checkpoint_id, checkpoint_id);
     assert_eq!(taken_again.payload, taken.payload);
+    assert_eq!(taken.signal_id, first_signal_id);
+    assert_eq!(taken_again.signal_id, first_signal_id);
+    assert_ne!(first_signal_id, checkpoint_id);
+    // Identical retries create a new value identity: no implicit deduplication.
+    let retry_id = backend
+        .put_custom_signal(&instance_id, checkpoint_id, &custom_payload)
+        .await
+        .unwrap();
+    assert_ne!(retry_id, first_signal_id);
+    let replacement = b"replacement";
+    let replacement_id = backend
+        .put_custom_signal(&instance_id, checkpoint_id, replacement)
+        .await
+        .unwrap();
+    assert_ne!(replacement_id, retry_id);
+    for _ in 0..2 {
+        let value = backend
+            .get_custom_signal(&instance_id, checkpoint_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(value.signal_id, replacement_id);
+        assert_eq!(value.payload.as_deref(), Some(replacement.as_slice()));
+    }
+    assert!(
+        backend
+            .get_custom_signal(&instance_id, "different-address")
+            .await
+            .unwrap()
+            .is_none()
+    );
 
     // --- paired records -----------------------------------------------------
     // This harness emits none of this vocabulary's start events, so the paired
@@ -1009,7 +1040,7 @@ pub async fn run_lifecycle_command_sequence<P: Persistence>(backend: &P) {
         .await
         .unwrap();
     let cancel = backend.get_pending_signal(&id).await.unwrap().unwrap();
-    for kind in [Kind::Pause, Kind::Shutdown, Kind::Resume, Kind::Cancel] {
+    for kind in [Kind::Pause, Kind::Shutdown, Kind::Cancel] {
         backend.insert_signal(&id, kind, b"later").await.unwrap();
         assert_eq!(
             backend
@@ -1167,7 +1198,7 @@ pub async fn run_lifecycle_policy_matrix<P: Persistence>(backend: &P) {
         S::Failed,
         S::Cancelled,
     ];
-    let kinds = [K::Cancel, K::Pause, K::Resume, K::Shutdown];
+    let kinds = [K::Cancel, K::Pause, K::Shutdown];
     for status in statuses {
         for kind in kinds {
             let id = Uuid::new_v4().to_string();
@@ -1206,7 +1237,6 @@ pub async fn run_lifecycle_policy_matrix<P: Persistence>(backend: &P) {
                 match kind {
                     K::Cancel => S::Cancelled,
                     K::Pause | K::Shutdown => S::Suspended,
-                    K::Resume => status,
                 }
             };
             assert_eq!(after.status, expected_status, "{status:?} + {kind:?}");
@@ -1225,6 +1255,14 @@ pub async fn run_lifecycle_policy_matrix<P: Persistence>(backend: &P) {
             assert_eq!(after.exit_code, before.exit_code);
             assert_eq!(after.checkpoint_id, before.checkpoint_id);
             assert_eq!(after.sleep_until.is_some(), !rejects && kind == K::Shutdown);
+            assert_eq!(
+                after.wake_reason,
+                if !rejects && kind == K::Shutdown {
+                    Some(crate::domain::WakeReason::Recovery)
+                } else {
+                    before.wake_reason
+                }
+            );
             let event_count = backend
                 .count_events(&id, &ListEventsFilter::default())
                 .await
@@ -1338,5 +1376,58 @@ pub async fn run_lifecycle_policy_matrix<P: Persistence>(backend: &P) {
                 backend.delete_instances_batch(&[id]).await.unwrap();
             }
         }
+    }
+}
+
+/// Wake causes survive claiming and re-launching, and never become guest commands.
+pub async fn run_wake_reason_sequence<P: Persistence>(backend: &P) {
+    use crate::domain::{InstanceStatus, WakeReason};
+    for reason in [
+        WakeReason::Timer,
+        WakeReason::CustomSignal,
+        WakeReason::ManualResume,
+        WakeReason::Recovery,
+    ] {
+        let id = uuid::Uuid::new_v4().to_string();
+        backend
+            .register_instance(&id, "wake-contract")
+            .await
+            .unwrap();
+        backend
+            .update_instance_status(&id, InstanceStatus::Suspended, None)
+            .await
+            .unwrap();
+        backend
+            .schedule_wake(&id, Utc::now() - Duration::seconds(1), reason)
+            .await
+            .unwrap();
+        let due = backend.get_sleeping_instances_due(1000).await.unwrap();
+        assert_eq!(
+            due.iter()
+                .find(|row| row.instance_id == id)
+                .unwrap()
+                .wake_reason,
+            Some(reason)
+        );
+        assert!(backend.claim_sleeping_instance(&id).await.unwrap());
+        backend
+            .mark_instance_running(&id, Utc::now())
+            .await
+            .unwrap();
+        let running = backend.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(running.wake_reason, Some(reason));
+        assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+        backend
+            .update_instance_status(&id, InstanceStatus::Completed, None)
+            .await
+            .unwrap();
+        backend
+            .schedule_wake(&id, Utc::now(), reason)
+            .await
+            .unwrap();
+        let ended = backend.get_instance(&id).await.unwrap().unwrap();
+        assert!(ended.sleep_until.is_none());
+        assert!(ended.wake_reason.is_none());
+        backend.delete_instances_batch(&[id]).await.unwrap();
     }
 }

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -61,6 +61,10 @@ impl Store {
         if let Some(status) = effects.status {
             instance.status = status;
         }
+        if effects.clear_result {
+            instance.output = None;
+            instance.error = None;
+        }
         if effects.finish_now {
             instance.finished_at = Some(now);
         }
@@ -82,6 +86,7 @@ impl Store {
             Change::Keep => {}
             Change::Clear => instance.sleep_until = None,
             Change::Set(WakeDeadline::Now) => instance.sleep_until = Some(now),
+            Change::Set(WakeDeadline::At(deadline)) => instance.sleep_until = Some(deadline),
         }
         if let Some(event_type) = effects.event {
             let id = self.next_id();
@@ -387,12 +392,12 @@ impl Persistence for InMemoryPersistence {
             .cloned())
     }
 
-    async fn acknowledge_signal(
+    async fn apply_lifecycle_command(
         &self,
         instance_id: &str,
         command_id: &str,
         signal_type: crate::domain::SignalType,
-    ) -> Result<bool, CoreError> {
+    ) -> Result<Decision, CoreError> {
         let mut store = self.store.lock().unwrap();
         let status = store.instance_mut(instance_id)?.status;
         let decision = lifecycle::acknowledge(
@@ -406,7 +411,20 @@ impl Persistence for InMemoryPersistence {
         if let Decision::Applied(effects) = decision {
             store.apply_transition(instance_id, effects, Utc::now())?;
         }
-        Ok(decision.accepted())
+        Ok(decision)
+    }
+
+    async fn park_instance(
+        &self,
+        instance_id: &str,
+        request: crate::lifecycle::ParkRequest,
+    ) -> Result<Decision, CoreError> {
+        let mut store = self.store.lock().unwrap();
+        let decision = lifecycle::park(store.instance_mut(instance_id)?.status, request);
+        if let Decision::Applied(effects) = decision {
+            store.apply_transition(instance_id, effects, Utc::now())?;
+        }
+        Ok(decision)
     }
 
     async fn cancel_suspended_instances(

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -88,6 +88,11 @@ impl Store {
             Change::Set(WakeDeadline::Now) => instance.sleep_until = Some(now),
             Change::Set(WakeDeadline::At(deadline)) => instance.sleep_until = Some(deadline),
         }
+        match effects.wake_reason {
+            Change::Keep => {}
+            Change::Clear => instance.wake_reason = None,
+            Change::Set(reason) => instance.wake_reason = Some(reason),
+        }
         if let Some(event_type) = effects.event {
             let id = self.next_id();
             self.events.push(EventRecord {
@@ -168,6 +173,7 @@ impl Persistence for InMemoryPersistence {
                 output: None,
                 error: None,
                 sleep_until: None,
+                wake_reason: None,
                 termination_reason: None,
                 exit_code: None,
                 recovery_attempts: 0,
@@ -468,26 +474,29 @@ impl Persistence for InMemoryPersistence {
         Ok(cancelled)
     }
 
-    async fn insert_custom_signal(
+    async fn put_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
         payload: &[u8],
-    ) -> Result<(), CoreError> {
+    ) -> Result<String, CoreError> {
         let mut store = self.store.lock().unwrap();
+        store.instance_mut(instance_id)?;
+        let signal_id = uuid::Uuid::new_v4().to_string();
         store.custom_signals.insert(
             (instance_id.to_string(), checkpoint_id.to_string()),
             CustomSignalRecord {
+                signal_id: signal_id.clone(),
                 instance_id: instance_id.to_string(),
                 checkpoint_id: checkpoint_id.to_string(),
                 payload: (!payload.is_empty()).then(|| payload.to_vec()),
                 created_at: Utc::now(),
             },
         );
-        Ok(())
+        Ok(signal_id)
     }
 
-    async fn take_pending_custom_signal(
+    async fn get_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
@@ -557,14 +566,16 @@ impl Persistence for InMemoryPersistence {
             .count() as i64)
     }
 
-    async fn set_instance_sleep(
+    async fn schedule_wake(
         &self,
         instance_id: &str,
         sleep_until: DateTime<Utc>,
+        reason: crate::domain::WakeReason,
     ) -> Result<(), CoreError> {
         let mut store = self.store.lock().unwrap();
         let instance = store.instance_mut(instance_id)?;
         instance.sleep_until = (!instance.status.is_terminal()).then_some(sleep_until);
+        instance.wake_reason = (!instance.status.is_terminal()).then_some(reason);
         Ok(())
     }
 
@@ -923,6 +934,7 @@ mod tests {
         crate::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
         crate::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
         crate::persistence::conformance::run_lifecycle_policy_matrix(&backend).await;
+        crate::persistence::conformance::run_wake_reason_sequence(&backend).await;
     }
 
     fn foreign_vocabulary() -> EventVocabulary {

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -13,6 +13,9 @@
 //! guard operations atomic.
 
 use crate::domain::InstanceStatus as CoreInstanceStatus;
+use crate::lifecycle::{
+    self, Change, Decision, Receipt, SuspensionReason, Transition, WakeDeadline,
+};
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -46,6 +49,59 @@ impl Store {
     fn next_id(&mut self) -> i64 {
         self.next_id += 1;
         self.next_id
+    }
+
+    fn apply_transition(
+        &mut self,
+        instance_id: &str,
+        effects: Transition,
+        now: DateTime<Utc>,
+    ) -> Result<(), CoreError> {
+        let instance = self.instance_mut(instance_id)?;
+        if let Some(status) = effects.status {
+            instance.status = status;
+        }
+        if effects.finish_now {
+            instance.finished_at = Some(now);
+        }
+        match effects.reason {
+            Change::Keep => {}
+            Change::Clear => instance.termination_reason = None,
+            Change::Set(reason) => {
+                instance.termination_reason = Some(
+                    match reason {
+                        SuspensionReason::Shutdown => "shutdown_requested",
+                        SuspensionReason::Sleeping => "sleeping",
+                        SuspensionReason::WaitingSignal => "waiting_signal",
+                    }
+                    .into(),
+                )
+            }
+        }
+        match effects.wake {
+            Change::Keep => {}
+            Change::Clear => instance.sleep_until = None,
+            Change::Set(WakeDeadline::Now) => instance.sleep_until = Some(now),
+        }
+        if let Some(event_type) = effects.event {
+            let id = self.next_id();
+            self.events.push(EventRecord {
+                id: Some(id),
+                instance_id: instance_id.into(),
+                event_type,
+                checkpoint_id: None,
+                payload: None,
+                created_at: now,
+                subtype: None,
+            });
+        }
+        if effects.acknowledge {
+            self.signals
+                .get_mut(instance_id)
+                .expect("policy requires a stored command")
+                .acknowledged_at = Some(now);
+        }
+        Ok(())
     }
 
     fn instance_mut(&mut self, instance_id: &str) -> Result<&mut InstanceRecord, CoreError> {
@@ -298,10 +354,9 @@ impl Persistence for InMemoryPersistence {
     ) -> Result<(), CoreError> {
         let mut store = self.store.lock().unwrap();
         store.instance_mut(instance_id)?;
-        if store.signals.get(instance_id).is_some_and(|signal| {
-            signal.acknowledged_at.is_none()
-                && signal.signal_type == crate::domain::SignalType::Cancel
-        }) {
+        if !lifecycle::may_replace_command(
+            store.signals.get(instance_id).map(SignalRecord::command),
+        ) {
             return Ok(());
         }
         store.signals.insert(
@@ -338,51 +393,20 @@ impl Persistence for InMemoryPersistence {
         command_id: &str,
         signal_type: crate::domain::SignalType,
     ) -> Result<bool, CoreError> {
-        use crate::domain::SignalType;
         let mut store = self.store.lock().unwrap();
-        let Some(signal) = store.signals.get(instance_id) else {
-            return Ok(false);
-        };
-        if signal.command_id != command_id || signal.signal_type != signal_type {
-            return Ok(false);
+        let status = store.instance_mut(instance_id)?.status;
+        let decision = lifecycle::acknowledge(
+            status,
+            store.signals.get(instance_id).map(SignalRecord::command),
+            Receipt {
+                id: command_id,
+                kind: signal_type,
+            },
+        );
+        if let Decision::Applied(effects) = decision {
+            store.apply_transition(instance_id, effects, Utc::now())?;
         }
-        if signal.acknowledged_at.is_some() {
-            return Ok(true);
-        }
-        let instance = store.instance_mut(instance_id)?;
-        if instance.status.is_terminal() && signal_type != SignalType::Cancel {
-            return Ok(false);
-        }
-        let now = Utc::now();
-        match signal_type {
-            SignalType::Cancel => {
-                instance.status = CoreInstanceStatus::Cancelled;
-                instance.finished_at = Some(now);
-                instance.sleep_until = None;
-            }
-            SignalType::Pause | SignalType::Shutdown => {
-                instance.status = CoreInstanceStatus::Suspended;
-                instance.finished_at = Some(now);
-                instance.sleep_until = (signal_type == SignalType::Shutdown).then_some(now);
-                instance.termination_reason =
-                    (signal_type == SignalType::Shutdown).then(|| "shutdown_requested".into());
-            }
-            SignalType::Resume => {}
-        }
-        if matches!(signal_type, SignalType::Pause | SignalType::Shutdown) {
-            let event_id = store.next_id();
-            store.events.push(EventRecord {
-                id: Some(event_id),
-                instance_id: instance_id.to_owned(),
-                event_type: crate::domain::EventType::Suspended,
-                checkpoint_id: None,
-                payload: None,
-                created_at: now,
-                subtype: None,
-            });
-        }
-        store.signals.get_mut(instance_id).unwrap().acknowledged_at = Some(now);
-        Ok(true)
+        Ok(decision.accepted())
     }
 
     async fn cancel_suspended_instances(
@@ -394,33 +418,34 @@ impl Persistence for InMemoryPersistence {
         let mut candidates: Vec<_> = store
             .instances
             .values()
-            .filter(|instance| {
-                instance.status == CoreInstanceStatus::Suspended
-                    && instance_id.is_none_or(|id| id == instance.instance_id)
-                    && store
+            .filter(|instance| instance_id.is_none_or(|id| id == instance.instance_id))
+            .filter_map(|instance| {
+                let Decision::Applied(effects) = lifecycle::cancel_parked(
+                    instance.status,
+                    store
                         .signals
                         .get(&instance.instance_id)
-                        .is_some_and(|signal| {
-                            signal.signal_type == crate::domain::SignalType::Cancel
-                                && signal.acknowledged_at.is_none()
-                        })
+                        .map(SignalRecord::command),
+                ) else {
+                    return None;
+                };
+                Some((
+                    instance.instance_id.clone(),
+                    instance.tenant_id.clone(),
+                    effects,
+                ))
             })
-            .map(|instance| instance.instance_id.clone())
             .collect();
-        candidates.sort();
+        candidates.sort_by(|a, b| a.0.cmp(&b.0));
         candidates.truncate(limit.max(0) as usize);
         let now = Utc::now();
         let mut cancelled = Vec::new();
-        for id in candidates {
-            let instance = store.instances.get_mut(&id).unwrap();
-            instance.status = CoreInstanceStatus::Cancelled;
-            instance.finished_at = Some(now);
-            instance.sleep_until = None;
+        for (id, tenant_id, effects) in candidates {
+            store.apply_transition(&id, effects, now)?;
             cancelled.push(crate::persistence::CancelledInstance {
-                instance_id: id.clone(),
-                tenant_id: instance.tenant_id.clone(),
+                instance_id: id,
+                tenant_id,
             });
-            store.signals.get_mut(&id).unwrap().acknowledged_at = Some(now);
         }
         Ok(cancelled)
     }

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -922,6 +922,7 @@ mod tests {
         crate::persistence::conformance::run_conformance_sequence(&backend).await;
         crate::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
         crate::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
+        crate::persistence::conformance::run_lifecycle_policy_matrix(&backend).await;
     }
 
     fn foreign_vocabulary() -> EventVocabulary {

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -49,6 +49,9 @@ pub struct InstanceRecord {
     pub error: Option<String>,
     /// When a sleeping instance should be woken.
     pub sleep_until: Option<DateTime<Utc>>,
+    /// Scheduled or most recently claimed host wake cause. Preserved across claim/retry and execution
+    /// start; lifecycle commands can clear an obsolete wake intent.
+    pub wake_reason: Option<crate::domain::WakeReason>,
     /// How/why the instance reached its terminal state.
     pub termination_reason: Option<String>,
     /// Process exit code if available.
@@ -106,7 +109,7 @@ pub struct SignalRecord {
     pub command_id: String,
     /// Instance this signal is for.
     pub instance_id: String,
-    /// Type of signal (cancel, pause, resume).
+    /// Type of signal (cancel, pause, shutdown).
     pub signal_type: SignalType,
     /// Optional signal payload data.
     pub payload: Option<Vec<u8>>,
@@ -139,6 +142,8 @@ pub struct CancelledInstance {
 /// Pending custom signal scoped to a specific checkpoint.
 #[derive(Debug, Clone)]
 pub struct CustomSignalRecord {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    pub signal_id: String,
     /// Instance this signal is for.
     pub instance_id: String,
     /// Target checkpoint/wait key.
@@ -650,14 +655,20 @@ pub trait Persistence: Send + Sync {
         limit: i64,
     ) -> Result<Vec<CancelledInstance>, CoreError>;
 
-    async fn insert_custom_signal(
+    /// Replace the retained value at an instance/checkpoint address. Last write
+    /// wins; every successful write receives a fresh signal ID, even for identical
+    /// payloads. This is neither a queue nor retry deduplication. Returns that ID.
+    async fn put_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
         payload: &[u8],
-    ) -> Result<(), CoreError>;
+    ) -> Result<String, CoreError>;
 
-    async fn take_pending_custom_signal(
+    /// Read the current retained value without consuming it. Replays see the
+    /// same identity and payload until a later write replaces it. The checkpoint
+    /// ID is an address; the returned signal ID identifies the stored value.
+    async fn get_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
@@ -754,6 +765,18 @@ pub trait Persistence: Send + Sync {
         &self,
         instance_id: &str,
         sleep_until: DateTime<Utc>,
+    ) -> Result<(), CoreError> {
+        self.schedule_wake(instance_id, sleep_until, crate::domain::WakeReason::Timer)
+            .await
+    }
+
+    /// Atomically persist a wake deadline and its host-side cause. Terminal
+    /// instances retain no scheduled wake. A wake reason is never a guest signal.
+    async fn schedule_wake(
+        &self,
+        instance_id: &str,
+        deadline: DateTime<Utc>,
+        reason: crate::domain::WakeReason,
     ) -> Result<(), CoreError>;
 
     /// Clear the sleep_until timestamp for an instance.

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -615,7 +615,29 @@ pub trait Persistence: Send + Sync {
         instance_id: &str,
         command_id: &str,
         signal_type: SignalType,
-    ) -> Result<bool, CoreError>;
+    ) -> Result<bool, CoreError> {
+        Ok(self
+            .apply_lifecycle_command(instance_id, command_id, signal_type)
+            .await?
+            .accepted())
+    }
+
+    /// Evaluate core command policy against locked state and atomically apply its
+    /// effects. Return the typed disposition, retaining idempotency information.
+    async fn apply_lifecycle_command(
+        &self,
+        instance_id: &str,
+        command_id: &str,
+        signal_type: SignalType,
+    ) -> Result<crate::lifecycle::Decision, CoreError>;
+
+    /// Evaluate the core parking guard and commit suspension metadata and its
+    /// deadline atomically. A concurrent terminal transition cannot be overwritten.
+    async fn park_instance(
+        &self,
+        instance_id: &str,
+        request: crate::lifecycle::ParkRequest,
+    ) -> Result<crate::lifecycle::Decision, CoreError>;
 
     /// Atomically cancel suspended instances with pending cancel commands, clear
     /// their wake deadlines, and acknowledge those exact commands. Returns only

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -116,6 +116,17 @@ pub struct SignalRecord {
     pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
+impl SignalRecord {
+    /// Borrow the command facts used by the pure lifecycle policy.
+    pub fn command(&self) -> crate::lifecycle::Command<'_> {
+        crate::lifecycle::Command {
+            id: &self.command_id,
+            kind: self.signal_type,
+            acknowledged: self.acknowledged_at.is_some(),
+        }
+    }
+}
+
 /// Instance whose pending cancellation was applied without a running guest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CancelledInstance {

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -894,6 +894,17 @@ pub async fn handle_resume_instance(
         };
 
     let repository = LaunchRepository::new(state.pool.clone());
+    for released in repository
+        .reconcile_released_instance(&request.instance_id)
+        .await
+        .map_err(|error| {
+            crate::error::Error::Other(format!("Failed to reconcile parked launch: {error}"))
+        })?
+    {
+        state
+            .lifecycle_observers
+            .notify_released(&released, "reconciled");
+    }
     let enqueue = EnqueueRequest::immediate(
         uuid::Uuid::new_v4().to_string(),
         request.instance_id.clone(),
@@ -904,16 +915,8 @@ pub async fn handle_resume_instance(
     );
     match repository.enqueue(enqueue).await {
         Ok(EnqueueOutcome::Enqueued(launch)) | Ok(EnqueueOutcome::Existing(launch)) => {
-            // A manual resume supersedes an old timed wake claim. The durable
-            // queue row already fences duplicate runner handoffs, so a failed
-            // clear is safe to retry and does not invalidate this acceptance.
-            if let Err(error) = state
-                .persistence
-                .clear_instance_sleep(&request.instance_id)
-                .await
-            {
-                warn!(instance_id = %request.instance_id, error = %error, "Failed to clear sleep_until after queuing manual resume");
-            }
+            // Enqueuing a new resume clears the old timer in its transaction.
+            // Clearing here could erase a timer set by a fast resumed guest.
             state.launch_notifier.notify_one();
             info!(
                 instance_id = %request.instance_id,
@@ -1401,9 +1404,10 @@ pub fn spawn_container_monitor(
                                             // instance with no checkpoint stays
                                             // suspended forever.
                                             if let Err(e) = persistence
-                                                .set_instance_sleep(
+                                                .schedule_wake(
                                                     &instance_id,
                                                     chrono::Utc::now(),
+                                                    runtara_core::domain::WakeReason::Recovery,
                                                 )
                                                 .await
                                             {
@@ -1850,14 +1854,14 @@ pub enum SendSignalOutcome {
         /// The status that refused it.
         status: String,
     },
-    /// The signal type is not one of `cancel`, `pause`, `resume`.
+    /// The signal type is not one of `cancel`, `pause`.
     UnknownSignalType {
         /// What the caller asked for.
         signal_type: String,
     },
 }
 
-/// Send a lifecycle signal (`cancel`, `pause`, `resume`) to an instance.
+/// Send a lifecycle signal (`cancel`, `pause`) to an instance.
 pub async fn handle_send_signal(
     state: &EnvironmentHandlerState,
     instance_id: &str,
@@ -1880,7 +1884,6 @@ pub async fn handle_send_signal(
     let signal_type = match signal_type {
         "cancel" => runtara_core::domain::SignalType::Cancel,
         "pause" => runtara_core::domain::SignalType::Pause,
-        "resume" => runtara_core::domain::SignalType::Resume,
         _ => {
             return Ok(SendSignalOutcome::UnknownSignalType {
                 signal_type: signal_type.to_string(),
@@ -1914,7 +1917,10 @@ pub async fn handle_send_signal(
 #[derive(Debug, PartialEq, Eq)]
 pub enum SendCustomSignalOutcome {
     /// The signal was stored, and a parked instance woken if one was waiting.
-    Delivered,
+    Delivered {
+        /// Identity of the retained value written by this request.
+        signal_id: String,
+    },
     /// No such instance.
     InstanceNotFound,
 }
@@ -1942,13 +1948,13 @@ pub async fn handle_send_custom_signal(
     }
 
     let payload = payload.map(|p| p.as_bytes().to_vec()).unwrap_or_default();
-    state
+    let signal_id = state
         .persistence
-        .insert_custom_signal(instance_id, checkpoint_id, &payload)
+        .put_custom_signal(instance_id, checkpoint_id, &payload)
         .await?;
 
     wake_suspended_on_signal(state.persistence.as_ref(), instance_id).await;
-    Ok(SendCustomSignalOutcome::Delivered)
+    Ok(SendCustomSignalOutcome::Delivered { signal_id })
 }
 
 /// On-signal waker (store-freeing Wait): a Wait compiled with the store-freeing
@@ -1974,7 +1980,11 @@ pub async fn wake_suspended_on_signal(persistence: &dyn Persistence, instance_id
                     == Some(crate::runner::embedded::WAITING_SIGNAL_TERMINATION) =>
         {
             if let Err(e) = persistence
-                .set_instance_sleep(instance_id, chrono::Utc::now())
+                .schedule_wake(
+                    instance_id,
+                    chrono::Utc::now(),
+                    runtara_core::domain::WakeReason::CustomSignal,
+                )
                 .await
             {
                 warn!(instance_id, error = %e, "Failed to wake suspended instance after custom signal");

--- a/crates/runtara-environment/src/launch_queue.rs
+++ b/crates/runtara-environment/src/launch_queue.rs
@@ -738,6 +738,18 @@ impl LaunchRepository {
                 .fetch_optional(&mut *tx)
                 .await?
             {
+                if matches!(request.kind, LaunchKind::Resume | LaunchKind::Wake) {
+                    let reason = (request.kind == LaunchKind::Resume).then_some(
+                        runtara_store_postgres::encoding::wake_reason_to_str(
+                            runtara_core::domain::WakeReason::ManualResume,
+                        ),
+                    );
+                    sqlx::query("UPDATE instances SET wake_reason = COALESCE($2, wake_reason), sleep_until = NULL WHERE instance_id = $1")
+                        .bind(&request.instance_id)
+                        .bind(reason)
+                        .execute(&mut *tx)
+                        .await?;
+                }
                 tx.commit().await?;
                 return Ok(EnqueueOutcome::Enqueued(row.try_into()?));
             }
@@ -797,6 +809,23 @@ impl LaunchRepository {
         &self,
         limit: usize,
     ) -> Result<Vec<Launch>, LaunchQueueError> {
+        self.reconcile_released(limit, None).await
+    }
+
+    /// Release a finished generation before an explicit resume can mistake it
+    /// for an already queued relaunch. Starting/queued generations stay active.
+    pub async fn reconcile_released_instance(
+        &self,
+        instance_id: &str,
+    ) -> Result<Vec<Launch>, LaunchQueueError> {
+        self.reconcile_released(1, Some(instance_id)).await
+    }
+
+    async fn reconcile_released(
+        &self,
+        limit: usize,
+        instance_id: Option<&str>,
+    ) -> Result<Vec<Launch>, LaunchQueueError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -809,7 +838,8 @@ impl LaunchRepository {
                 JOIN instances AS core_instance
                   ON core_instance.instance_id = launch.instance_id
                  AND core_instance.tenant_id = launch.tenant_id
-                WHERE launch.state IN ('queued', 'preparing', 'leased', 'starting', 'running')
+                WHERE ($2::TEXT IS NULL OR launch.instance_id = $2)
+                  AND launch.state IN ('queued', 'preparing', 'leased', 'starting', 'running')
                   AND (
                         core_instance.status IN ('completed', 'failed', 'cancelled')
                         OR (
@@ -840,6 +870,7 @@ impl LaunchRepository {
         rows_to_launches(
             sqlx::query_as::<_, LaunchRow>(&query)
                 .bind(limit)
+                .bind(instance_id)
                 .fetch_all(&self.pool)
                 .await?,
         )

--- a/crates/runtara-environment/src/recovery_marks.rs
+++ b/crates/runtara-environment/src/recovery_marks.rs
@@ -33,7 +33,7 @@ pub async fn mark_for_recovery(
         "UPDATE instances \
          SET status = 'suspended'::instance_status, \
              termination_reason = 'environment_restart'::termination_reason, \
-             sleep_until = NOW(), \
+             sleep_until = NOW(), wake_reason = 'recovery', \
              recovery_attempts = $2, \
              recovery_marker = $3 \
          WHERE instance_id = $1",
@@ -46,4 +46,29 @@ pub async fn mark_for_recovery(
     .map_err(|e| Error::Other(format!("mark_for_recovery: {e}")))?;
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "db-integration-tests"))]
+mod tests {
+    use super::*;
+    use runtara_core::{domain::WakeReason, persistence::Persistence};
+    use runtara_store_postgres::PostgresPersistence;
+
+    #[tokio::test]
+    async fn recovery_schedules_a_host_wake_without_a_guest_command() {
+        let pool = crate::test_support::pool().await;
+        let backend = PostgresPersistence::new(pool.clone());
+        let id = crate::test_support::unique_id("wake-recovery");
+        backend
+            .register_instance(&id, "wake-contract")
+            .await
+            .unwrap();
+        mark_for_recovery(&pool, &id, 1, Some("2")).await.unwrap();
+        let instance = backend.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(instance.wake_reason, Some(WakeReason::Recovery));
+        assert!(instance.sleep_until.is_some());
+        assert_eq!(instance.recovery_attempts, 1);
+        assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+        backend.delete_instances_batch(&[id]).await.unwrap();
+    }
 }

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -1261,7 +1261,7 @@ fn on_signal_checkpoint_ids(
 /// Re-reading here, after the row is visible to the waker, closes it: if the
 /// signal is already present we self-wake by stamping `sleep_until = now`, which
 /// is exactly what the waker would have done. The read is non-destructive
-/// (`take_pending_custom_signal` retains the row, despite its name), so the
+/// (`get_custom_signal` retains the row), so the
 /// replayed guest still observes the signal.
 ///
 /// Returns true when it woke the instance.
@@ -1272,12 +1272,16 @@ async fn wake_if_signal_already_arrived(
 ) -> bool {
     for checkpoint_id in on_signal_checkpoint_ids(wakes) {
         match persistence
-            .take_pending_custom_signal(instance_id, checkpoint_id)
+            .get_custom_signal(instance_id, checkpoint_id)
             .await
         {
             Ok(Some(_)) => {
                 if let Err(e) = persistence
-                    .set_instance_sleep(instance_id, chrono::Utc::now())
+                    .schedule_wake(
+                        instance_id,
+                        chrono::Utc::now(),
+                        runtara_core::domain::WakeReason::CustomSignal,
+                    )
                     .await
                 {
                     warn!(instance_id, error = %e, "Failed to self-wake after a signal raced the park");
@@ -2190,6 +2194,10 @@ mod tests {
             .expect("instance exists");
         assert_eq!(inst.status, CoreInstanceStatus::Suspended);
         assert_eq!(
+            inst.wake_reason,
+            Some(runtara_core::domain::WakeReason::Timer)
+        );
+        assert_eq!(
             inst.sleep_until.map(|dt| dt.timestamp_millis() as u64),
             Some(deadline_ms),
             "sleep_until must be the wake deadline so the wake scan selects it"
@@ -2278,7 +2286,7 @@ mod tests {
         // forever with its signal already in the table.
         let (persistence, instance_id) = running_instance().await;
         persistence
-            .insert_custom_signal(&instance_id, "raced-sig", b"{}")
+            .put_custom_signal(&instance_id, "raced-sig", b"{}")
             .await
             .expect("insert signal");
 
@@ -2298,6 +2306,10 @@ mod tests {
             .expect("get")
             .expect("instance exists");
         assert_eq!(inst.status, CoreInstanceStatus::Suspended);
+        assert_eq!(
+            inst.wake_reason,
+            Some(runtara_core::domain::WakeReason::CustomSignal)
+        );
         assert!(
             inst.sleep_until.is_some(),
             "a signal already present at park time must self-wake the instance, \
@@ -2306,7 +2318,7 @@ mod tests {
         // Non-destructive: the replayed guest still observes the signal.
         assert!(
             persistence
-                .take_pending_custom_signal(&instance_id, "raced-sig")
+                .get_custom_signal(&instance_id, "raced-sig")
                 .await
                 .expect("read signal")
                 .is_some(),

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -18,6 +18,7 @@
 //! - Memory metrics come from the store's resource limiter (exact guest
 //!   linear-memory peak); CPU metrics are absent.
 
+#[cfg(all(test, feature = "db-integration-tests"))]
 use runtara_core::domain::InstanceStatus as CoreInstanceStatus;
 
 use async_trait::async_trait;
@@ -1386,58 +1387,41 @@ async fn park_invoke_suspend(
         // Pure on-resume: already handled by the ack path.
         return;
     }
-    let wake_marker = if has_on_signal_wake(wakes) {
-        WAITING_SIGNAL_TERMINATION
-    } else {
-        "sleeping"
+    use runtara_core::lifecycle::{Decision, ParkReason, ParkRequest};
+    let deadline = deadline_ms
+        .and_then(|ms| chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64));
+    if deadline_ms.is_some() && deadline.is_none() {
+        warn!(
+            instance_id,
+            ?deadline_ms,
+            "Suspend deadline out of range; leaving sleep_until unset"
+        );
+    }
+    let request = ParkRequest {
+        reason: if has_on_signal_wake(wakes) {
+            ParkReason::Signal
+        } else {
+            ParkReason::Timer
+        },
+        deadline,
     };
-    // status first, then sleep_until: the wake scan requires BOTH
-    // `status='suspended'` AND `sleep_until IS NOT NULL`, so neither ordering
-    // exposes a half-parked instance to a premature claim.
-    match persistence
-        .complete_instance(
-            runtara_core::persistence::CompleteInstanceParams::new(
-                instance_id,
-                CoreInstanceStatus::Suspended,
-            )
-            .if_running()
-            .with_termination(wake_marker, None),
-        )
-        .await
-    {
-        Ok(true) => {}
-        Ok(false) => {
-            // Already terminal (or otherwise not running) — a malformed guest
-            // that completed/failed and THEN returned suspended, or the
-            // monitor's timeout landed first. Never overwrite, never schedule.
+    match persistence.park_instance(instance_id, request).await {
+        Ok(Decision::Applied(_)) => {}
+        Ok(_) => {
             warn!(
                 instance_id,
                 "Invoke suspend ignored: instance is not running (terminal status preserved)"
             );
             return;
         }
-        Err(e) => {
-            warn!(instance_id, error = %e, "Failed to mark instance suspended after invoke suspend");
+        Err(error) => {
+            warn!(instance_id, %error, "Failed to park instance after invoke suspend");
+            return;
         }
     }
-    if wake_if_signal_already_arrived(persistence, instance_id, wakes).await {
-        return;
-    }
-    let Some(deadline_ms) = deadline_ms else {
-        // Deadline-less on-signal: parked as suspended; the waker relaunches it.
-        return;
-    };
-    let Some(deadline) = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(deadline_ms as i64)
-    else {
-        warn!(
-            instance_id,
-            deadline_ms, "Suspend deadline out of range; leaving sleep_until unset"
-        );
-        return;
-    };
-    if let Err(e) = persistence.set_instance_sleep(instance_id, deadline).await {
-        warn!(instance_id, error = %e, "Failed to set sleep_until after invoke suspend");
-    }
+    // Close the arrival-before-park race. Later arrivals observe suspended state
+    // and schedule their own immediate wake. Never overwrite it with the timer.
+    wake_if_signal_already_arrived(persistence, instance_id, wakes).await;
 }
 
 fn invoke_metrics_of(result: &runtara_component_host::InvokeRunResult) -> ContainerMetrics {

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -687,7 +687,11 @@ impl EnvironmentRuntime {
                         if let Err(e) = self
                             .state
                             .persistence
-                            .set_instance_sleep(&info.instance_id, chrono::Utc::now())
+                            .schedule_wake(
+                                &info.instance_id,
+                                chrono::Utc::now(),
+                                runtara_core::domain::WakeReason::Recovery,
+                            )
                             .await
                         {
                             warn!(

--- a/crates/runtara-environment/src/runtime_host.rs
+++ b/crates/runtara-environment/src/runtime_host.rs
@@ -46,7 +46,7 @@ use runtara_core::instance_handlers::{
     CheckpointRequest, GetCheckpointRequest, InstanceEvent, InstanceEventType,
     InstanceHandlerState, PollSignalsRequest, RetryAttemptEvent, Signal, SignalAck, SignalType,
     SleepRequest, handle_checkpoint, handle_get_checkpoint, handle_instance_event,
-    handle_poll_signals, handle_retry_attempt, handle_signal_ack, handle_sleep,
+    handle_poll_signals, handle_retry_attempt, handle_signal_ack_decision, handle_sleep,
 };
 use runtara_core::persistence::Persistence;
 
@@ -280,7 +280,7 @@ impl PersistenceRuntimeHost {
 
     /// Apply only the command the guest actually observed.
     async fn ack_signal(&self, signal_type: SignalType, command_id: &str) -> Result<bool, String> {
-        handle_signal_ack(
+        handle_signal_ack_decision(
             &self.state,
             SignalAck {
                 command_id: command_id.to_owned(),
@@ -290,6 +290,7 @@ impl PersistenceRuntimeHost {
             },
         )
         .await
+        .map(|decision| decision.accepted())
         .map_err(Self::err)
     }
 
@@ -522,7 +523,9 @@ impl RuntimeHost for PersistenceRuntimeHost {
         if !self.ack_signal(kind, &command_id).await? {
             return Ok(false);
         }
-        if matches!(kind, SignalType::SignalCancel | SignalType::SignalShutdown) {
+        if runtara_core::lifecycle::execution_action(kind.into())
+            == runtara_core::lifecycle::ExecutionAction::Stop
+        {
             self.cancelled.store(true, Ordering::SeqCst);
         }
         Ok(true)

--- a/crates/runtara-environment/src/runtime_host.rs
+++ b/crates/runtara-environment/src/runtime_host.rs
@@ -330,7 +330,6 @@ impl PersistenceRuntimeHost {
         match value {
             0 => Some(SignalType::SignalCancel),
             1 => Some(SignalType::SignalPause),
-            2 => Some(SignalType::SignalResume),
             3 => Some(SignalType::SignalShutdown),
             _ => None,
         }
@@ -342,7 +341,6 @@ impl PersistenceRuntimeHost {
         match Self::signal_type_of(signal_type) {
             Some(SignalType::SignalCancel) => "cancel",
             Some(SignalType::SignalPause) => "pause",
-            Some(SignalType::SignalResume) => "resume",
             Some(SignalType::SignalShutdown) => "shutdown",
             // Unknown types degrade to cancel, matching handle_poll_signals'
             // own unknown-type fallback.
@@ -502,6 +500,7 @@ impl RuntimeHost for PersistenceRuntimeHost {
             custom_signal: response
                 .custom_signal
                 .map(|signal| RuntimeCustomSignalInfo {
+                    signal_id: signal.signal_id,
                     checkpoint_id: signal.checkpoint_id,
                     payload: signal.payload,
                 }),
@@ -677,7 +676,7 @@ mod tests {
     async fn custom_signal_poll_is_idempotent_rereads() {
         let (p, host, inst_id) = setup().await;
         assert_eq!(host.poll_custom_signal("sig-1".into()).await.unwrap(), None);
-        p.insert_custom_signal(inst_id.as_str(), "sig-1", b"payload-1")
+        p.put_custom_signal(inst_id.as_str(), "sig-1", b"payload-1")
             .await
             .unwrap();
         // Non-destructive read (wait-replay fix): both polls see the payload.

--- a/crates/runtara-environment/src/wake_scheduler.rs
+++ b/crates/runtara-environment/src/wake_scheduler.rs
@@ -311,7 +311,13 @@ impl WakeScheduler {
                     );
                     if let Err(e) = scheduler
                         .persistence
-                        .set_instance_sleep(&instance.instance_id, chrono::Utc::now())
+                        .schedule_wake(
+                            &instance.instance_id,
+                            chrono::Utc::now(),
+                            instance
+                                .wake_reason
+                                .unwrap_or(runtara_core::domain::WakeReason::Timer),
+                        )
                         .await
                     {
                         warn!(
@@ -387,7 +393,13 @@ impl WakeScheduler {
         if result.is_err()
             && let Err(restore_err) = self
                 .persistence
-                .set_instance_sleep(&instance.instance_id, self.retry_deadline())
+                .schedule_wake(
+                    &instance.instance_id,
+                    self.retry_deadline(),
+                    instance
+                        .wake_reason
+                        .unwrap_or(runtara_core::domain::WakeReason::Timer),
+                )
                 .await
         {
             warn!(
@@ -464,6 +476,17 @@ impl WakeScheduler {
         };
 
         let repository = LaunchRepository::new(self.pool.clone());
+        for released in repository
+            .reconcile_released_instance(&instance.instance_id)
+            .await
+            .map_err(|error| {
+                crate::error::Error::Other(format!("Failed to reconcile parked launch: {error}"))
+            })?
+        {
+            self.lifecycle_observers
+                .notify_released(&released, "reconciled");
+        }
+
         let request = EnqueueRequest::immediate(
             uuid::Uuid::new_v4().to_string(),
             instance.instance_id.clone(),
@@ -474,17 +497,8 @@ impl WakeScheduler {
         );
         match repository.enqueue(request).await {
             Ok(EnqueueOutcome::Enqueued(launch)) | Ok(EnqueueOutcome::Existing(launch)) => {
-                // The core wake claim is no longer needed once a durable launch
-                // generation owns this handoff. If this clear is interrupted,
-                // another scan only observes the same active generation and
-                // cannot start a duplicate guest.
-                if let Err(error) = self
-                    .persistence
-                    .clear_instance_sleep(&instance.instance_id)
-                    .await
-                {
-                    warn!(instance_id = %instance.instance_id, error = %error, "Failed to clear wake claim after queuing launch");
-                }
+                // A new generation clears its wake claim inside enqueue's
+                // transaction. A late clear here could erase its next timer.
                 self.launch_notifier.notify_one();
                 info!(
                     instance_id = %instance.instance_id,
@@ -500,7 +514,13 @@ impl WakeScheduler {
                 // healthy suspended instance into a failure or silently
                 // discarding its due wake.
                 self.persistence
-                    .set_instance_sleep(&instance.instance_id, self.retry_deadline())
+                    .schedule_wake(
+                        &instance.instance_id,
+                        self.retry_deadline(),
+                        instance
+                            .wake_reason
+                            .unwrap_or(runtara_core::domain::WakeReason::Timer),
+                    )
                     .await?;
                 info!(
                     instance_id = %instance.instance_id,

--- a/crates/runtara-environment/tests/handlers_test.rs
+++ b/crates/runtara-environment/tests/handlers_test.rs
@@ -500,6 +500,24 @@ async fn test_resume_instance_does_not_prepersist_placeholder_input() {
         active_launch(&pool, &instance_id).await.kind,
         LaunchKind::Resume
     );
+    let reason: Option<String> =
+        sqlx::query_scalar("SELECT wake_reason FROM instances WHERE instance_id = $1")
+            .bind(&instance_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(reason.as_deref(), Some("manual_resume"));
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pending_signals WHERE instance_id = $1 AND acknowledged_at IS NULL",
+    )
+    .bind(&instance_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        pending, 0,
+        "explicit resume must not enqueue a guest command"
+    );
 
     cleanup(&pool, Some(&instance_id), Some(&image_id)).await;
 }
@@ -1134,6 +1152,14 @@ async fn test_resume_instance_success() {
     create_test_instance(&pool, &instance_id, "test-tenant", &image_id).await;
     update_test_instance_status(&pool, &instance_id, "suspended", Some("checkpoint-123")).await;
 
+    // Core parked before the previous runner retired its launch row. Resume
+    // must not accept that running generation as its idempotent winner.
+    let old_launch = Uuid::new_v4().to_string();
+    sqlx::query("INSERT INTO instance_launches (launch_id, instance_id, tenant_id, image_id, kind, state, deadline_at) VALUES ($1, $2, 'test-tenant', $3, 'start', 'running', NOW() + INTERVAL '1 minute')")
+        .bind(&old_launch).bind(&instance_id).bind(&image_id).execute(&pool).await.unwrap();
+    sqlx::query("UPDATE instances SET sleep_until = NOW() + INTERVAL '1 hour', wake_reason = 'timer' WHERE instance_id = $1")
+        .bind(&instance_id).execute(&pool).await.unwrap();
+
     let request = ResumeInstanceRequest {
         instance_id: instance_id.clone(),
     };
@@ -1152,6 +1178,39 @@ async fn test_resume_instance_success() {
         active_launch(&pool, &instance_id).await.kind,
         LaunchKind::Resume
     );
+    let reason: Option<String> =
+        sqlx::query_scalar("SELECT wake_reason FROM instances WHERE instance_id = $1")
+            .bind(&instance_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(reason.as_deref(), Some("manual_resume"));
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pending_signals WHERE instance_id = $1 AND acknowledged_at IS NULL",
+    )
+    .bind(&instance_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        pending, 0,
+        "explicit resume must not enqueue a guest command"
+    );
+
+    let old_state: String =
+        sqlx::query_scalar("SELECT state FROM instance_launches WHERE launch_id = $1")
+            .bind(&old_launch)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(old_state, "suspended");
+    let timer_cleared: bool =
+        sqlx::query_scalar("SELECT sleep_until IS NULL FROM instances WHERE instance_id = $1")
+            .bind(&instance_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(timer_cleared);
 
     cleanup(&pool, Some(&instance_id), Some(&image_id)).await;
 }

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -376,13 +376,22 @@ impl Persistence for MockPersistence {
         Ok(None)
     }
 
-    async fn acknowledge_signal(
+    async fn apply_lifecycle_command(
         &self,
         _instance_id: &str,
         _command_id: &str,
         _signal_type: runtara_core::domain::SignalType,
-    ) -> Result<bool, CoreError> {
-        Ok(false)
+    ) -> Result<runtara_core::lifecycle::Decision, CoreError> {
+        Ok(runtara_core::lifecycle::Decision::Rejected)
+    }
+
+    async fn park_instance(
+        &self,
+        _instance_id: &str,
+        _request: runtara_core::lifecycle::ParkRequest,
+    ) -> std::result::Result<runtara_core::lifecycle::Decision, runtara_core::error::CoreError>
+    {
+        Ok(runtara_core::lifecycle::Decision::Rejected)
     }
 
     async fn cancel_suspended_instances(

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -255,6 +255,7 @@ impl MockPersistence {
             output: None,
             error: None,
             sleep_until: None,
+            wake_reason: None,
             termination_reason: None,
             exit_code: None,
             recovery_attempts: 0,
@@ -405,16 +406,16 @@ impl Persistence for MockPersistence {
         Ok(Vec::new())
     }
 
-    async fn insert_custom_signal(
+    async fn put_custom_signal(
         &self,
         _instance_id: &str,
         _checkpoint_id: &str,
         _payload: &[u8],
-    ) -> Result<(), CoreError> {
-        Ok(())
+    ) -> Result<String, CoreError> {
+        Ok("mock-custom-signal".into())
     }
 
-    async fn take_pending_custom_signal(
+    async fn get_custom_signal(
         &self,
         _instance_id: &str,
         _checkpoint_id: &str,
@@ -456,10 +457,11 @@ impl Persistence for MockPersistence {
         Ok(self.instances.lock().unwrap().len() as i64)
     }
 
-    async fn set_instance_sleep(
+    async fn schedule_wake(
         &self,
         _instance_id: &str,
         _sleep_until: DateTime<Utc>,
+        _reason: runtara_core::domain::WakeReason,
     ) -> Result<(), CoreError> {
         Ok(())
     }
@@ -1067,6 +1069,7 @@ async fn test_completed_instance_in_core_not_flagged() {
             output: None,
             error: None,
             sleep_until: None,
+            wake_reason: None,
             termination_reason: Some("completed".to_string()),
             exit_code: None,
             recovery_attempts: 0,

--- a/crates/runtara-sdk/README.md
+++ b/crates/runtara-sdk/README.md
@@ -8,7 +8,7 @@ High-level client library for building durable workflow instances that talk to `
 
 ## What it is
 
-`runtara-sdk` is the ergonomic surface a workflow/instance uses to register itself, checkpoint state, send lifecycle events (heartbeat, completed, failed, suspended), and poll for cancel/pause/resume signals. The central type is `RuntaraSdk`, built from env via `RuntaraSdk::from_env()` or programmatically via `HttpSdkConfig`; `checkpoint()` returns a `CheckpointResult` that distinguishes fresh execution from resume and carries any pending `Signal`. The `#[resilient]` proc-macro (re-exported from `runtara-sdk-macros`) wires instance code into a global SDK registry so long-running operations can be cancelled cooperatively.
+`runtara-sdk` is the ergonomic surface a workflow/instance uses to register itself, checkpoint state, send lifecycle events (heartbeat, completed, failed, suspended), and poll for cancel/pause/shutdown signals. The central type is `RuntaraSdk`, built from env via `RuntaraSdk::from_env()` or programmatically via `HttpSdkConfig`; `checkpoint()` returns a `CheckpointResult` that distinguishes fresh execution from resume and carries any pending `Signal`. The `#[resilient]` proc-macro (re-exported from `runtara-sdk-macros`) wires instance code into a global SDK registry so long-running operations can be cancelled cooperatively.
 
 ## Using it standalone
 

--- a/crates/runtara-sdk/src/backend/embedded.rs
+++ b/crates/runtara-sdk/src/backend/embedded.rs
@@ -806,13 +806,22 @@ mod tests {
             Ok(None)
         }
 
-        async fn acknowledge_signal(
+        async fn apply_lifecycle_command(
             &self,
             _instance_id: &str,
             _command_id: &str,
             _signal_type: runtara_core::domain::SignalType,
-        ) -> CoreResult<bool> {
-            Ok(false)
+        ) -> CoreResult<runtara_core::lifecycle::Decision> {
+            Ok(runtara_core::lifecycle::Decision::Rejected)
+        }
+
+        async fn park_instance(
+            &self,
+            _instance_id: &str,
+            _request: runtara_core::lifecycle::ParkRequest,
+        ) -> std::result::Result<runtara_core::lifecycle::Decision, runtara_core::error::CoreError>
+        {
+            Ok(runtara_core::lifecycle::Decision::Rejected)
         }
 
         async fn cancel_suspended_instances(

--- a/crates/runtara-sdk/src/backend/embedded.rs
+++ b/crates/runtara-sdk/src/backend/embedded.rs
@@ -75,7 +75,6 @@ impl EmbeddedBackend {
         let signal_type = match record.signal_type {
             CoreSignalType::Cancel => SignalType::Cancel,
             CoreSignalType::Pause => SignalType::Pause,
-            CoreSignalType::Resume => SignalType::Resume,
             CoreSignalType::Shutdown => SignalType::Shutdown,
         };
         Ok(Some(Signal {
@@ -426,12 +425,10 @@ impl SdkBackend for EmbeddedBackend {
         let custom = match checkpoint_id {
             Some(id) => self
                 .rt
-                .block_on(
-                    self.persistence
-                        .take_pending_custom_signal(&self.instance_id, id),
-                )
+                .block_on(self.persistence.get_custom_signal(&self.instance_id, id))
                 .map_err(|e| SdkError::Internal(e.to_string()))?
                 .map(|signal| CustomSignal {
+                    signal_id: signal.signal_id,
                     checkpoint_id: signal.checkpoint_id,
                     payload: signal.payload.unwrap_or_default(),
                 }),
@@ -444,7 +441,6 @@ impl SdkBackend for EmbeddedBackend {
         let signal_type = match signal_type {
             SignalType::Cancel => CoreSignalType::Cancel,
             SignalType::Pause => CoreSignalType::Pause,
-            SignalType::Resume => CoreSignalType::Resume,
             SignalType::Shutdown => CoreSignalType::Shutdown,
         };
         self.rt
@@ -684,6 +680,7 @@ mod tests {
                     output: inst.output.clone(),
                     error: inst.error.clone(),
                     sleep_until: inst.sleep_until,
+                    wake_reason: None,
                     termination_reason: None,
                     exit_code: None,
                     recovery_attempts: 0,
@@ -835,16 +832,16 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn insert_custom_signal(
+        async fn put_custom_signal(
             &self,
             _instance_id: &str,
             _checkpoint_id: &str,
             _payload: &[u8],
-        ) -> CoreResult<()> {
-            Ok(())
+        ) -> CoreResult<String> {
+            Ok("mock-custom-signal".into())
         }
 
-        async fn take_pending_custom_signal(
+        async fn get_custom_signal(
             &self,
             _instance_id: &str,
             _checkpoint_id: &str,
@@ -880,10 +877,11 @@ mod tests {
             Ok(0)
         }
 
-        async fn set_instance_sleep(
+        async fn schedule_wake(
             &self,
             instance_id: &str,
             sleep_until: DateTime<Utc>,
+            _reason: runtara_core::domain::WakeReason,
         ) -> CoreResult<()> {
             let mut instances = self.instances.write().await;
             if let Some(inst) = instances.get_mut(instance_id) {

--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -307,6 +307,8 @@ struct SignalResp {
 
 #[derive(Deserialize)]
 struct CustomSignalResp {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    signal_id: String,
     checkpoint_id: String,
     #[serde(default)]
     payload: Option<String>, // base64
@@ -391,21 +393,23 @@ fn parse_instance_status(s: &str) -> InstanceStatus {
     }
 }
 
-fn parse_signal_type(s: &str) -> SignalType {
-    match s {
+fn parse_signal_type(s: &str) -> Result<SignalType> {
+    Ok(match s {
         "cancel" => SignalType::Cancel,
         "pause" => SignalType::Pause,
-        "resume" => SignalType::Resume,
         "shutdown" => SignalType::Shutdown,
-        _ => SignalType::Cancel, // safe default
-    }
+        _ => {
+            return Err(SdkError::Internal(format!(
+                "Unsupported lifecycle command: {s}"
+            )));
+        }
+    })
 }
 
 fn signal_type_str(st: &SignalType) -> &'static str {
     match st {
         SignalType::Cancel => "cancel",
         SignalType::Pause => "pause",
-        SignalType::Resume => "resume",
         SignalType::Shutdown => "shutdown",
     }
 }
@@ -445,17 +449,18 @@ fn encode_b64(data: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(data)
 }
 
-fn parse_signal(resp: &SignalResp) -> Signal {
-    Signal {
+fn parse_signal(resp: &SignalResp) -> Result<Signal> {
+    Ok(Signal {
         command_id: resp.command_id.clone(),
-        signal_type: parse_signal_type(&resp.signal_type),
+        signal_type: parse_signal_type(&resp.signal_type)?,
         payload: resp.payload.as_deref().map(decode_b64).unwrap_or_default(),
         checkpoint_id: None,
-    }
+    })
 }
 
 fn parse_custom_signal(resp: &CustomSignalResp) -> CustomSignal {
     CustomSignal {
+        signal_id: resp.signal_id.clone(),
         checkpoint_id: resp.checkpoint_id.clone(),
         payload: resp.payload.as_deref().map(decode_b64).unwrap_or_default(),
     }
@@ -532,7 +537,7 @@ impl SdkBackend for HttpBackend {
         Ok(CheckpointResult {
             found: resp.found,
             state: resp.state.as_deref().map(decode_b64).unwrap_or_default(),
-            pending_signal: resp.signal.as_ref().map(parse_signal),
+            pending_signal: resp.signal.as_ref().map(parse_signal).transpose()?,
             custom_signal: resp.custom_signal.as_ref().map(parse_custom_signal),
         })
     }
@@ -712,7 +717,7 @@ impl SdkBackend for HttpBackend {
         };
 
         let resp: PollSignalsResp = self.get(&url)?;
-        let signal = resp.signal.as_ref().map(parse_signal);
+        let signal = resp.signal.as_ref().map(parse_signal).transpose()?;
         let custom = resp.custom_signal.as_ref().map(parse_custom_signal);
         Ok((signal, custom))
     }
@@ -807,6 +812,17 @@ mod config_tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn unsupported_commands_are_not_interpreted_as_cancellation() {
+        for kind in ["resume", "future-command", ""] {
+            assert!(super::parse_signal_type(kind).is_err());
+        }
+        assert_eq!(
+            super::parse_signal_type("cancel").unwrap(),
+            crate::types::SignalType::Cancel
+        );
     }
 
     #[test]

--- a/crates/runtara-sdk/src/backend/mod.rs
+++ b/crates/runtara-sdk/src/backend/mod.rs
@@ -87,7 +87,7 @@ pub trait SdkBackend: Send + Sync {
     /// Poll for pending signals (instance-wide and/or custom).
     ///
     /// If `checkpoint_id` is `Some`, polls for a custom signal scoped to that checkpoint.
-    /// If `None`, polls for instance-wide signals (cancel/pause/resume).
+    /// If `None`, polls for instance-wide signals (cancel/pause/shutdown).
     ///
     /// Returns `(instance_signal, custom_signal)`.
     fn poll_signals(

--- a/crates/runtara-sdk/src/client.rs
+++ b/crates/runtara-sdk/src/client.rs
@@ -354,37 +354,31 @@ impl RuntaraSdk {
     pub fn poll_signal_now(&mut self) -> Result<Option<Signal>> {
         self.last_signal_poll = Instant::now();
 
-        let (signal, custom) = self.backend.poll_signals(None)?;
+        let (signal, _custom) = self.backend.poll_signals(None)?;
 
         if let Some(sig) = signal {
             debug!(signal_type = ?sig.signal_type, "Signal received");
             return Ok(Some(sig));
         }
 
-        if let Some(custom) = custom {
-            let sdk_signal = Signal {
-                command_id: String::new(),
-                signal_type: SignalType::Resume, // custom signals are scoped; type unused here
-                payload: custom.payload,
-                checkpoint_id: Some(custom.checkpoint_id),
-            };
-            debug!("Custom signal received for checkpoint");
-            return Ok(Some(sdk_signal));
-        }
-
         Ok(None)
     }
 
-    /// Poll for a custom signal scoped to a specific checkpoint/signal ID.
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(instance_id = %self.backend.instance_id(), signal_id = %signal_id)))]
-    pub fn poll_custom_signal(&mut self, signal_id: &str) -> Result<Option<Vec<u8>>> {
-        let (_signal, custom) = self.backend.poll_signals(Some(signal_id))?;
+    /// Read the retained custom signal at a checkpoint address without consuming
+    /// it. The returned signal ID identifies the value, not the address.
+    pub fn get_custom_signal(
+        &mut self,
+        checkpoint_id: &str,
+    ) -> Result<Option<crate::types::CustomSignal>> {
+        let (_, custom) = self.backend.poll_signals(Some(checkpoint_id))?;
+        Ok(custom)
+    }
 
-        if let Some(custom) = custom {
-            debug!(signal_id = %signal_id, "Custom signal received");
-            return Ok(Some(custom.payload));
-        }
-        Ok(None)
+    /// Read only the payload at a checkpoint address, preserving it for replay.
+    pub fn poll_custom_signal(&mut self, checkpoint_id: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .get_custom_signal(checkpoint_id)?
+            .map(|signal| signal.payload))
     }
 
     /// Acknowledge a received signal.
@@ -426,10 +420,6 @@ impl RuntaraSdk {
                 SignalType::Cancel => return Err(SdkError::Cancelled),
                 SignalType::Pause => return Err(SdkError::Paused),
                 SignalType::Shutdown => return Err(SdkError::ShuttingDown),
-                SignalType::Resume => {
-                    // Resume is informational, cache it but don't error
-                    self.pending_signal = Some(signal);
-                }
             }
         }
         Ok(())

--- a/crates/runtara-sdk/src/lib.rs
+++ b/crates/runtara-sdk/src/lib.rs
@@ -12,7 +12,7 @@
 //! - **Checkpointing**: Save state for durability with automatic resume handling
 //! - **Durable Sleep**: Request sleep with automatic checkpoint/wake
 //! - **Lifecycle Events**: Send heartbeat, completed, failed events
-//! - **Signal Handling**: Poll and handle cancel, pause, resume signals
+//! - **Signal Handling**: Poll and handle cancel, pause, shutdown signals
 //! - **Status Queries**: Query instance status and server health
 //!
 //! # Quick Start

--- a/crates/runtara-sdk/src/types.rs
+++ b/crates/runtara-sdk/src/types.rs
@@ -28,8 +28,6 @@ pub enum SignalType {
     Cancel,
     /// Pause execution (checkpoint and wait)
     Pause,
-    /// Resume paused execution
-    Resume,
     /// Server shutdown in progress. Instance should checkpoint and exit
     /// cleanly (status=suspended), to be resumed after restart.
     Shutdown,
@@ -60,7 +58,7 @@ pub struct CheckpointResult {
     pub found: bool,
     /// Checkpoint state (existing state if found, empty if saved).
     pub state: Vec<u8>,
-    /// Pending instance-wide signal if any (cancel, pause, resume).
+    /// Pending instance-wide signal if any (cancel, pause, shutdown).
     /// Instance should handle this signal after processing the checkpoint.
     pub pending_signal: Option<Signal>,
     /// Pending checkpoint-scoped custom signal (if waiting on a specific checkpoint_id).
@@ -70,6 +68,8 @@ pub struct CheckpointResult {
 /// Custom signal targeted to a specific checkpoint/wait key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CustomSignal {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    pub signal_id: String,
     /// Target checkpoint/wait key
     pub checkpoint_id: String,
     /// Signal payload
@@ -270,7 +270,7 @@ mod tests {
     fn test_signal_clone() {
         let signal = Signal {
             command_id: "test-command".into(),
-            signal_type: SignalType::Resume,
+            signal_type: SignalType::Pause,
             payload: vec![42],
             checkpoint_id: Some("cp".to_string()),
         };
@@ -360,25 +360,6 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_result_should_not_exit_on_resume() {
-        let result = CheckpointResult {
-            found: false,
-            state: vec![],
-            pending_signal: Some(Signal {
-                command_id: "test-command".into(),
-                signal_type: SignalType::Resume,
-                payload: vec![],
-                checkpoint_id: None,
-            }),
-            custom_signal: None,
-        };
-
-        assert!(!result.should_pause());
-        assert!(!result.should_cancel());
-        assert!(!result.should_exit()); // Resume doesn't mean exit
-    }
-
-    #[test]
     fn test_checkpoint_result_no_signal() {
         let result = CheckpointResult {
             found: true,
@@ -399,6 +380,7 @@ mod tests {
             state: vec![],
             pending_signal: None,
             custom_signal: Some(CustomSignal {
+                signal_id: "test-signal-value".into(),
                 checkpoint_id: "wait-key".to_string(),
                 payload: vec![10, 20, 30],
             }),
@@ -427,6 +409,7 @@ mod tests {
                 checkpoint_id: Some("cp".to_string()),
             }),
             custom_signal: Some(CustomSignal {
+                signal_id: "test-signal-value".into(),
                 checkpoint_id: "key".to_string(),
                 payload: vec![5],
             }),
@@ -456,6 +439,7 @@ mod tests {
     #[test]
     fn test_custom_signal_creation() {
         let signal = CustomSignal {
+            signal_id: "test-signal-value".into(),
             checkpoint_id: "my-wait-key".to_string(),
             payload: vec![1, 2, 3, 4],
         };
@@ -467,6 +451,7 @@ mod tests {
     #[test]
     fn test_custom_signal_empty_payload() {
         let signal = CustomSignal {
+            signal_id: "test-signal-value".into(),
             checkpoint_id: "empty-payload".to_string(),
             payload: vec![],
         };
@@ -477,6 +462,7 @@ mod tests {
     #[test]
     fn test_custom_signal_clone_eq() {
         let signal = CustomSignal {
+            signal_id: "test-signal-value".into(),
             checkpoint_id: "test".to_string(),
             payload: vec![42],
         };

--- a/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
@@ -973,7 +973,7 @@ export async function deliverSignal(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ checkpointId: body.signalId, payload: body.payload }),
   });
 
   if (!response.ok) {

--- a/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/queries/index.ts
@@ -973,7 +973,10 @@ export async function deliverSignal(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ checkpointId: body.signalId, payload: body.payload }),
+    body: JSON.stringify({
+      checkpointId: body.signalId,
+      payload: body.payload,
+    }),
   });
 
   if (!response.ok) {

--- a/crates/runtara-server/src/api/handlers/step_events.rs
+++ b/crates/runtara-server/src/api/handlers/step_events.rs
@@ -415,7 +415,7 @@ pub async fn get_scope_ancestors(
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PendingInputResponse {
-    /// Signal ID to deliver the response to
+    /// Legacy field name: checkpoint address to deliver the response to, not a value ID
     pub signal_id: String,
     /// Tool name that requested the input
     pub tool_name: Option<String>,
@@ -752,8 +752,10 @@ pub async fn submit_workflow_action(
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitSignalRequest {
-    /// The signal ID from the pending input request or `external_input_requested` event.
-    pub signal_id: String,
+    /// Checkpoint/wait address from the pending input request or external-input event.
+    /// Legacy `signalId` and `signal_id` request fields are accepted as aliases.
+    #[serde(alias = "signalId", alias = "signal_id")]
+    pub checkpoint_id: String,
     /// The response payload to deliver to the waiting step.
     /// Should conform to the response_schema from the pending input request.
     pub payload: Value,
@@ -807,7 +809,7 @@ fn workflow_runtime_error_response(error: WorkflowRuntimeError) -> (StatusCode, 
 /// Submit a human response to a waiting AI Agent step.
 ///
 /// Delivers a custom signal to the workflow instance, resuming the AI Agent's
-/// WaitForSignal tool call. The signal_id must match the one from
+/// WaitForSignal tool call. The checkpoint address must match the wait key from
 /// the `pending-input` endpoint or the `external_input_requested` event.
 #[utoipa::path(
     post,
@@ -842,13 +844,13 @@ pub async fn submit_signal(
         );
     }
 
-    // Validate signal_id is not empty
-    if body.signal_id.is_empty() {
+    // Validate checkpoint_id is not empty
+    if body.checkpoint_id.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "success": false,
-                "message": "signal_id is required",
+                "message": "checkpointId is required",
                 "data": Value::Null
             })),
         );
@@ -886,17 +888,18 @@ pub async fn submit_signal(
 
     // Send custom signal
     match client
-        .send_custom_signal(&instance_id, &body.signal_id, Some(&payload_bytes))
+        .send_custom_signal(&instance_id, &body.checkpoint_id, Some(&payload_bytes))
         .await
     {
-        Ok(()) => (
+        Ok(signal_id) => (
             StatusCode::OK,
             Json(json!({
                 "success": true,
                 "message": "Signal delivered successfully",
                 "data": {
                     "instanceId": instance_id,
-                    "signalId": body.signal_id
+                    "signalId": signal_id,
+                    "checkpointId": body.checkpoint_id
                 }
             })),
         ),

--- a/crates/runtara-server/src/core_runtime/http_server.rs
+++ b/crates/runtara-server/src/core_runtime/http_server.rs
@@ -99,6 +99,8 @@ pub struct SignalInfo {
 /// Custom signal information
 #[derive(Debug, Serialize)]
 pub struct CustomSignalInfo {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    pub signal_id: String,
     pub checkpoint_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<String>,
@@ -166,7 +168,6 @@ fn signal_type_to_string(st: i32) -> String {
     match st {
         0 => "cancel".to_string(),   // SignalCancel
         1 => "pause".to_string(),    // SignalPause
-        2 => "resume".to_string(),   // SignalResume
         3 => "shutdown".to_string(), // SignalShutdown
         _ => format!("unknown({})", st),
     }
@@ -355,6 +356,7 @@ async fn checkpoint_handler(
             });
 
             let custom_signal = resp.custom_signal.map(|cs| CustomSignalInfo {
+                signal_id: cs.signal_id,
                 checkpoint_id: cs.checkpoint_id,
                 payload: if cs.payload.is_empty() {
                     None
@@ -402,6 +404,7 @@ async fn poll_signals_handler(
             });
 
             let custom_signal = resp.custom_signal.map(|cs| CustomSignalInfo {
+                signal_id: cs.signal_id,
                 checkpoint_id: cs.checkpoint_id,
                 payload: if cs.payload.is_empty() {
                     None
@@ -433,6 +436,7 @@ async fn poll_custom_signal_handler(
     match instance_handlers::handle_poll_signals(&state, request).await {
         Ok(resp) => {
             let custom_signal = resp.custom_signal.map(|cs| CustomSignalInfo {
+                signal_id: cs.signal_id,
                 checkpoint_id: cs.checkpoint_id,
                 payload: if cs.payload.is_empty() {
                     None
@@ -637,7 +641,6 @@ async fn signal_ack_handler(
     let signal_type = match body.signal_type.as_str() {
         "cancel" => SignalType::SignalCancel as i32,
         "pause" => SignalType::SignalPause as i32,
-        "resume" => SignalType::SignalResume as i32,
         "shutdown" => SignalType::SignalShutdown as i32,
         _ => {
             return (

--- a/crates/runtara-server/src/core_runtime/mod.rs
+++ b/crates/runtara-server/src/core_runtime/mod.rs
@@ -537,13 +537,22 @@ mod tests {
             Ok(None)
         }
 
-        async fn acknowledge_signal(
+        async fn apply_lifecycle_command(
             &self,
             _instance_id: &str,
             _command_id: &str,
             _signal_type: runtara_core::domain::SignalType,
-        ) -> Result<bool, CoreError> {
-            Ok(false)
+        ) -> Result<runtara_core::lifecycle::Decision, CoreError> {
+            Ok(runtara_core::lifecycle::Decision::Rejected)
+        }
+
+        async fn park_instance(
+            &self,
+            _instance_id: &str,
+            _request: runtara_core::lifecycle::ParkRequest,
+        ) -> std::result::Result<runtara_core::lifecycle::Decision, runtara_core::error::CoreError>
+        {
+            Ok(runtara_core::lifecycle::Decision::Rejected)
         }
 
         async fn cancel_suspended_instances(

--- a/crates/runtara-server/src/core_runtime/mod.rs
+++ b/crates/runtara-server/src/core_runtime/mod.rs
@@ -566,16 +566,16 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn insert_custom_signal(
+        async fn put_custom_signal(
             &self,
             _instance_id: &str,
             _checkpoint_id: &str,
             _payload: &[u8],
-        ) -> Result<(), CoreError> {
-            Ok(())
+        ) -> Result<String, CoreError> {
+            Ok("mock-custom-signal".into())
         }
 
-        async fn take_pending_custom_signal(
+        async fn get_custom_signal(
             &self,
             _instance_id: &str,
             _checkpoint_id: &str,
@@ -615,10 +615,11 @@ mod tests {
             Ok(0)
         }
 
-        async fn set_instance_sleep(
+        async fn schedule_wake(
             &self,
             _instance_id: &str,
             _sleep_until: DateTime<Utc>,
+            _reason: runtara_core::domain::WakeReason,
         ) -> Result<(), CoreError> {
             Ok(())
         }

--- a/crates/runtara-server/src/environment_client.rs
+++ b/crates/runtara-server/src/environment_client.rs
@@ -277,16 +277,10 @@ impl EnvironmentClient {
     ) -> Result<()> {
         info!("Sending signal to instance");
 
-        // Resume is handled via resume_instance()
-        if signal_type == SignalType::Resume {
-            return self.resume_instance(instance_id).await;
-        }
-
         let signal_str = match signal_type {
             SignalType::Cancel => "cancel",
             SignalType::Pause => "pause",
             SignalType::Shutdown => "shutdown",
-            SignalType::Resume => unreachable!(),
         };
 
         let payload_str = payload.map(|p| String::from_utf8_lossy(p).to_string());
@@ -314,13 +308,13 @@ impl EnvironmentClient {
     }
 
     /// Send a custom (workflow-defined) signal addressed to one checkpoint.
-    #[instrument(skip(self, payload), fields(instance_id = %instance_id, signal_id = %signal_id))]
+    #[instrument(skip(self, payload), fields(instance_id = %instance_id, checkpoint_id = %checkpoint_id))]
     pub async fn send_custom_signal(
         &self,
         instance_id: &str,
-        signal_id: &str,
+        checkpoint_id: &str,
         payload: Option<&[u8]>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         info!("Sending custom signal to instance");
 
         let payload_str = payload.map(|p| String::from_utf8_lossy(p).to_string());
@@ -328,12 +322,12 @@ impl EnvironmentClient {
         match handlers::handle_send_custom_signal(
             &self.state,
             instance_id,
-            signal_id,
+            checkpoint_id,
             payload_str.as_deref(),
         )
         .await?
         {
-            SendCustomSignalOutcome::Delivered => Ok(()),
+            SendCustomSignalOutcome::Delivered { signal_id } => Ok(signal_id),
             SendCustomSignalOutcome::InstanceNotFound => {
                 Err(EnvironmentError::InstanceNotFound(instance_id.to_string()))
             }

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -643,7 +643,7 @@ impl RuntimeClient {
         let sdk = &self.client;
 
         // Use resume_instance() which sends ResumeInstance request to relaunch the workflow
-        // Note: send_signal(Resume) only stores a signal which won't work since the process exited
+        // Resume is an explicit host launch operation, never a guest lifecycle command.
         sdk.resume_instance(instance_id)
             .await
             .map_err(|e| RuntimeError::SdkError(e.to_string()))?;
@@ -655,22 +655,23 @@ impl RuntimeClient {
     /// Send a custom signal to a workflow instance.
     ///
     /// Used for human-in-the-loop interactions where an AI Agent step is waiting
-    /// for external input via WaitForSignal. The signal_id must match exactly
-    /// what the workflow is polling for.
+    /// for external input via WaitForSignal. The checkpoint address must match
+    /// what the workflow polls. Returns the new retained value's signal ID.
     pub async fn send_custom_signal(
         &self,
         instance_id: &str,
-        signal_id: &str,
+        checkpoint_id: &str,
         payload: Option<&[u8]>,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<String, RuntimeError> {
         let sdk = &self.client;
 
-        sdk.send_custom_signal(instance_id, signal_id, payload)
+        let signal_id = sdk
+            .send_custom_signal(instance_id, checkpoint_id, payload)
             .await
             .map_err(|e| RuntimeError::SdkError(e.to_string()))?;
 
         info!(instance_id = %instance_id, signal_id = %signal_id, "Sent custom signal to workflow instance");
-        Ok(())
+        Ok(signal_id)
     }
 
     /// Get image info by image ID

--- a/crates/runtara-server/src/runtime_types.rs
+++ b/crates/runtara-server/src/runtime_types.rs
@@ -85,8 +85,6 @@ pub enum SignalType {
     Cancel,
     /// Pause execution (checkpoint and wait).
     Pause,
-    /// Resume paused execution.
-    Resume,
     /// Server draining: suspend at next checkpoint so the instance can be
     /// resumed after restart.
     Shutdown,
@@ -97,7 +95,6 @@ impl From<SignalType> for i32 {
         match signal {
             SignalType::Cancel => 0,
             SignalType::Pause => 1,
-            SignalType::Resume => 2,
             SignalType::Shutdown => 3,
         }
     }
@@ -1466,7 +1463,6 @@ mod tests {
     fn test_signal_type_to_i32() {
         assert_eq!(i32::from(SignalType::Cancel), 0);
         assert_eq!(i32::from(SignalType::Pause), 1);
-        assert_eq!(i32::from(SignalType::Resume), 2);
     }
 
     #[test]

--- a/crates/runtara-server/tests/core_instance_api.rs
+++ b/crates/runtara-server/tests/core_instance_api.rs
@@ -278,7 +278,6 @@ async fn typed_signals_round_trip_through_poll_checkpoint_and_ack() {
     for (signal_type, label, status) in [
         (SignalType::Cancel, "cancel", InstanceStatus::Cancelled),
         (SignalType::Pause, "pause", InstanceStatus::Suspended),
-        (SignalType::Resume, "resume", InstanceStatus::Running),
         (SignalType::Shutdown, "shutdown", InstanceStatus::Suspended),
     ] {
         let id = Uuid::new_v4().to_string();
@@ -328,4 +327,62 @@ async fn typed_signals_round_trip_through_poll_checkpoint_and_ack() {
         backend.delete_instances_batch(&[id]).await.unwrap();
     }
     runtime.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_values_keep_identity_across_poll_and_checkpoint_without_guest_resume() {
+    use runtara_core::domain::InstanceStatus;
+    let pool = test_pool().await;
+    let backend = Arc::new(PostgresPersistence::new(pool));
+    let (runtime, addr) = start(backend.clone(), 0).await;
+    let id = Uuid::new_v4().to_string();
+    assert_eq!(register(addr, &id, "custom-contract").await, 200);
+    let signal_id = backend
+        .put_custom_signal(&id, "payment", b"{}")
+        .await
+        .unwrap();
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/api/v1/instances/{id}");
+    for _ in 0..2 {
+        let poll: serde_json::Value = client
+            .get(format!("{url}/signals/payment"))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert!(poll["signal"].is_null());
+        assert_eq!(poll["custom_signal"]["signal_id"], signal_id);
+        assert_eq!(poll["custom_signal"]["checkpoint_id"], "payment");
+        assert_eq!(poll["custom_signal"]["payload"], "e30=");
+        let checkpoint: serde_json::Value = client
+            .post(format!("{url}/checkpoint"))
+            .json(&json!({"checkpoint_id": "payment", "state": "e30="}))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(checkpoint["custom_signal"], poll["custom_signal"]);
+        assert!(checkpoint["signal"].is_null());
+    }
+    let response = client
+        .post(format!("{url}/signals/ack"))
+        .json(&json!({"command_id": signal_id, "signal_type": "resume"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        InstanceStatus::Running
+    );
+    backend.delete_instances_batch(&[id]).await.unwrap();
+    runtime.shutdown().await.unwrap();
 }

--- a/crates/runtara-server/tests/runtime_types.rs
+++ b/crates/runtara-server/tests/runtime_types.rs
@@ -51,7 +51,6 @@ fn test_instance_status_is_terminal() {
 fn test_signal_type_to_i32() {
     assert_eq!(i32::from(SignalType::Cancel), 0);
     assert_eq!(i32::from(SignalType::Pause), 1);
-    assert_eq!(i32::from(SignalType::Resume), 2);
 }
 
 #[test]

--- a/crates/runtara-store-postgres/migrations/postgresql/022_retire_guest_resume.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/022_retire_guest_resume.sql
@@ -1,0 +1,4 @@
+-- Resume is a host launch operation. Retire persisted legacy commands without
+-- changing instance state. Retain the old enum label for migration compatibility.
+UPDATE pending_signals SET acknowledged_at = NOW()
+WHERE signal_type = 'resume' AND acknowledged_at IS NULL;

--- a/crates/runtara-store-postgres/migrations/postgresql/023_custom_signal_identity.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/023_custom_signal_identity.sql
@@ -1,0 +1,3 @@
+-- A checkpoint addresses a retained value; signal_id identifies that value.
+ALTER TABLE pending_checkpoint_signals
+    ADD COLUMN signal_id UUID NOT NULL DEFAULT gen_random_uuid();

--- a/crates/runtara-store-postgres/migrations/postgresql/024_wake_reasons.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/024_wake_reasons.sql
@@ -1,0 +1,7 @@
+-- Wake metadata belongs to host scheduling, separate from guest commands.
+ALTER TABLE instances ADD COLUMN wake_reason TEXT
+    CHECK (wake_reason IN ('timer', 'custom_signal', 'manual_resume', 'recovery'));
+UPDATE instances SET wake_reason = CASE
+    WHEN termination_reason IN ('shutdown_requested', 'environment_restart') THEN 'recovery'
+    ELSE 'timer' END
+WHERE sleep_until IS NOT NULL;

--- a/crates/runtara-store-postgres/src/backend.rs
+++ b/crates/runtara-store-postgres/src/backend.rs
@@ -381,41 +381,42 @@ async fn insert_signal(
 }
 
 /// Insert or update a pending custom signal scoped to a checkpoint.
-async fn insert_custom_signal(
+async fn put_custom_signal(
     pool: &PgPool,
     instance_id: &str,
     checkpoint_id: &str,
     payload: &[u8],
-) -> Result<(), CoreError> {
+) -> Result<String, CoreError> {
     let payload_opt = if payload.is_empty() {
         None
     } else {
         Some(payload)
     };
 
-    sqlx::query(
+    let signal_id = sqlx::query_scalar(
         r#"
         INSERT INTO pending_checkpoint_signals (instance_id, checkpoint_id, payload, created_at)
         VALUES ($1, $2, $3, NOW())
         ON CONFLICT (instance_id, checkpoint_id) DO UPDATE
         SET payload = EXCLUDED.payload,
-            created_at = NOW()
+            created_at = NOW(), signal_id = gen_random_uuid()
+        RETURNING signal_id::text
         "#,
     )
     .bind(instance_id)
     .bind(checkpoint_id)
     .bind(payload_opt)
-    .execute(pool)
+    .fetch_one(pool)
     .await
     .db()?;
 
-    Ok(())
+    Ok(signal_id)
 }
 
-// `get_pending_signal`, `take_pending_custom_signal`
+// `get_pending_signal`, `get_custom_signal`
 // are migrated to the shared layer:
 // see PostgresPersistence::op_get_pending_signal /
-// op_take_pending_custom_signal (crate::ops_common::ops::signals).
+// op_get_custom_signal (crate::ops_common::ops::signals).
 
 // Health, sleep, and active-count operations are migrated to the shared layer:
 // see PostgresPersistence::op_health_check, op_count_active_instances,
@@ -691,21 +692,21 @@ impl Persistence for PostgresPersistence {
         Ok(cancelled)
     }
 
-    async fn insert_custom_signal(
+    async fn put_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
         payload: &[u8],
-    ) -> Result<(), CoreError> {
-        insert_custom_signal(&self.pool, instance_id, checkpoint_id, payload).await
+    ) -> Result<String, CoreError> {
+        put_custom_signal(&self.pool, instance_id, checkpoint_id, payload).await
     }
 
-    async fn take_pending_custom_signal(
+    async fn get_custom_signal(
         &self,
         instance_id: &str,
         checkpoint_id: &str,
     ) -> Result<Option<CustomSignalRecord>, CoreError> {
-        Self::op_take_pending_custom_signal(&self.pool, instance_id, checkpoint_id).await
+        Self::op_get_custom_signal(&self.pool, instance_id, checkpoint_id).await
     }
 
     async fn save_retry_attempt(
@@ -743,12 +744,13 @@ impl Persistence for PostgresPersistence {
         Self::op_count_active_instances(&self.pool).await
     }
 
-    async fn set_instance_sleep(
+    async fn schedule_wake(
         &self,
         instance_id: &str,
-        sleep_until: DateTime<Utc>,
+        deadline: DateTime<Utc>,
+        reason: runtara_core::domain::WakeReason,
     ) -> Result<(), CoreError> {
-        Self::op_set_instance_sleep(&self.pool, instance_id, sleep_until).await
+        Self::op_set_instance_sleep(&self.pool, instance_id, deadline, reason).await
     }
 
     async fn mark_instance_running(
@@ -1578,34 +1580,28 @@ mod tests {
         let instance_id = Uuid::new_v4();
         create_test_instance(&pool, instance_id, "test-tenant").await;
 
-        insert_custom_signal(&pool, &instance_id.to_string(), "wait-1", b"custom-payload")
+        put_custom_signal(&pool, &instance_id.to_string(), "wait-1", b"custom-payload")
             .await
             .unwrap();
 
         // First read retrieves the signal.
-        let signal = PostgresPersistence::op_take_pending_custom_signal(
-            &pool,
-            &instance_id.to_string(),
-            "wait-1",
-        )
-        .await
-        .unwrap()
-        .expect("custom signal should exist");
+        let signal =
+            PostgresPersistence::op_get_custom_signal(&pool, &instance_id.to_string(), "wait-1")
+                .await
+                .unwrap()
+                .expect("custom signal should exist");
         assert_eq!(signal.checkpoint_id, "wait-1");
         assert_eq!(signal.payload.unwrap(), b"custom-payload".to_vec());
 
         // Reads are non-destructive: a second read (as happens on
         // replay-from-start) returns the same signal, not None — this is what
-        // lets a drained/resumed WaitForSignal re-read its consumed signal
+        // lets a drained/resumed WaitForSignal re-read its retained signal
         // instead of dead-hanging.
-        let signal = PostgresPersistence::op_take_pending_custom_signal(
-            &pool,
-            &instance_id.to_string(),
-            "wait-1",
-        )
-        .await
-        .unwrap()
-        .expect("custom signal should still exist (non-destructive read)");
+        let signal =
+            PostgresPersistence::op_get_custom_signal(&pool, &instance_id.to_string(), "wait-1")
+                .await
+                .unwrap()
+                .expect("custom signal should still exist (non-destructive read)");
         assert_eq!(signal.checkpoint_id, "wait-1");
         assert_eq!(signal.payload.unwrap(), b"custom-payload".to_vec());
 
@@ -2078,7 +2074,7 @@ mod tests {
     // ========================================================================
     //
     // These tests drive the `Persistence` trait rather than the `op_*` statics:
-    // `insert_signal`, `insert_custom_signal`, `update_instance_metrics` and
+    // `insert_signal`, `put_custom_signal`, `update_instance_metrics` and
     // `update_instance_stderr` were never migrated to `common/ops` and survive
     // as free functions in this module, so the trait is the only uniform entry
     // point across the whole family.
@@ -2288,15 +2284,15 @@ mod tests {
             .await
             .unwrap();
 
-        p.insert_custom_signal(&instance_id, "wait-1", b"payload-1")
+        p.put_custom_signal(&instance_id, "wait-1", b"payload-1")
             .await
             .unwrap();
-        p.insert_custom_signal(&instance_id, "wait-1", b"payload-2")
+        p.put_custom_signal(&instance_id, "wait-1", b"payload-2")
             .await
             .unwrap();
 
         let signal = p
-            .take_pending_custom_signal(&instance_id, "wait-1")
+            .get_custom_signal(&instance_id, "wait-1")
             .await
             .unwrap()
             .expect("custom signal should exist");

--- a/crates/runtara-store-postgres/src/backend.rs
+++ b/crates/runtara-store-postgres/src/backend.rs
@@ -581,12 +581,12 @@ impl Persistence for PostgresPersistence {
         Self::op_get_pending_signal(&self.pool, instance_id).await
     }
 
-    async fn acknowledge_signal(
+    async fn apply_lifecycle_command(
         &self,
         instance_id: &str,
         command_id: &str,
         signal_type: CoreSignalType,
-    ) -> Result<bool, CoreError> {
+    ) -> Result<runtara_core::lifecycle::Decision, CoreError> {
         use runtara_core::lifecycle::{self, Decision, Receipt};
         let mut tx = self.pool.begin().await.db()?;
         let status = crate::lifecycle::lock_instance(&mut tx, instance_id).await?;
@@ -610,7 +610,22 @@ impl Persistence for PostgresPersistence {
         {
             report_completion(sink.as_ref(), &self.pool, instance_id).await;
         }
-        Ok(decision.accepted())
+        Ok(decision)
+    }
+
+    async fn park_instance(
+        &self,
+        instance_id: &str,
+        request: runtara_core::lifecycle::ParkRequest,
+    ) -> Result<runtara_core::lifecycle::Decision, CoreError> {
+        let mut tx = self.pool.begin().await.db()?;
+        let status = crate::lifecycle::lock_instance(&mut tx, instance_id).await?;
+        let decision = runtara_core::lifecycle::park(status, request);
+        if let runtara_core::lifecycle::Decision::Applied(effects) = decision {
+            crate::lifecycle::apply_transition(&mut tx, &[instance_id.to_owned()], effects).await?;
+        }
+        tx.commit().await.db()?;
+        Ok(decision)
     }
 
     async fn cancel_suspended_instances(

--- a/crates/runtara-store-postgres/src/backend.rs
+++ b/crates/runtara-store-postgres/src/backend.rs
@@ -355,33 +355,28 @@ async fn insert_signal(
     signal_type: CoreSignalType,
     payload: &[u8],
 ) -> Result<(), CoreError> {
-    let payload_opt = if payload.is_empty() {
-        None
-    } else {
-        Some(payload)
-    };
-
+    let mut tx = pool.begin().await.db()?;
+    crate::lifecycle::lock_instance(&mut tx, instance_id).await?;
+    let commands = crate::lifecycle::lock_commands(&mut tx, &[instance_id.to_owned()]).await?;
+    if !runtara_core::lifecycle::may_replace_command(commands.first().map(|c| c.command())) {
+        return Ok(());
+    }
     sqlx::query(
         r#"
         INSERT INTO pending_signals (instance_id, signal_type, payload, created_at)
         VALUES ($1, $2::signal_type, $3, NOW())
         ON CONFLICT (instance_id) DO UPDATE
-        SET signal_type = EXCLUDED.signal_type,
-            payload = EXCLUDED.payload,
-            created_at = NOW(),
-            acknowledged_at = NULL,
-            command_id = gen_random_uuid()
-        WHERE pending_signals.acknowledged_at IS NOT NULL
-           OR pending_signals.signal_type <> 'cancel'
-        "#,
+        SET signal_type = EXCLUDED.signal_type, payload = EXCLUDED.payload,
+            created_at = NOW(), acknowledged_at = NULL, command_id = gen_random_uuid()
+    "#,
     )
     .bind(instance_id)
     .bind(crate::encoding::signal_type_to_str(signal_type))
-    .bind(payload_opt)
-    .execute(pool)
+    .bind((!payload.is_empty()).then_some(payload))
+    .execute(&mut *tx)
     .await
     .db()?;
-
+    tx.commit().await.db()?;
     Ok(())
 }
 
@@ -592,70 +587,30 @@ impl Persistence for PostgresPersistence {
         command_id: &str,
         signal_type: CoreSignalType,
     ) -> Result<bool, CoreError> {
-        // Lock the instance before its command. Lifecycle transitions and future
-        // parked cancellation use this ordering too.
+        use runtara_core::lifecycle::{self, Decision, Receipt};
         let mut tx = self.pool.begin().await.db()?;
-        let status: Option<String> = sqlx::query_scalar(
-            "SELECT status::text FROM instances WHERE instance_id = $1 FOR UPDATE",
-        )
-        .bind(instance_id)
-        .fetch_optional(&mut *tx)
-        .await
-        .db()?;
-        let Some(status) = status else {
-            return Err(CoreError::InstanceNotFound {
-                instance_id: instance_id.into(),
-            });
-        };
-        let command: Option<(String, String, Option<DateTime<Utc>>)> = sqlx::query_as(
-            "SELECT command_id::text, signal_type::text, acknowledged_at FROM pending_signals WHERE instance_id = $1 FOR UPDATE"
-        ).bind(instance_id).fetch_optional(&mut *tx).await.db()?;
-        let Some((stored_id, stored_type, acknowledged_at)) = command else {
-            return Ok(false);
-        };
-        if stored_id != command_id
-            || stored_type != crate::encoding::signal_type_to_str(signal_type)
-        {
-            return Ok(false);
+        let status = crate::lifecycle::lock_instance(&mut tx, instance_id).await?;
+        let ids = [instance_id.to_owned()];
+        let commands = crate::lifecycle::lock_commands(&mut tx, &ids).await?;
+        let decision = lifecycle::acknowledge(
+            status,
+            commands.first().map(|c| c.command()),
+            Receipt {
+                id: command_id,
+                kind: signal_type,
+            },
+        );
+        if let Decision::Applied(effects) = decision {
+            crate::lifecycle::apply_transition(&mut tx, &ids, effects).await?;
         }
-        if acknowledged_at.is_some() {
-            return Ok(true);
-        }
-        if is_reportable_terminal_status(&status) && signal_type != CoreSignalType::Cancel {
-            return Ok(false);
-        }
-        match signal_type {
-            CoreSignalType::Cancel => {
-                sqlx::query("UPDATE instances SET status = 'cancelled', finished_at = NOW(), sleep_until = NULL WHERE instance_id = $1")
-                    .bind(instance_id).execute(&mut *tx).await.db()?;
-            }
-            CoreSignalType::Pause | CoreSignalType::Shutdown => {
-                let shutdown = signal_type == CoreSignalType::Shutdown;
-                sqlx::query("UPDATE instances SET status = 'suspended', finished_at = NOW(), termination_reason = CASE WHEN $2 THEN 'shutdown_requested'::termination_reason ELSE NULL END, sleep_until = CASE WHEN $2 THEN NOW() ELSE NULL END WHERE instance_id = $1")
-                    .bind(instance_id).bind(shutdown).execute(&mut *tx).await.db()?;
-            }
-            CoreSignalType::Resume => {}
-        }
-        if matches!(
-            signal_type,
-            CoreSignalType::Pause | CoreSignalType::Shutdown
-        ) {
-            sqlx::query("INSERT INTO instance_events (instance_id, event_type, created_at) VALUES ($1, 'suspended', NOW())")
-                .bind(instance_id).execute(&mut *tx).await.db()?;
-        }
-        sqlx::query("UPDATE pending_signals SET acknowledged_at = NOW() WHERE instance_id = $1")
-            .bind(instance_id)
-            .execute(&mut *tx)
-            .await
-            .db()?;
         tx.commit().await.db()?;
-        if signal_type == CoreSignalType::Cancel
-            && !is_reportable_terminal_status(&status)
+        if let Decision::Applied(effects) = decision
+            && effects.report_completion
             && let Some(sink) = &self.metrics_sink
         {
             report_completion(sink.as_ref(), &self.pool, instance_id).await;
         }
-        Ok(true)
+        Ok(decision.accepted())
     }
 
     async fn cancel_suspended_instances(
@@ -663,48 +618,60 @@ impl Persistence for PostgresPersistence {
         instance_id: Option<&str>,
         limit: i64,
     ) -> Result<Vec<runtara_core::persistence::CancelledInstance>, CoreError> {
-        // Lock instances first, as in explicit acknowledgment. The command ID
-        // joins both writes so a replaced/handled receipt cannot cancel a run.
-        // One statement commits status, deadline clearing and receipt together.
-        let rows: Vec<(String, String)> = sqlx::query_as(
+        use runtara_core::lifecycle::{self, Decision};
+        let mut tx = self.pool.begin().await.db()?;
+        // Candidate predicates narrow the indexed scan; core policy is evaluated
+        // against locked instances and commands before any writes are applied.
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
             r#"
-            WITH candidates AS MATERIALIZED (
-                SELECT i.instance_id, s.command_id
-                FROM instances i JOIN pending_signals s USING (instance_id)
-                WHERE i.status = 'suspended'
-                  AND s.signal_type = 'cancel' AND s.acknowledged_at IS NULL
-                  AND ($1::text IS NULL OR i.instance_id = $1)
-                ORDER BY i.instance_id
-                LIMIT $2
-                FOR UPDATE OF i SKIP LOCKED
-            ), acknowledged AS (
-                UPDATE pending_signals s SET acknowledged_at = NOW()
-                FROM candidates c
-                WHERE s.instance_id = c.instance_id AND s.command_id = c.command_id
-                  AND s.signal_type = 'cancel' AND s.acknowledged_at IS NULL
-                RETURNING s.instance_id
-            )
-            UPDATE instances i
-            SET status = 'cancelled', finished_at = NOW(), sleep_until = NULL
-            FROM acknowledged a
-            WHERE i.instance_id = a.instance_id
-            RETURNING i.instance_id, i.tenant_id
+            SELECT i.instance_id, i.tenant_id, i.status::text
+            FROM instances i JOIN pending_signals s USING (instance_id)
+            WHERE i.status = 'suspended' AND s.signal_type = 'cancel'
+              AND s.acknowledged_at IS NULL AND ($1::text IS NULL OR i.instance_id = $1)
+            ORDER BY i.instance_id LIMIT $2 FOR UPDATE OF i SKIP LOCKED
         "#,
         )
         .bind(instance_id)
         .bind(limit.max(0))
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *tx)
         .await
         .db()?;
+        let ids: Vec<_> = rows.iter().map(|r| r.0.clone()).collect();
+        let commands = crate::lifecycle::lock_commands(&mut tx, &ids).await?;
+        let commands: std::collections::HashMap<_, _> = commands
+            .iter()
+            .map(|c| (c.instance_id.as_str(), c.command()))
+            .collect();
+        let mut groups: Vec<(runtara_core::lifecycle::Transition, Vec<String>)> = Vec::new();
         let mut cancelled = Vec::new();
-        for (instance_id, tenant_id) in rows {
-            if let Some(sink) = &self.metrics_sink {
-                report_completion(sink.as_ref(), &self.pool, &instance_id).await;
+        for (id, tenant_id, status) in rows {
+            let status = crate::encoding::status_from_str(&status).db()?;
+            if let Decision::Applied(effects) =
+                lifecycle::cancel_parked(status, commands.get(id.as_str()).copied())
+            {
+                if let Some((_, ids)) = groups.iter_mut().find(|(effect, _)| *effect == effects) {
+                    ids.push(id.clone());
+                } else {
+                    groups.push((effects, vec![id.clone()]));
+                }
+                cancelled.push(runtara_core::persistence::CancelledInstance {
+                    instance_id: id,
+                    tenant_id,
+                });
             }
-            cancelled.push(runtara_core::persistence::CancelledInstance {
-                instance_id,
-                tenant_id,
-            });
+        }
+        for (effects, ids) in &groups {
+            crate::lifecycle::apply_transition(&mut tx, ids, *effects).await?;
+        }
+        tx.commit().await.db()?;
+        for (effects, ids) in groups {
+            if effects.report_completion
+                && let Some(sink) = &self.metrics_sink
+            {
+                for id in ids {
+                    report_completion(sink.as_ref(), &self.pool, &id).await;
+                }
+            }
         }
         Ok(cancelled)
     }

--- a/crates/runtara-store-postgres/src/dialect/mod.rs
+++ b/crates/runtara-store-postgres/src/dialect/mod.rs
@@ -91,16 +91,12 @@ pub(crate) trait Dialect: Send + Sync + 'static {
 
     /// SQL for reading a pending custom signal by `(instance_id, checkpoint_id)`.
     ///
-    /// **Non-destructive**: this SELECTs the row and leaves it in place. A
-    /// replay-from-start engine treats checkpoints as a result cache, so a
-    /// guest waiting on a signal must be able to re-read the one it already
-    /// consumed when the instance is drained/restarted and replayed. A
-    /// destructive take made that wait the only non-replayable durable
-    /// operation and dead-hung post-consume resumes. Rows are reclaimed by
-    /// `ON DELETE CASCADE` when the instance is deleted.
+    /// Non-destructive: returns the current value and its signal ID until a
+    /// subsequent write replaces them. Checkpoint IDs are slot addresses.
+    /// Rows are reclaimed when their instance is deleted.
     ///
     /// Binds (in order): instance_id, checkpoint_id.
-    fn sql_take_pending_custom_signal() -> &'static str;
+    fn sql_get_custom_signal() -> &'static str;
 
     /// SQL for upserting a checkpoint row.
     ///

--- a/crates/runtara-store-postgres/src/dialect/postgres.rs
+++ b/crates/runtara-store-postgres/src/dialect/postgres.rs
@@ -77,10 +77,10 @@ impl Dialect for PostgresDialect {
         expr.to_string()
     }
 
-    fn sql_take_pending_custom_signal() -> &'static str {
+    fn sql_get_custom_signal() -> &'static str {
         // Non-destructive read: SELECT and leave the row in place so a
         // replayed WaitForSignal re-reads the same signal (see the trait doc).
-        "SELECT instance_id, checkpoint_id, payload, created_at \
+        "SELECT instance_id, signal_id::text as signal_id, checkpoint_id, payload, created_at \
          FROM pending_checkpoint_signals \
          WHERE instance_id = $1 AND checkpoint_id = $2"
     }
@@ -115,7 +115,7 @@ impl Dialect for PostgresDialect {
     fn sql_get_pending_signal() -> &'static str {
         "SELECT instance_id, command_id::text as command_id, signal_type::text as signal_type, payload, created_at, acknowledged_at \
          FROM pending_signals \
-         WHERE instance_id = $1 AND acknowledged_at IS NULL"
+         WHERE instance_id = $1 AND acknowledged_at IS NULL AND signal_type <> 'resume'"
     }
 
     fn sql_health_check() -> &'static str {

--- a/crates/runtara-store-postgres/src/encoding.rs
+++ b/crates/runtara-store-postgres/src/encoding.rs
@@ -37,7 +37,6 @@ pub fn signal_type_to_str(value: SignalType) -> &'static str {
     match value {
         SignalType::Cancel => "cancel",
         SignalType::Pause => "pause",
-        SignalType::Resume => "resume",
         SignalType::Shutdown => "shutdown",
     }
 }
@@ -47,7 +46,6 @@ pub fn signal_type_from_str(value: &str) -> Result<SignalType, sqlx::Error> {
     match value {
         "cancel" => Ok(SignalType::Cancel),
         "pause" => Ok(SignalType::Pause),
-        "resume" => Ok(SignalType::Resume),
         "shutdown" => Ok(SignalType::Shutdown),
         _ => Err(sqlx::Error::Decode(
             "unrecognized stored signal_type".into(),
@@ -82,6 +80,29 @@ pub fn event_type_from_str(value: &str) -> Result<EventType, sqlx::Error> {
     }
 }
 
+/// Encode host wake metadata independently of lifecycle command labels.
+pub fn wake_reason_to_str(value: runtara_core::domain::WakeReason) -> &'static str {
+    use runtara_core::domain::WakeReason;
+    match value {
+        WakeReason::Timer => "timer",
+        WakeReason::CustomSignal => "custom_signal",
+        WakeReason::ManualResume => "manual_resume",
+        WakeReason::Recovery => "recovery",
+    }
+}
+
+/// Decode a stored host wake reason.
+pub fn wake_reason_from_str(value: &str) -> Result<runtara_core::domain::WakeReason, sqlx::Error> {
+    use runtara_core::domain::WakeReason;
+    match value {
+        "timer" => Ok(WakeReason::Timer),
+        "custom_signal" => Ok(WakeReason::CustomSignal),
+        "manual_resume" => Ok(WakeReason::ManualResume),
+        "recovery" => Ok(WakeReason::Recovery),
+        _ => Err(sqlx::Error::Decode("unrecognized wake reason".into())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,7 +122,7 @@ mod tests {
         for invalid in ["", "unknown", "INVALID"] {
             assert!(status_from_str(invalid).is_err());
         }
-        for label in ["cancel", "pause", "resume", "shutdown"] {
+        for label in ["cancel", "pause", "shutdown"] {
             assert_eq!(
                 signal_type_to_str(signal_type_from_str(label).unwrap()),
                 label

--- a/crates/runtara-store-postgres/src/lib.rs
+++ b/crates/runtara-store-postgres/src/lib.rs
@@ -25,6 +25,7 @@ pub mod encoding;
 
 mod backend;
 mod dialect;
+mod lifecycle;
 mod ops_common;
 mod vocabulary;
 

--- a/crates/runtara-store-postgres/src/lifecycle.rs
+++ b/crates/runtara-store-postgres/src/lifecycle.rs
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Transactional encoding and application of core lifecycle decisions.
+use crate::rows::DbResult;
+use runtara_core::{
+    domain::{InstanceStatus, SignalType},
+    error::CoreError,
+    lifecycle::{Change, Command, SuspensionReason, Transition, WakeDeadline},
+};
+use sqlx::{Postgres, Transaction};
+
+pub(crate) struct LockedCommand {
+    pub instance_id: String,
+    id: String,
+    kind: SignalType,
+    acknowledged: bool,
+}
+impl LockedCommand {
+    pub fn command(&self) -> Command<'_> {
+        Command {
+            id: &self.id,
+            kind: self.kind,
+            acknowledged: self.acknowledged,
+        }
+    }
+}
+
+pub(crate) async fn lock_instance(
+    tx: &mut Transaction<'_, Postgres>,
+    id: &str,
+) -> Result<InstanceStatus, CoreError> {
+    let status: Option<String> =
+        sqlx::query_scalar("SELECT status::text FROM instances WHERE instance_id = $1 FOR UPDATE")
+            .bind(id)
+            .fetch_optional(&mut **tx)
+            .await
+            .db()?;
+    let status = status.ok_or_else(|| CoreError::InstanceNotFound {
+        instance_id: id.into(),
+    })?;
+    crate::encoding::status_from_str(&status).db()
+}
+
+pub(crate) async fn lock_commands(
+    tx: &mut Transaction<'_, Postgres>,
+    ids: &[String],
+) -> Result<Vec<LockedCommand>, CoreError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<(String, String, String, bool)> = sqlx::query_as("SELECT instance_id, command_id::text, signal_type::text, acknowledged_at IS NOT NULL FROM pending_signals WHERE instance_id = ANY($1) ORDER BY instance_id FOR UPDATE")
+        .bind(ids).fetch_all(&mut **tx).await.db()?;
+    rows.into_iter()
+        .map(|(instance_id, id, kind, acknowledged)| {
+            Ok(LockedCommand {
+                instance_id,
+                id,
+                kind: crate::encoding::signal_type_from_str(&kind).db()?,
+                acknowledged,
+            })
+        })
+        .collect()
+}
+
+fn reason_label(reason: SuspensionReason) -> &'static str {
+    match reason {
+        SuspensionReason::Shutdown => "shutdown_requested",
+        SuspensionReason::Sleeping => "sleeping",
+        SuspensionReason::WaitingSignal => "waiting_signal",
+    }
+}
+
+/// All instances and their commands must already be locked. Equal effects are
+/// applied in batches, keeping recovery independent of per-instance round trips.
+pub(crate) async fn apply_transition(
+    tx: &mut Transaction<'_, Postgres>,
+    ids: &[String],
+    effects: Transition,
+) -> Result<(), CoreError> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let reason = match effects.reason {
+        Change::Set(value) => Some(reason_label(value)),
+        _ => None,
+    };
+    let wake_now = matches!(effects.wake, Change::Set(WakeDeadline::Now));
+    sqlx::query(r#"
+        UPDATE instances SET
+            status = COALESCE($2::instance_status, status),
+            finished_at = CASE WHEN $3 THEN NOW() ELSE finished_at END,
+            termination_reason = CASE WHEN $4 THEN termination_reason ELSE $5::termination_reason END,
+            sleep_until = CASE WHEN $6 THEN sleep_until WHEN $7 THEN NOW() ELSE NULL END
+        WHERE instance_id = ANY($1)
+    "#).bind(ids).bind(effects.status.map(crate::encoding::status_to_str)).bind(effects.finish_now)
+        .bind(matches!(effects.reason, Change::Keep)).bind(reason)
+        .bind(matches!(effects.wake, Change::Keep)).bind(wake_now)
+        .execute(&mut **tx).await.db()?;
+    if let Some(event) = effects.event {
+        sqlx::query("INSERT INTO instance_events (instance_id, event_type, created_at) SELECT unnest($1::text[]), $2::instance_event_type, NOW()")
+            .bind(ids).bind(crate::encoding::event_type_to_str(event)).execute(&mut **tx).await.db()?;
+    }
+    if effects.acknowledge {
+        sqlx::query(
+            "UPDATE pending_signals SET acknowledged_at = NOW() WHERE instance_id = ANY($1)",
+        )
+        .bind(ids)
+        .execute(&mut **tx)
+        .await
+        .db()?;
+    }
+    Ok(())
+}

--- a/crates/runtara-store-postgres/src/lifecycle.rs
+++ b/crates/runtara-store-postgres/src/lifecycle.rs
@@ -48,7 +48,7 @@ pub(crate) async fn lock_commands(
     if ids.is_empty() {
         return Ok(Vec::new());
     }
-    let rows: Vec<(String, String, String, bool)> = sqlx::query_as("SELECT instance_id, command_id::text, signal_type::text, acknowledged_at IS NOT NULL FROM pending_signals WHERE instance_id = ANY($1) ORDER BY instance_id FOR UPDATE")
+    let rows: Vec<(String, String, String, bool)> = sqlx::query_as("SELECT instance_id, command_id::text, signal_type::text, acknowledged_at IS NOT NULL FROM pending_signals WHERE instance_id = ANY($1) AND signal_type <> 'resume' ORDER BY instance_id FOR UPDATE")
         .bind(ids).fetch_all(&mut **tx).await.db()?;
     rows.into_iter()
         .map(|(instance_id, id, kind, acknowledged)| {
@@ -88,6 +88,10 @@ pub(crate) async fn apply_transition(
         Change::Set(WakeDeadline::At(deadline)) => Some(deadline),
         _ => None,
     };
+    let wake_reason = match effects.wake_reason {
+        Change::Set(reason) => Some(crate::encoding::wake_reason_to_str(reason)),
+        _ => None,
+    };
     let wake_now = matches!(effects.wake, Change::Set(WakeDeadline::Now));
     sqlx::query(r#"
         UPDATE instances SET
@@ -96,11 +100,12 @@ pub(crate) async fn apply_transition(
             termination_reason = CASE WHEN $4 THEN termination_reason ELSE $5::termination_reason END,
             sleep_until = CASE WHEN $6 THEN sleep_until WHEN $7 THEN NOW() ELSE $8 END,
             output = CASE WHEN $9 THEN NULL ELSE output END,
-            error = CASE WHEN $9 THEN NULL ELSE error END
+            error = CASE WHEN $9 THEN NULL ELSE error END,
+            wake_reason = CASE WHEN $10 THEN wake_reason ELSE $11 END
         WHERE instance_id = ANY($1)
     "#).bind(ids).bind(effects.status.map(crate::encoding::status_to_str)).bind(effects.finish_now)
         .bind(matches!(effects.reason, Change::Keep)).bind(reason)
-        .bind(matches!(effects.wake, Change::Keep)).bind(wake_now).bind(wake_at).bind(effects.clear_result)
+        .bind(matches!(effects.wake, Change::Keep)).bind(wake_now).bind(wake_at).bind(effects.clear_result).bind(matches!(effects.wake_reason, Change::Keep)).bind(wake_reason)
         .execute(&mut **tx).await.db()?;
     if let Some(event) = effects.event {
         sqlx::query("INSERT INTO instance_events (instance_id, event_type, created_at) SELECT unnest($1::text[]), $2::instance_event_type, NOW()")

--- a/crates/runtara-store-postgres/src/lifecycle.rs
+++ b/crates/runtara-store-postgres/src/lifecycle.rs
@@ -84,17 +84,23 @@ pub(crate) async fn apply_transition(
         Change::Set(value) => Some(reason_label(value)),
         _ => None,
     };
+    let wake_at = match effects.wake {
+        Change::Set(WakeDeadline::At(deadline)) => Some(deadline),
+        _ => None,
+    };
     let wake_now = matches!(effects.wake, Change::Set(WakeDeadline::Now));
     sqlx::query(r#"
         UPDATE instances SET
             status = COALESCE($2::instance_status, status),
             finished_at = CASE WHEN $3 THEN NOW() ELSE finished_at END,
             termination_reason = CASE WHEN $4 THEN termination_reason ELSE $5::termination_reason END,
-            sleep_until = CASE WHEN $6 THEN sleep_until WHEN $7 THEN NOW() ELSE NULL END
+            sleep_until = CASE WHEN $6 THEN sleep_until WHEN $7 THEN NOW() ELSE $8 END,
+            output = CASE WHEN $9 THEN NULL ELSE output END,
+            error = CASE WHEN $9 THEN NULL ELSE error END
         WHERE instance_id = ANY($1)
     "#).bind(ids).bind(effects.status.map(crate::encoding::status_to_str)).bind(effects.finish_now)
         .bind(matches!(effects.reason, Change::Keep)).bind(reason)
-        .bind(matches!(effects.wake, Change::Keep)).bind(wake_now)
+        .bind(matches!(effects.wake, Change::Keep)).bind(wake_now).bind(wake_at).bind(effects.clear_result)
         .execute(&mut **tx).await.db()?;
     if let Some(event) = effects.event {
         sqlx::query("INSERT INTO instance_events (instance_id, event_type, created_at) SELECT unnest($1::text[]), $2::instance_event_type, NOW()")

--- a/crates/runtara-store-postgres/src/ops_common/ops/instances.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/instances.rs
@@ -125,7 +125,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until, \
+                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason, \
                             recovery_attempts, recovery_marker \
                      FROM instances \
                      WHERE instance_id = {p1}"
@@ -153,7 +153,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, input, output, error, sleep_until, \
+                            created_at, started_at, finished_at, input, output, error, sleep_until, wake_reason, \
                             recovery_attempts, recovery_marker \
                      FROM instances \
                      WHERE instance_id = {p1}"
@@ -464,7 +464,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until \
+                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason \
                      FROM instances \
                      WHERE ({p1} IS NULL OR tenant_id = {p1}) \
                        AND ({p2} IS NULL OR status = {p2}{status_cast}) \

--- a/crates/runtara-store-postgres/src/ops_common/ops/signals.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/signals.rs
@@ -3,9 +3,9 @@
 //! Signal-family operations.
 //!
 //! Hosts: `get_pending_signal`,
-//! `take_pending_custom_signal`.
+//! `get_custom_signal`.
 //!
-//! Not hosted here: `insert_signal` / `insert_custom_signal` stay inline
+//! Not hosted here: `insert_signal` / `put_custom_signal` stay inline
 //! in the backend file. Both map an empty `&[u8]` payload to `NULL`
 //! before binding, so "signalled, no payload" reads back as an absent
 //! payload instead of a zero-length blob every consumer would have to
@@ -15,8 +15,8 @@
 //! that has already been acknowledged is never handed out a second time
 //! and cannot re-fire a resumed instance.
 //!
-//! `take_pending_custom_signal` is a **non-destructive** read via
-//! `Dialect::sql_take_pending_custom_signal` (a plain SELECT). The row is
+//! `get_custom_signal` is a **non-destructive** read via
+//! `Dialect::sql_get_custom_signal` (a plain SELECT). The row is
 //! retained so replay-from-start re-reads the same signal — see the op's
 //! doc comment for the durability rationale.
 
@@ -56,7 +56,7 @@ macro_rules! impl_signal_ops {
             /// drain/restart replayed it. Retained rows are reclaimed by
             /// `ON DELETE CASCADE` at instance deletion. Name kept as
             /// `take_*` for call-site stability; the semantics are read-only.
-            pub(crate) async fn op_take_pending_custom_signal(
+            pub(crate) async fn op_get_custom_signal(
                 pool: &$Pool,
                 instance_id: &str,
                 checkpoint_id: &str,
@@ -65,7 +65,7 @@ macro_rules! impl_signal_ops {
                 ::runtara_core::error::CoreError,
             > {
                 use crate::dialect::Dialect;
-                let sql = <$Dialect>::sql_take_pending_custom_signal();
+                let sql = <$Dialect>::sql_get_custom_signal();
                 let record = ::sqlx::query_as::<_, crate::rows::CustomSignalRow>(sql)
                     .bind(instance_id)
                     .bind(checkpoint_id)

--- a/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
@@ -5,7 +5,7 @@
 //! The `impl_sleep_ops!` macro expands to concrete `impl $Backend { ... }`
 //! blocks with `op_set_instance_sleep`, `op_clear_instance_sleep`, and
 //! `op_get_sleeping_instances_due`. Fields modified are `sleep_until`
-//! on the `instances` table — no other state.
+//! and `wake_reason` on the `instances` table.
 //!
 //! The due-instance scan compares `sleep_until` against `Dialect::NOW`
 //! (`CURRENT_TIMESTAMP`) with both sides passed through
@@ -22,17 +22,20 @@ macro_rules! impl_sleep_ops {
                 pool: &$Pool,
                 instance_id: &str,
                 sleep_until: ::chrono::DateTime<::chrono::Utc>,
+                reason: ::runtara_core::domain::WakeReason,
             ) -> ::core::result::Result<(), ::runtara_core::error::CoreError> {
                 use crate::ops_common::error::not_found_if_empty;
                 use crate::dialect::Dialect;
                 let p1 = <$Dialect>::placeholder(1);
                 let p2 = <$Dialect>::placeholder(2);
+                let p3 = <$Dialect>::placeholder(3);
                 let sql = format!(
-                    "UPDATE instances SET sleep_until = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN NULL ELSE {p2} END WHERE instance_id = {p1}"
+                    "UPDATE instances SET sleep_until = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN NULL ELSE {p2} END, wake_reason = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN NULL ELSE {p3} END WHERE instance_id = {p1}"
                 );
                 let result = ::sqlx::query(&sql)
                     .bind(instance_id)
                     .bind(sleep_until)
+                    .bind(crate::encoding::wake_reason_to_str(reason))
                     .execute(pool)
                     .await
                     .map_err(|e| ::runtara_core::error::CoreError::PersistenceError {
@@ -125,7 +128,7 @@ macro_rules! impl_sleep_ops {
                 let sql = format!(
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, checkpoint_id, attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until \
+                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason \
                      FROM instances \
                      WHERE sleep_until IS NOT NULL \
                        AND {lhs} <= {rhs} \
@@ -193,7 +196,7 @@ macro_rules! impl_sleep_ops {
                      ) \
                      RETURNING instance_id, tenant_id, definition_version, \
                                {status_col}, {termination_col}, checkpoint_id, attempt, max_attempts, \
-                               created_at, started_at, finished_at, output, error, sleep_until"
+                               created_at, started_at, finished_at, output, error, sleep_until, wake_reason"
                 );
                 let records = ::sqlx::query_as::<_, crate::rows::InstanceRow>(&sql)
                     .bind(limit)

--- a/crates/runtara-store-postgres/src/rows.rs
+++ b/crates/runtara-store-postgres/src/rows.rs
@@ -40,6 +40,11 @@ impl<'r> FromRow<'r, PgRow> for InstanceRow {
             output: row.try_get("output")?,
             error: row.try_get("error")?,
             sleep_until: row.try_get("sleep_until")?,
+            wake_reason: row
+                .try_get::<Option<String>, _>("wake_reason")?
+                .as_deref()
+                .map(crate::encoding::wake_reason_from_str)
+                .transpose()?,
             termination_reason: row.try_get("termination_reason").unwrap_or_default(),
             exit_code: row.try_get("exit_code").unwrap_or_default(),
             recovery_attempts: row.try_get("recovery_attempts").unwrap_or_default(),
@@ -105,6 +110,7 @@ pub struct CustomSignalRow(pub CustomSignalRecord);
 impl<'r> FromRow<'r, PgRow> for CustomSignalRow {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         Ok(Self(CustomSignalRecord {
+            signal_id: row.try_get("signal_id")?,
             instance_id: row.try_get("instance_id")?,
             checkpoint_id: row.try_get("checkpoint_id")?,
             payload: row.try_get("payload")?,

--- a/crates/runtara-store-postgres/tests/conformance.rs
+++ b/crates/runtara-store-postgres/tests/conformance.rs
@@ -34,6 +34,7 @@ async fn postgres_backend_passes_conformance_sequence() {
     run_conformance_sequence(&backend).await;
     runtara_core::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
     runtara_core::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
+    runtara_core::persistence::conformance::run_lifecycle_policy_matrix(&backend).await;
 }
 
 /// Obtain a Postgres pool. Prefers `TEST_RUNTARA_DATABASE_URL` (for CI and
@@ -205,7 +206,7 @@ async fn command_ack_rolls_back_transition_when_receipt_write_fails() {
         .await
         .unwrap();
     let signal = backend.get_pending_signal(&id).await.unwrap().unwrap();
-    // Fail the second write after the status and wake deadline have been updated.
+    // Fail acknowledgment after the status, wake deadline, and event have been written.
     // The constraint is scoped to this test's UUID and removed before asserting.
     let constraint = format!("ack_failure_{}", uuid::Uuid::new_v4().simple());
     sqlx::query(&format!("ALTER TABLE pending_signals ADD CONSTRAINT {constraint} CHECK (instance_id <> '{id}' OR acknowledged_at IS NULL)"))
@@ -227,6 +228,14 @@ async fn command_ack_rolls_back_transition_when_receipt_write_fails() {
     assert!(instance.termination_reason.is_none());
     assert_eq!(
         backend
+            .count_events(&id, &Default::default())
+            .await
+            .unwrap(),
+        0,
+        "the suspension event must roll back too"
+    );
+    assert_eq!(
+        backend
             .get_pending_signal(&id)
             .await
             .unwrap()
@@ -243,7 +252,7 @@ async fn command_ack_rolls_back_transition_when_receipt_write_fails() {
 }
 
 #[tokio::test]
-async fn parked_cancellation_rolls_back_ack_when_transition_fails() {
+async fn parked_cancellation_preserves_receipt_when_transition_fails() {
     use runtara_core::{
         domain::{InstanceStatus, SignalType},
         persistence::Persistence,
@@ -297,4 +306,185 @@ async fn parked_cancellation_rolls_back_ack_when_transition_fails() {
             .len(),
         1
     );
+}
+
+#[tokio::test]
+async fn parked_batch_rolls_back_every_instance_when_one_receipt_fails() {
+    use runtara_core::{
+        domain::{InstanceStatus as S, SignalType as K},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool.clone());
+    let mut ids = Vec::new();
+    let mut receipts = Vec::new();
+    for _ in 0..3 {
+        let id = uuid::Uuid::new_v4().to_string();
+        backend
+            .register_instance(&id, "batch-rollback")
+            .await
+            .unwrap();
+        backend
+            .update_instance_status(&id, S::Suspended, None)
+            .await
+            .unwrap();
+        backend
+            .set_instance_sleep(&id, chrono::Utc::now() + chrono::Duration::hours(1))
+            .await
+            .unwrap();
+        backend.insert_signal(&id, K::Cancel, b"").await.unwrap();
+        receipts.push(
+            backend
+                .get_pending_signal(&id)
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
+        );
+        ids.push(id);
+    }
+    let constraint = format!("batch_ack_failure_{}", uuid::Uuid::new_v4().simple());
+    sqlx::query(&format!("ALTER TABLE pending_signals ADD CONSTRAINT {constraint} CHECK (instance_id <> '{}' OR acknowledged_at IS NULL)", ids[1]))
+        .execute(&pool).await.unwrap();
+    let result = backend.cancel_suspended_instances(None, 1000).await;
+    sqlx::query(&format!(
+        "ALTER TABLE pending_signals DROP CONSTRAINT {constraint}"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert!(result.is_err());
+    for (id, receipt) in ids.iter().zip(&receipts) {
+        let instance = backend.get_instance(id).await.unwrap().unwrap();
+        assert_eq!(instance.status, S::Suspended);
+        assert!(instance.sleep_until.is_some() && instance.finished_at.is_none());
+        assert_eq!(
+            backend
+                .get_pending_signal(id)
+                .await
+                .unwrap()
+                .unwrap()
+                .command_id,
+            *receipt
+        );
+    }
+    let cancelled = backend
+        .cancel_suspended_instances(None, 1000)
+        .await
+        .unwrap();
+    for id in &ids {
+        assert!(cancelled.iter().any(|c| c.instance_id == *id));
+    }
+    backend.delete_instances_batch(&ids).await.unwrap();
+}
+
+#[tokio::test]
+async fn replacement_and_acknowledgment_serialize_without_consuming_the_new_command() {
+    use runtara_core::{
+        domain::{InstanceStatus as S, SignalType as K},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool);
+    for turn in 0..18 {
+        let id = uuid::Uuid::new_v4().to_string();
+        backend
+            .register_instance(&id, "replacement-race")
+            .await
+            .unwrap();
+        backend
+            .update_instance_status(&id, S::Running, None)
+            .await
+            .unwrap();
+        backend.insert_signal(&id, K::Pause, b"old").await.unwrap();
+        let old = backend.get_pending_signal(&id).await.unwrap().unwrap();
+        let accepted = match turn {
+            0 => {
+                // Force acknowledgment-first as well as racing both paths.
+                let accepted = backend
+                    .acknowledge_signal(&id, &old.command_id, K::Pause)
+                    .await
+                    .unwrap();
+                backend.insert_signal(&id, K::Cancel, b"new").await.unwrap();
+                accepted
+            }
+            1 => {
+                backend.insert_signal(&id, K::Cancel, b"new").await.unwrap();
+                backend
+                    .acknowledge_signal(&id, &old.command_id, K::Pause)
+                    .await
+                    .unwrap()
+            }
+            _ => {
+                let (ack, replacement) = tokio::join!(
+                    backend.acknowledge_signal(&id, &old.command_id, K::Pause),
+                    backend.insert_signal(&id, K::Cancel, b"new")
+                );
+                replacement.unwrap();
+                ack.unwrap()
+            }
+        };
+        let current = backend.get_pending_signal(&id).await.unwrap().unwrap();
+        assert_ne!(current.command_id, old.command_id);
+        assert_eq!(current.signal_type, K::Cancel);
+        assert_eq!(current.payload.as_deref(), Some(b"new".as_slice()));
+        assert_eq!(
+            backend.get_instance(&id).await.unwrap().unwrap().status,
+            if accepted { S::Suspended } else { S::Running }
+        );
+        assert!(
+            !backend
+                .acknowledge_signal(&id, &old.command_id, K::Pause)
+                .await
+                .unwrap()
+        );
+        assert!(
+            backend
+                .acknowledge_signal(&id, &current.command_id, K::Cancel)
+                .await
+                .unwrap()
+        );
+        backend.delete_instances_batch(&[id]).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn parking_and_terminal_transition_cannot_revive_cancelled_execution() {
+    use runtara_core::{
+        domain::{InstanceStatus as S, SignalType as K},
+        lifecycle::{ParkReason, ParkRequest},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool);
+    for _ in 0..12 {
+        let id = uuid::Uuid::new_v4().to_string();
+        backend
+            .register_instance(&id, "park-cancel-race")
+            .await
+            .unwrap();
+        backend
+            .update_instance_status(&id, S::Running, None)
+            .await
+            .unwrap();
+        backend.insert_signal(&id, K::Cancel, b"").await.unwrap();
+        let receipt = backend.get_pending_signal(&id).await.unwrap().unwrap();
+        let (parked, cancelled) = tokio::join!(
+            backend.park_instance(
+                &id,
+                ParkRequest {
+                    reason: ParkReason::Signal,
+                    deadline: Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+                }
+            ),
+            backend.acknowledge_signal(&id, &receipt.command_id, K::Cancel)
+        );
+        parked.unwrap();
+        assert!(cancelled.unwrap());
+        let instance = backend.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(instance.status, S::Cancelled);
+        assert!(instance.sleep_until.is_none());
+        assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+        backend.delete_instances_batch(&[id]).await.unwrap();
+    }
 }

--- a/crates/runtara-store-postgres/tests/conformance.rs
+++ b/crates/runtara-store-postgres/tests/conformance.rs
@@ -35,6 +35,7 @@ async fn postgres_backend_passes_conformance_sequence() {
     runtara_core::persistence::conformance::run_lifecycle_command_sequence(&backend).await;
     runtara_core::persistence::conformance::run_parked_cancellation_sequence(&backend).await;
     runtara_core::persistence::conformance::run_lifecycle_policy_matrix(&backend).await;
+    runtara_core::persistence::conformance::run_wake_reason_sequence(&backend).await;
 }
 
 /// Obtain a Postgres pool. Prefers `TEST_RUNTARA_DATABASE_URL` (for CI and
@@ -123,12 +124,7 @@ async fn domain_values_match_the_existing_postgres_schema() {
             .unwrap();
         assert!(selected.iter().any(|instance| instance.instance_id == id));
     }
-    for signal_type in [
-        SignalType::Cancel,
-        SignalType::Pause,
-        SignalType::Resume,
-        SignalType::Shutdown,
-    ] {
+    for signal_type in [SignalType::Cancel, SignalType::Pause, SignalType::Shutdown] {
         backend
             .update_instance_status(&id, InstanceStatus::Running, None)
             .await
@@ -487,4 +483,63 @@ async fn parking_and_terminal_transition_cannot_revive_cancelled_execution() {
         assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
         backend.delete_instances_batch(&[id]).await.unwrap();
     }
+}
+
+#[tokio::test]
+async fn legacy_resume_is_retired_and_not_delivered_by_old_writers() {
+    use runtara_core::{
+        domain::{InstanceStatus, SignalType},
+        persistence::Persistence,
+    };
+    let (pool, _container) = postgres_test_pool().await;
+    let backend = PostgresPersistence::new(pool.clone());
+    let id = uuid::Uuid::new_v4().to_string();
+    backend
+        .register_instance(&id, "retired-resume")
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO pending_signals (instance_id, signal_type) VALUES ($1, 'resume')")
+        .bind(&id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql(include_str!(
+        "../migrations/postgresql/022_retire_guest_resume.sql"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    let acknowledged: bool = sqlx::query_scalar(
+        "SELECT acknowledged_at IS NOT NULL FROM pending_signals WHERE instance_id = $1",
+    )
+    .bind(&id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(acknowledged);
+    assert_eq!(
+        backend.get_instance(&id).await.unwrap().unwrap().status,
+        InstanceStatus::Pending
+    );
+    // An older producer must not resurrect the retired guest command.
+    sqlx::query("UPDATE pending_signals SET acknowledged_at = NULL WHERE instance_id = $1")
+        .bind(&id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(backend.get_pending_signal(&id).await.unwrap().is_none());
+    backend
+        .insert_signal(&id, SignalType::Pause, b"")
+        .await
+        .unwrap();
+    assert_eq!(
+        backend
+            .get_pending_signal(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .signal_type,
+        SignalType::Pause
+    );
+    backend.delete_instances_batch(&[id]).await.unwrap();
 }

--- a/crates/runtara-workflow-runtime/src/lib.rs
+++ b/crates/runtara-workflow-runtime/src/lib.rs
@@ -80,6 +80,8 @@ pub struct RuntimeSignalInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCustomSignalInfo {
+    /// Identity of this retained value, distinct from its checkpoint address.
+    pub signal_id: String,
     pub checkpoint_id: String,
     pub payload: Vec<u8>,
 }
@@ -96,7 +98,6 @@ fn signal_type_name(signal_type: SignalType) -> &'static str {
     match signal_type {
         SignalType::Cancel => "cancel",
         SignalType::Pause => "pause",
-        SignalType::Resume => "resume",
         SignalType::Shutdown => "shutdown",
     }
 }
@@ -121,6 +122,7 @@ fn runtime_signal(signal: Signal) -> RuntimeSignalInfo {
 
 fn runtime_custom_signal(signal: CustomSignal) -> RuntimeCustomSignalInfo {
     RuntimeCustomSignalInfo {
+        signal_id: signal.signal_id,
         checkpoint_id: signal.checkpoint_id,
         payload: signal.payload,
     }
@@ -277,6 +279,7 @@ mod component {
 
     fn custom_signal_info(signal: super::RuntimeCustomSignalInfo) -> CustomSignalInfo {
         CustomSignalInfo {
+            signal_id: signal.signal_id,
             checkpoint_id: signal.checkpoint_id,
             payload: signal.payload,
         }
@@ -473,7 +476,6 @@ mod tests {
     fn signal_type_names_match_runtime_abi() {
         assert_eq!(signal_type_name(SignalType::Cancel), "cancel");
         assert_eq!(signal_type_name(SignalType::Pause), "pause");
-        assert_eq!(signal_type_name(SignalType::Resume), "resume");
         assert_eq!(signal_type_name(SignalType::Shutdown), "shutdown");
     }
 
@@ -507,6 +509,7 @@ mod tests {
                 checkpoint_id: Some("step-a".to_string()),
             }),
             custom_signal: Some(CustomSignal {
+                signal_id: "test-signal-value".into(),
                 checkpoint_id: "wait-a".to_string(),
                 payload: br#"{"resume":true}"#.to_vec(),
             }),
@@ -521,6 +524,7 @@ mod tests {
         assert_eq!(signal.payload, b"pause-now");
         assert_eq!(signal.checkpoint_id.as_deref(), Some("step-a"));
         let custom = wire.custom_signal.expect("custom signal");
+        assert_eq!(custom.signal_id, "test-signal-value");
         assert_eq!(custom.checkpoint_id, "wait-a");
         assert_eq!(custom.payload, br#"{"resume":true}"#);
     }

--- a/crates/runtara-workflow-wit/README.md
+++ b/crates/runtara-workflow-wit/README.md
@@ -7,14 +7,19 @@ This crate intentionally separates workflow semantics from runtime lifecycle:
 - `runtara:workflow-stdlib/json@0.1.0` owns reusable JSON semantics such as
   manifest initialization, source construction, mappings, conditions, switch
   routing, filtering, logging payloads, structured error payloads, and grouping.
-- `runtara:workflow-runtime/runtime@0.2.0` owns SDK/runtime lifecycle calls such
+- `runtara:workflow-runtime/runtime@0.3.0` owns SDK/runtime lifecycle calls such
   as input loading, completion, failure, events, cancellation, and durable
   sleep.
 
 Both are composed statically with workflow-logic and agent components into one
 final `workflow.wasm`.
 
-The runtime 0.2.0 contract adds `command-id` to lifecycle signals and requires it
+Runtime 0.3.0 adds `signal-id` to `custom-signal-info`, separate from its
+`checkpoint-id` address. Reads are retained and writes replace the value with
+a new identity. Guest `resume` is retired; resumption belongs to the host.
+Rebuild components and recompile workflow artifacts for this ABI change.
+
+The runtime 0.2.0 contract added `command-id` to lifecycle signals and requires it
 when acknowledging a checkpoint signal. Recompile workflow artifacts and rebuild
 the shared runtime component when upgrading from 0.1.0. The instance HTTP API
 likewise requires the `command_id` returned by polling or checkpointing in

--- a/crates/runtara-workflow-wit/src/lib.rs
+++ b/crates/runtara-workflow-wit/src/lib.rs
@@ -9,10 +9,10 @@ pub const WORKFLOW_WIT_VERSION: &str = "0.1.0";
 pub const STDLIB_PACKAGE: &str = "runtara:workflow-stdlib@0.1.0";
 
 /// WIT package name for the runtime/SDK lifecycle component.
-pub const RUNTIME_PACKAGE: &str = "runtara:workflow-runtime@0.2.0";
+pub const RUNTIME_PACKAGE: &str = "runtara:workflow-runtime@0.3.0";
 
 /// Runtime interface imported by compiled workflows and implemented by the host.
-pub const RUNTIME_INTERFACE_NAME: &str = "runtara:workflow-runtime/runtime@0.2.0";
+pub const RUNTIME_INTERFACE_NAME: &str = "runtara:workflow-runtime/runtime@0.3.0";
 
 /// WIT package name for safe runtime connection resolution.
 pub const CONNECTION_RESOLVER_PACKAGE: &str = "runtara:connection-resolver@0.1.0";
@@ -38,7 +38,7 @@ pub const LIFECYCLE_INTERFACE_NAME_V1: &str = "runtara:workflow-lifecycle/lifecy
 /// WIT text for `runtara:workflow-stdlib@0.1.0`.
 pub const STDLIB_WIT: &str = include_str!("../wit/stdlib/runtara-workflow-stdlib.wit");
 
-/// WIT text for `runtara:workflow-runtime@0.2.0`.
+/// WIT text for `runtara:workflow-runtime@0.3.0`.
 pub const RUNTIME_WIT: &str = include_str!("../wit/runtime/runtara-workflow-runtime.wit");
 
 /// WIT text for `runtara:connection-resolver@0.1.0`.

--- a/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
+++ b/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
@@ -4,7 +4,7 @@
 // loading persisted input, completing/failing instances, event emission,
 // cancellation, heartbeat, and durable sleep.
 
-package runtara:workflow-runtime@0.2.0;
+package runtara:workflow-runtime@0.3.0;
 
 interface runtime {
     record signal-info {
@@ -15,6 +15,7 @@ interface runtime {
     }
 
     record custom-signal-info {
+        signal-id: string,
         checkpoint-id: string,
         payload: list<u8>,
     }

--- a/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/tests.rs
@@ -773,7 +773,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "debug-mode-enabled",
         ),
     );
@@ -789,7 +789,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "checkpoint",
         ),
         breakpoint_key_position,
@@ -807,7 +807,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "custom-event",
         ),
         breakpoint_event_position,
@@ -816,7 +816,7 @@ fn assert_direct_breakpoint_before_import(core: &[u8], module: &str, name: &str)
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "breakpoint-pause",
         ),
         custom_event_position,
@@ -1218,7 +1218,7 @@ fn direct_compile_exports_wasi_cli_run_and_imports_components() {
                     saw_runtime_import |= import
                         .name
                         .0
-                        .contains("runtara:workflow-runtime/runtime@0.2.0");
+                        .contains("runtara:workflow-runtime/runtime@0.3.0");
                 }
             }
             Payload::ComponentExportSection(reader) => {
@@ -1449,22 +1449,22 @@ fn direct_core_run_lowers_embed_workflow_breakpoint_after_child_input_mapping() 
                                 stdlib_build_source_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
                             (
@@ -4468,7 +4468,7 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
         (
             "runtime.load-input",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "load-input",
             vec![WasmType::Pointer],
         ),
@@ -4663,21 +4663,21 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
         (
             "runtime.complete",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "complete",
             vec![WasmType::Pointer, WasmType::Length, WasmType::Pointer],
         ),
         (
             "runtime.fail",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "fail",
             vec![WasmType::Pointer, WasmType::Length, WasmType::Pointer],
         ),
         (
             "runtime.custom-event",
             "runtara:workflow-runtime/runtime",
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "custom-event",
             vec![
                 WasmType::Pointer,
@@ -4770,7 +4770,7 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "init-manifest") => {
                                 init_manifest_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "load-input") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "load-input") => {
                                 load_input_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "build-source") => {
@@ -4797,13 +4797,13 @@ fn direct_core_run_lowers_finish_mapping_through_stdlib() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "error") => {
                                 error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
                             _ => {}
@@ -4961,25 +4961,25 @@ fn direct_core_run_lowers_finish_breakpoint_after_output_mapping() {
                                 stdlib_apply_mapping_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "complete") => {
                                 runtime_complete_index = Some(next_function_index)
                             }
                             _ => {}
@@ -5187,7 +5187,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "debug-mode-enabled",
         ),
     );
@@ -5203,7 +5203,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "checkpoint",
         ),
     );
@@ -5223,7 +5223,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
     // static occurrence.
     let custom_event_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.2",
+        "cm32p2|runtara:workflow-runtime/runtime@0.3",
         "custom-event",
     );
     let custom_event_position =
@@ -5232,7 +5232,7 @@ fn direct_core_run_lowers_agent_breakpoint_after_input_mapping_before_validation
         &run_calls,
         direct_core_import(
             &imports,
-            "cm32p2|runtara:workflow-runtime/runtime@0.2",
+            "cm32p2|runtara:workflow-runtime/runtime@0.3",
             "breakpoint-pause",
         ),
     );
@@ -7085,7 +7085,7 @@ fn direct_core_run_emits_step_debug_events_when_tracking_enabled() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "init-manifest") => {
                                 init_manifest_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "load-input") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "load-input") => {
                                 load_input_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "build-source") => {
@@ -7094,13 +7094,13 @@ fn direct_core_run_emits_step_debug_events_when_tracking_enabled() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "step-debug-start") => {
@@ -7781,17 +7781,17 @@ fn direct_core_run_lowers_split_retry_helpers() {
     );
     let blocking_sleep_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.2",
+        "cm32p2|runtara:workflow-runtime/runtime@0.3",
         "blocking-sleep",
     );
     let durable_sleep_checkpoint_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.2",
+        "cm32p2|runtara:workflow-runtime/runtime@0.3",
         "durable-sleep-checkpoint",
     );
     let record_retry_index = direct_core_import(
         &imports,
-        "cm32p2|runtara:workflow-runtime/runtime@0.2",
+        "cm32p2|runtara:workflow-runtime/runtime@0.3",
         "record-retry-attempt",
     );
 
@@ -8548,7 +8548,7 @@ fn direct_core_run_lowers_durable_delay_finish_through_stdlib_and_runtime() {
                                 delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "durable-sleep-checkpoint",
                             ) => durable_sleep_checkpoint_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay") => {
@@ -8689,29 +8689,29 @@ fn direct_core_run_lowers_delay_breakpoint_pause_before_sleep() {
                                 stdlib_build_source_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay-duration-ms") => {
                                 stdlib_delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "durable-sleep-checkpoint",
                             ) => runtime_durable_sleep_checkpoint_index = Some(next_function_index),
                             _ => {}
@@ -8832,10 +8832,10 @@ fn direct_core_run_lowers_non_durable_delay_finish_through_blocking_sleep() {
                                 delay_duration_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "durable-sleep-checkpoint",
                             ) => durable_sleep_checkpoint_index = Some(next_function_index),
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "blocking-sleep") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "blocking-sleep") => {
                                 blocking_sleep_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "delay") => {
@@ -9004,29 +9004,29 @@ fn direct_core_run_lowers_wait_for_signal_finish_through_runtime_polling() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "instance-id") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "instance-id") => {
                                 runtime_instance_id_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "now-ms") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "now-ms") => {
                                 runtime_now_ms_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "fail") => {
                                 runtime_fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "check-signals") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "check-signals") => {
                                 runtime_check_signals_index = Some(next_function_index)
                             }
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "poll-custom-signal",
                             ) => runtime_poll_custom_signal_index = Some(next_function_index),
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "heartbeat") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "heartbeat") => {
                                 runtime_heartbeat_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "blocking-sleep") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "blocking-sleep") => {
                                 runtime_blocking_sleep_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9153,7 +9153,7 @@ fn direct_core_run_lowers_wait_for_signal_debug_events_with_tracking() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
                                 apply_mapping_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9270,25 +9270,25 @@ fn direct_core_run_lowers_wait_for_signal_breakpoint_pause() {
                     if matches!(import.ty, TypeRef::Func(_)) {
                         match (import.module, import.name) {
                             (
-                                "cm32p2|runtara:workflow-runtime/runtime@0.2",
+                                "cm32p2|runtara:workflow-runtime/runtime@0.3",
                                 "debug-mode-enabled",
                             ) => runtime_debug_mode_enabled_index = Some(next_function_index),
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-key") => {
                                 stdlib_breakpoint_key_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "checkpoint") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "checkpoint") => {
                                 runtime_checkpoint_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "breakpoint-event") => {
                                 stdlib_breakpoint_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 runtime_custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "breakpoint-pause") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "breakpoint-pause") => {
                                 runtime_breakpoint_pause_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "instance-id") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "instance-id") => {
                                 runtime_instance_id_index = Some(next_function_index)
                             }
                             _ => {}
@@ -9527,7 +9527,7 @@ fn direct_core_run_wraps_wait_on_wait_error_before_runtime_fail() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "wait-on-wait-error") => {
                                 wait_on_wait_error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "fail") => {
                                 runtime_fail_index = Some(next_function_index)
                             }
                             _ => {}
@@ -10023,7 +10023,7 @@ fn direct_core_run_lowers_log_finish_through_stdlib_and_runtime() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "log") => {
                                 log_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "apply-mapping") => {
@@ -10172,13 +10172,13 @@ fn direct_core_run_lowers_error_through_stdlib_and_runtime() {
                             ("cm32p2|runtara:workflow-stdlib/json@0.1", "error") => {
                                 error_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "custom-event") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "custom-event") => {
                                 custom_event_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "fail") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "fail") => {
                                 fail_index = Some(next_function_index)
                             }
-                            ("cm32p2|runtara:workflow-runtime/runtime@0.2", "complete") => {
+                            ("cm32p2|runtara:workflow-runtime/runtime@0.3", "complete") => {
                                 complete_index = Some(next_function_index)
                             }
                             _ => {}
@@ -10446,7 +10446,7 @@ fn direct_compile_writes_component_scaffold_sidecars() {
     assert_eq!(world_wit, result.component_artifacts.world_wit);
     assert_eq!(wac, result.component_artifacts.wac_source);
     assert!(world_wit.contains("import runtara:workflow-stdlib/json@0.1.0;"));
-    assert!(world_wit.contains("import runtara:workflow-runtime/runtime@0.2.0;"));
+    assert!(world_wit.contains("import runtara:workflow-runtime/runtime@0.3.0;"));
     assert!(world_wit.contains("export runtara:workflow-lifecycle/lifecycle@0.2.0;"));
     assert!(wac.contains("new runtara:workflow-stdlib"));
     // HostImport default: the runtime component is neither instantiated nor

--- a/crates/runtara-workflows/src/direct_wasm/component.rs
+++ b/crates/runtara-workflows/src/direct_wasm/component.rs
@@ -445,7 +445,7 @@ mod tests {
         assert!(
             artifacts
                 .world_wit
-                .contains("import runtara:workflow-runtime/runtime@0.2.0;")
+                .contains("import runtara:workflow-runtime/runtime@0.3.0;")
         );
         // The Phase-5 default exports the invoke lifecycle; the legacy run
         // export remains reachable via the explicit CliRunHttp ABI.
@@ -509,7 +509,7 @@ package runtara:workflow@0.1.0;
 
 world workflow {
     import runtara:workflow-stdlib/json@0.1.0;
-    import runtara:workflow-runtime/runtime@0.2.0;
+    import runtara:workflow-runtime/runtime@0.3.0;
     import runtara:agent-crypto/capabilities@0.4.0;
     import runtara:agent-object-model/capabilities@0.4.0;
     export runtara:workflow-lifecycle/lifecycle@0.2.0;
@@ -658,7 +658,7 @@ world workflow {
         assert!(
             artifacts
                 .world_wit
-                .contains("import runtara:workflow-runtime/runtime@0.2.0;")
+                .contains("import runtara:workflow-runtime/runtime@0.3.0;")
         );
     }
 
@@ -700,7 +700,7 @@ world workflow {
                 },
                 DirectSharedComponentRequirement {
                     package: "runtara:workflow-runtime",
-                    package_with_version: "runtara:workflow-runtime@0.2.0",
+                    package_with_version: "runtara:workflow-runtime@0.3.0",
                     bundle_wasm_filename: "runtara_workflow_runtime.wasm",
                     bundle_meta_filename: "runtara_workflow_runtime.meta.json",
                     cas_wasm_filename: "runtara-workflow-runtime.wasm",

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -425,7 +425,7 @@ struct ServerState {
     /// Payloads served for custom-signal polls (`GET signals/{id}`), modeling
     /// the pending-signal row. Served **non-destructively** (peeked, never
     /// removed) so a replayed `WaitForSignal` re-reads the same signal — the
-    /// core `take_pending_custom_signal` is likewise a non-destructive read.
+    /// core `get_custom_signal` is likewise a non-destructive read.
     /// The first entry answers every poll; empty → no signal (the wait keeps
     /// polling), so a test that arms no signal would hang by design.
     custom_signals: Mutex<Vec<Value>>,
@@ -805,7 +805,7 @@ fn route(
                         .expect("custom_signal_polls lock") += 1;
                     let payload_b64 = base64::engine::general_purpose::STANDARD
                         .encode(serde_json::to_vec(&payload).expect("payload serializes"));
-                    serde_json::json!({"checkpoint_id": "wait", "payload": payload_b64})
+                    serde_json::json!({"signal_id": "retained-test-value", "checkpoint_id": "wait", "payload": payload_b64})
                 });
                 return (
                     200,
@@ -2121,7 +2121,7 @@ fn direct_compose_host_import_binding_surfaces_runtime_as_component_import() {
     assert!(
         host_imports
             .iter()
-            .any(|name| name == "runtara:workflow-runtime/runtime@0.2.0"),
+            .any(|name| name == "runtara:workflow-runtime/runtime@0.3.0"),
         "host-import binding must surface the runtime interface; imports: {host_imports:?}"
     );
     assert!(
@@ -6664,7 +6664,7 @@ fn direct_wasm_execute_agent_capabilities_keeps_runtime_for_durable_workflow() {
         compiled
             .component_artifacts
             .world_wit
-            .contains("import runtara:workflow-runtime/runtime@0.2.0;"),
+            .contains("import runtara:workflow-runtime/runtime@0.3.0;"),
         "durable agent must keep the runtime import:\n{}",
         compiled.component_artifacts.world_wit
     );

--- a/e2e/test_core_persistence_contract.sh
+++ b/e2e/test_core_persistence_contract.sh
@@ -50,11 +50,12 @@ assert status["status"] == "completed" and status["output"] == output
 request(path + "/checkpoint", {"checkpoint_id": "after", "state": state}, expected=409)
 print("PASS checkpoint replay, heartbeat/custom events, completion and terminal guard")
 
-for label in ["cancel", "pause", "resume", "shutdown"]:
+for label in ["cancel", "pause", "shutdown"]:
     path = instance()
     assert not request(path + "/signals/ack", {"command_id": uuid.uuid4().hex, "signal_type": label})["success"]
     assert request(path + "/status")["status"] == "running"
-print("PASS unobserved lifecycle receipts cannot change instance status")
+request(path + "/signals/ack", {"command_id": uuid.uuid4().hex, "signal_type": "resume"}, expected=400)
+print("PASS unobserved lifecycle receipts cannot change instance status; guest resume rejected")
 
 path = instance()
 request(path + "/events", {"event_type": "failed", "payload": base64.b64encode(b"expected failure").decode()})

--- a/e2e/test_signal_contract.sh
+++ b/e2e/test_signal_contract.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Verify custom values and explicit host resume against an isolated local server.
+# Requires AUTH_PROVIDER=local, built agent components, and psql on PATH.
+# SERVER_API_URL / CORE_API_URL select the server; TENANT_ID must match it.
+# TEST_RUNTIME_DATABASE is mandatory. PGHOST/PGPORT/PGUSER select its PostgreSQL.
+# Database access is read-only and verifies that cancellation starts no new launch.
+set -euo pipefail
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+server = os.environ.get("SERVER_API_URL", "http://127.0.0.1:7001").rstrip("/")
+core = os.environ.get("CORE_API_URL", "http://127.0.0.1:8003").rstrip("/")
+pg_env = os.environ.copy()
+pg_env["PGDATABASE"] = os.environ["TEST_RUNTIME_DATABASE"]
+
+def request(base, path, body=None, expected=200):
+    req = urllib.request.Request(base + path, data=None if body is None else json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    try:
+        response = urllib.request.urlopen(req, timeout=120)
+    except urllib.error.HTTPError as error:
+        response = error
+    raw = response.read().decode()
+    if expected is not None:
+        assert response.status == expected, (path, response.status, raw)
+    return response.status, json.loads(raw)
+
+def api(path, body=None):
+    _, result = request(server, "/api/runtime" + path, body)
+    assert result.get("success", True), result
+    return result.get("data", result)
+
+def instance_state(ident):
+    ident = str(uuid.UUID(ident))
+    query = f"""SELECT json_build_object(
+        'status', status, 'reason', termination_reason, 'wake', sleep_until, 'wakeReason', wake_reason,
+        'launches', (SELECT count(*) FROM instance_launches WHERE instance_id = '{ident}'),
+        'launchState', (SELECT state FROM instance_launches WHERE instance_id = '{ident}' ORDER BY created_at DESC LIMIT 1),
+        'pending', (SELECT count(*) FROM pending_signals WHERE instance_id = '{ident}' AND acknowledged_at IS NULL)
+    ) FROM instances WHERE instance_id = '{ident}'"""
+    raw = subprocess.check_output(["psql", "-X", "-A", "-t", "-c", query], env=pg_env, text=True).strip()
+    return json.loads(raw) if raw else {"status": "pending"}
+
+def await_state(ident, status, seconds=15):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        state = instance_state(ident)
+        if state["status"] == status:
+            return state
+        assert state["status"] not in ["failed", "completed"], state
+        time.sleep(0.1)
+    raise AssertionError(("state deadline", status, state))
+
+def execute(step):
+    workflow = api("/workflows/create", {"name": "park-cancel-" + uuid.uuid4().hex, "description": "Parked cancellation E2E"})["id"]
+    graph = {"name": "Park cancellation", "durable": True, "entryPoint": "park",
+             "steps": {"park": {"id": "park", **step}, "finish": {"stepType": "Finish", "id": "finish"}},
+             "executionPlan": [{"fromStep": "park", "toStep": "finish"}],
+             "variables": {}, "inputSchema": {}, "outputSchema": {}}
+    api(f"/workflows/{workflow}/update", {"executionGraph": graph})
+    versions = api(f"/workflows/{workflow}/versions")
+    version = max(v.get("version", v.get("versionNumber", 1)) for v in versions)
+    api(f"/workflows/{workflow}/versions/{version}/compile", {})
+    return api(f"/workflows/{workflow}/execute", {"inputs": {"data": {}}})["instanceId"]
+
+# Ordinary API writes: canonical address, legacy alias, no deduplication or queue.
+ident = str(uuid.uuid4())
+_, registered = request(core, f"/api/v1/instances/{ident}/register", {"tenant_id": os.environ.get("TENANT_ID", "command-e2e")})
+assert registered["success"]
+value_ids = []
+for field, payload in [("checkpointId", {"value": 1}), ("signalId", {"value": 1}), ("checkpointId", {"value": 2})]:
+    result = api(f"/signals/{ident}", {field: "payment", "payload": payload})
+    assert result["checkpointId"] == "payment", result
+    value_ids.append(result["signalId"])
+assert len(set(value_ids)) == 3
+import base64
+for _ in range(2):
+    _, poll = request(core, f"/api/v1/instances/{ident}/signals/payment")
+    assert poll.get("signal") is None
+    assert poll["custom_signal"]["signal_id"] == value_ids[-1]
+    assert json.loads(base64.b64decode(poll["custom_signal"]["payload"])) == {"value": 2}
+    _, checkpoint = request(core, f"/api/v1/instances/{ident}/checkpoint", {"checkpoint_id": "payment", "state": "e30="})
+    assert checkpoint["custom_signal"] == poll["custom_signal"]
+request(core, f"/api/v1/instances/{ident}/signals/ack", {"command_id": value_ids[-1], "signal_type": "resume"}, expected=400)
+request(core, f"/api/v1/instances/{ident}/events", {"event_type": "completed", "payload": "e30="})
+print("PASS retained values: fresh write IDs, latest value, repeated reads, address alias, guest resume rejected")
+
+ident = execute({"stepType": "WaitForSignal", "pollIntervalMs": 500})
+parked = await_state(ident, "suspended")
+assert parked["reason"] == "waiting_signal"
+# Use the exact opaque wait address emitted by the compiled workflow.
+query = f"SELECT convert_from(payload, 'UTF8') FROM instance_events WHERE instance_id = '{str(uuid.UUID(ident))}' AND subtype = 'external_input_requested' ORDER BY created_at DESC LIMIT 1"
+event = json.loads(subprocess.check_output(["psql", "-X", "-A", "-t", "-c", query], env=pg_env, text=True).strip())
+address = event["signal_id"]
+value = api(f"/signals/{ident}", {"checkpointId": address, "payload": {"approved": True}})
+assert value["signalId"] != address
+completed = await_state(ident, "completed", seconds=30)
+assert completed["wakeReason"] == "custom_signal" and completed["pending"] == 0, completed
+assert completed["launches"] == parked["launches"] + 1, (parked, completed)
+print("PASS real WaitForSignal: custom value wakes and completes, with no guest resume command")
+
+ident = execute({"stepType": "Delay", "durationMs": {"valueType": "immediate", "value": 2000}})
+completed = await_state(ident, "completed", seconds=30)
+assert completed["wakeReason"] == "timer" and completed["pending"] == 0, completed
+print("PASS real Delay: timer wake completes without a guest command")
+
+ident = execute({"stepType": "Delay", "durationMs": {"valueType": "immediate", "value": 3600000}})
+parked = await_state(ident, "suspended")
+assert parked["wakeReason"] == "timer", parked
+api(f"/workflows/instances/{ident}/resume", {})
+deadline = time.monotonic() + 30
+while time.monotonic() < deadline:
+    state = instance_state(ident)
+    if state["launches"] > parked["launches"] and state["status"] == "suspended" and state["launchState"] == "suspended":
+        break
+    time.sleep(0.1)
+else:
+    raise AssertionError(("manual resume did not relaunch", state))
+assert state["pending"] == 0, state
+# The resumed delay re-parks on its original timer. Its launch kind proves host resume.
+query = f"SELECT kind FROM instance_launches WHERE instance_id = '{str(uuid.UUID(ident))}' ORDER BY created_at DESC LIMIT 1"
+kind = subprocess.check_output(["psql", "-X", "-A", "-t", "-c", query], env=pg_env, text=True).strip()
+assert kind == "resume", kind
+api(f"/workflows/instances/{ident}/stop", {})
+await_state(ident, "cancelled")
+print("PASS explicit host resume launches a generation, without a guest command")
+print("Signal contract E2E passed")
+PY


### PR DESCRIPTION
## Description

Lifecycle transitions were spread across handlers and storage adapters, while resume was also exposed as a guest command. Core now owns pure lifecycle decisions, and PostgreSQL and memory apply their effects atomically.

- Separate guest commands (`cancel`, `pause`, `shutdown`) from host wake causes: timer, custom signal, manual resume, and recovery.
- Define custom signals as retained, last-write-wins slots addressed by checkpoint ID. Every write gets a distinct signal ID; reads are non-destructive, with no implicit queue or deduplication.
- Reconcile parked launch generations before resume/wake, and clear old deadlines in the enqueue transaction. This fixes a race where resume accepted the previous launch and stranded the instance, and prevents a late clear from erasing a new timer.
- Cover lifecycle policy parity, rollback, concurrent transitions, identity, and real workflow wake/resume behavior.

## Related Issue

Follow-up to #224. The six unmerged commits are applied directly on main at `4a4d5685`, including all changes from #225. The already merged #224 commits are not repeated.

## Type of Change

- [x] Breaking change
- [x] Documentation update

## Testing

Revalidated on the updated main base:

- Frontend `npm run format:check` passed after correcting the request-body formatting flagged by CI.

- `cargo fmt --all -- --check` and workspace Clippy across all targets with the affected integration-test features and `-D warnings`.
- Core, SDK, and PostgreSQL suites: 242 tests passed.
- Full environment suite with `db-integration-tests`: 306 tests passed.
- Server: 1,171 unit tests, five database-backed HTTP tests, and 20 runtime-type tests passed.
- Rebuilt local server with isolated PostgreSQL/Valkey: signal contract, lifecycle command identity, parked cancellation, and core persistence E2Es passed.

Database suites ran serially. The full workspace test matrix remains for CI. The unchanged WASM/frontend portions were also validated during implementation: rebuilt components, 174 workflow execution integration tests, frontend build, and 1,503 frontend tests.

## Checklist

- [x] Read the contributing guidelines and followed project conventions.
- [x] Formatting and Clippy passed.
- [x] Added regression tests and ran the relevant unit, integration, and E2E suites.
- [x] Updated documentation and migration guidance.

## Upgrade Notes

Apply PostgreSQL migrations **022–024**, upgrade server and clients together, rebuild shared components, and recompile workflow artifacts for **WIT runtime 0.3.0**. Persistence adapters must implement the updated typed lifecycle/wake and custom-value contracts.

Legacy submission fields `signalId`/`signal_id` remain aliases for checkpoint addresses; responses distinguish `checkpointId` from the stored value's `signalId`. The historical PostgreSQL `resume` enum label remains for migration compatibility, but pending legacy commands are retired and current readers ignore it. Numeric command value `2` is retired; `0`, `1`, and `3` keep their meanings.
