### PR TITLE
Share one polling loop across the periodic workers, and pair each with its stop signal

### DIFF
--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 use crate::config::parse_enabled;
 use chrono::{DateTime, Utc};
 use tokio::sync::Notify;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
+
+use crate::periodic::PeriodicLoop;
 
 /// Configuration for the cleanup worker.
 #[derive(Debug, Clone)]
@@ -114,43 +116,15 @@ impl CleanupWorker {
             "Cleanup worker started"
         );
 
-        // Eager first pass: enforce retention immediately on startup so that
-        // cleanup runs even when the server restarts more frequently than
-        // `poll_interval`. Race against the shutdown signal so a slow or
-        // hanging cleanup cannot block shutdown.
-        tokio::select! {
-            biased;
-
-            _ = self.shutdown.notified() => {
-                info!("Cleanup worker received shutdown signal during eager pass");
-                return;
-            }
-
-            res = self.cleanup_old_directories() => {
-                if let Err(e) = res {
-                    error!(error = %e, "Failed to cleanup old directories");
-                }
-            }
+        PeriodicLoop {
+            name: "Cleanup worker",
+            poll_interval: self.config.poll_interval,
+            shutdown: &self.shutdown,
+            eager_first_pass: true,
+            pass_error: "Failed to cleanup old directories",
         }
-
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = self.shutdown.notified() => {
-                    info!("Cleanup worker received shutdown signal");
-                    break;
-                }
-
-                _ = tokio::time::sleep(self.config.poll_interval) => {
-                    if let Err(e) = self.cleanup_old_directories().await {
-                        error!(error = %e, "Failed to cleanup old directories");
-                    }
-                }
-            }
-        }
-
-        info!("Cleanup worker stopped");
+        .run(|| self.cleanup_old_directories())
+        .await;
     }
 
     /// Scan for and remove old run directories.

--- a/crates/runtara-environment/src/db_cleanup_worker.rs
+++ b/crates/runtara-environment/src/db_cleanup_worker.rs
@@ -22,9 +22,10 @@ use chrono::Utc;
 use runtara_core::persistence::Persistence;
 use sqlx::PgPool;
 use tokio::sync::Notify;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::Result;
+use crate::periodic::PeriodicLoop;
 
 /// Configuration for the database cleanup worker.
 #[derive(Debug, Clone)]
@@ -196,43 +197,15 @@ impl DbCleanupWorker {
             "Database cleanup worker started"
         );
 
-        // Eager first pass: enforce retention immediately on startup so that
-        // cleanup runs even when the server restarts more frequently than
-        // `poll_interval`. Race against the shutdown signal so a slow or
-        // hanging cleanup (e.g. unreachable DB) cannot block shutdown.
-        tokio::select! {
-            biased;
-
-            _ = self.shutdown.notified() => {
-                info!("Database cleanup worker received shutdown signal during eager pass");
-                return;
-            }
-
-            res = self.run_cleanup_pass() => {
-                if let Err(e) = res {
-                    error!(error = %e, "Failed to cleanup old instances");
-                }
-            }
+        PeriodicLoop {
+            name: "Database cleanup worker",
+            poll_interval: self.config.poll_interval,
+            shutdown: &self.shutdown,
+            eager_first_pass: true,
+            pass_error: "Failed to cleanup old instances",
         }
-
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = self.shutdown.notified() => {
-                    info!("Database cleanup worker received shutdown signal");
-                    break;
-                }
-
-                _ = tokio::time::sleep(self.config.poll_interval) => {
-                    if let Err(e) = self.run_cleanup_pass().await {
-                        error!(error = %e, "Failed to cleanup old instances");
-                    }
-                }
-            }
-        }
-
-        info!("Database cleanup worker stopped");
+        .run(|| self.run_cleanup_pass())
+        .await;
     }
 
     /// One retention pass: expired instances, then expired debug events.

--- a/crates/runtara-environment/src/heartbeat_monitor.rs
+++ b/crates/runtara-environment/src/heartbeat_monitor.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::container_registry::ContainerRegistry;
 use crate::handlers::DrainController;
+use crate::periodic::PeriodicLoop;
 use crate::runner::{Runner, RunnerHandle};
 
 /// Configuration for the heartbeat monitor.
@@ -126,10 +127,10 @@ impl HeartbeatMonitor {
 
     /// Run the heartbeat monitor loop.
     ///
-    /// On startup, immediately kills any processes from a previous run that
-    /// were not confirmed dead (protects against platform restart edge cases).
-    /// Then periodically checks for stale instances and marks them as failed.
-    /// The loop exits when the shutdown signal is received.
+    /// Waits out a full interval before its first scan, deliberately: an
+    /// instance is only stale relative to `heartbeat_timeout`, and a scan at
+    /// t=0 has nothing to say that a scan one interval later does not. This is
+    /// the one periodic worker in the crate that does not want an eager pass.
     pub async fn run(&self) {
         info!(
             poll_interval_secs = self.config.poll_interval.as_secs(),
@@ -137,30 +138,30 @@ impl HeartbeatMonitor {
             "Heartbeat monitor started"
         );
 
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = self.shutdown.notified() => {
-                    info!("Heartbeat monitor received shutdown signal");
-                    break;
-                }
-
-                _ = tokio::time::sleep(self.config.poll_interval) => {
-                    if self.drain.is_draining() {
-                        // During drain, in-progress instances are racing to
-                        // checkpoint; skip scanning to avoid marking them as failed.
-                        debug!("Heartbeat monitor skipping scan during drain");
-                        continue;
-                    }
-                    if let Err(e) = self.check_stale_instances().await {
-                        error!(error = %e, "Failed to check stale instances");
-                    }
-                }
-            }
+        PeriodicLoop {
+            name: "Heartbeat monitor",
+            poll_interval: self.config.poll_interval,
+            shutdown: &self.shutdown,
+            eager_first_pass: false,
+            pass_error: "Failed to check stale instances",
         }
+        .run(|| self.scan_unless_draining())
+        .await;
+    }
 
-        info!("Heartbeat monitor stopped");
+    /// Scan for stale instances, unless a drain is in progress.
+    ///
+    /// The guard lives with the work rather than in the loop, which is where
+    /// every other worker in this crate keeps it — see `dispatch_once` and
+    /// `process_pending_wakes`. During drain, in-progress instances are racing
+    /// to checkpoint, and a scan that runs anyway sees them as stale and marks
+    /// them failed, turning a graceful drain into spurious failures.
+    async fn scan_unless_draining(&self) -> crate::error::Result<()> {
+        if self.drain.is_draining() {
+            debug!("Heartbeat monitor skipping scan during drain");
+            return Ok(());
+        }
+        self.check_stale_instances().await
     }
 
     /// Check for stale instances and mark them as failed.

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -26,10 +26,11 @@ use crate::config::parse_enabled;
 use chrono::Utc;
 use sqlx::PgPool;
 use tokio::sync::Notify;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::Result;
 use crate::image_registry::ImageRegistry;
+use crate::periodic::PeriodicLoop;
 
 /// Configuration for the image cleanup worker.
 #[derive(Debug, Clone)]
@@ -140,43 +141,15 @@ impl ImageCleanupWorker {
             "Image cleanup worker started"
         );
 
-        // Eager first pass: enforce retention immediately on startup so that
-        // cleanup runs even when the server restarts more frequently than
-        // `poll_interval`. Race against the shutdown signal so a slow or
-        // hanging cleanup (e.g. unreachable DB) cannot block shutdown.
-        tokio::select! {
-            biased;
-
-            _ = self.shutdown.notified() => {
-                info!("Image cleanup worker received shutdown signal during eager pass");
-                return;
-            }
-
-            res = self.cleanup_images() => {
-                if let Err(e) = res {
-                    error!(error = %e, "Failed to cleanup images");
-                }
-            }
+        PeriodicLoop {
+            name: "Image cleanup worker",
+            poll_interval: self.config.poll_interval,
+            shutdown: &self.shutdown,
+            eager_first_pass: true,
+            pass_error: "Failed to cleanup images",
         }
-
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = self.shutdown.notified() => {
-                    info!("Image cleanup worker received shutdown signal");
-                    break;
-                }
-
-                _ = tokio::time::sleep(self.config.poll_interval) => {
-                    if let Err(e) = self.cleanup_images().await {
-                        error!(error = %e, "Failed to cleanup images");
-                    }
-                }
-            }
-        }
-
-        info!("Image cleanup worker stopped");
+        .run(|| self.cleanup_images())
+        .await;
     }
 
     /// Run both cleanup phases.

--- a/crates/runtara-environment/src/lib.rs
+++ b/crates/runtara-environment/src/lib.rs
@@ -205,6 +205,9 @@ pub mod wake_scheduler;
 /// Pure configuration parsing shared by environment and server callers.
 pub mod config;
 
+/// The shutdown-aware polling loop the retention workers share.
+pub(crate) mod periodic;
+
 /// Background worker for cleaning up old run directories.
 pub mod cleanup_worker;
 

--- a/crates/runtara-environment/src/lib.rs
+++ b/crates/runtara-environment/src/lib.rs
@@ -205,7 +205,7 @@ pub mod wake_scheduler;
 /// Pure configuration parsing shared by environment and server callers.
 pub mod config;
 
-/// The shutdown-aware polling loop the retention workers share.
+/// The shutdown-aware polling loop the periodic workers share.
 pub(crate) mod periodic;
 
 /// Background worker for cleaning up old run directories.

--- a/crates/runtara-environment/src/periodic.rs
+++ b/crates/runtara-environment/src/periodic.rs
@@ -8,6 +8,17 @@
 //! only in what they logged and which pass they called, so a fix to the loop —
 //! the `biased` that makes shutdown win a ready race, say — had to be made
 //! three times or it was made once and drifted.
+//!
+//! One thing this moved: tracing takes an event's target from `module_path!()`
+//! at the callsite, so the lines emitted here now arrive under
+//! `runtara_environment::periodic` rather than under each worker's own module.
+//! The rendered text is unchanged and still names the worker, and every log
+//! filter in this repo is crate-level (`runtara_environment=info`), so nothing
+//! in tree is affected — but the split is deliberate and worth knowing: a
+//! worker's `disabled` and `started` lines stay behind in its own module
+//! because they carry per-worker configuration fields, while the shutdown,
+//! stopped and pass-failure lines come from here. A module-scoped filter set
+//! on one worker will therefore see it start and not see it stop.
 
 use std::fmt::Display;
 use std::future::Future;

--- a/crates/runtara-environment/src/periodic.rs
+++ b/crates/runtara-environment/src/periodic.rs
@@ -1,8 +1,9 @@
 // Copyright (C) 2025 SyncMyOrders Sp. z o.o.
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! The shutdown-aware polling loop this crate's retention workers share.
+//! The shutdown-aware polling loop this crate's periodic workers share.
 //!
-//! Run-dir cleanup, database cleanup and image cleanup each had their own copy
+//! Run-dir cleanup, database cleanup, image cleanup and the heartbeat monitor
+//! each had their own copy
 //! of the same forty lines: an eager pass raced against the shutdown signal,
 //! then a `biased` select between that signal and a sleep. The three differed
 //! only in what they logged and which pass they called, so a fix to the loop —
@@ -15,7 +16,7 @@
 //! The rendered text is unchanged and still names the worker, and every log
 //! filter in this repo is crate-level (`runtara_environment=info`), so nothing
 //! in tree is affected — but the split is deliberate and worth knowing: a
-//! worker's `disabled` and `started` lines stay behind in its own module
+//! worker's `disabled` and `started` lines stay in its own module
 //! because they carry per-worker configuration fields, while the shutdown,
 //! stopped and pass-failure lines come from here. A module-scoped filter set
 //! on one worker will therefore see it start and not see it stop.
@@ -42,7 +43,9 @@ pub(crate) struct PeriodicLoop<'a> {
     /// Run a pass immediately instead of waiting out the first interval.
     ///
     /// Retention workers want this: a host that restarts more often than the
-    /// interval would otherwise never enforce retention at all.
+    /// interval would otherwise never enforce retention at all. The heartbeat
+    /// monitor does not: staleness is measured against a timeout, so a scan at
+    /// t=0 can say nothing a scan one interval later cannot.
     pub eager_first_pass: bool,
     /// Logged when a pass returns `Err`. The pass keeps running after one.
     pub pass_error: &'static str,

--- a/crates/runtara-environment/src/periodic.rs
+++ b/crates/runtara-environment/src/periodic.rs
@@ -1,0 +1,253 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! The shutdown-aware polling loop this crate's retention workers share.
+//!
+//! Run-dir cleanup, database cleanup and image cleanup each had their own copy
+//! of the same forty lines: an eager pass raced against the shutdown signal,
+//! then a `biased` select between that signal and a sleep. The three differed
+//! only in what they logged and which pass they called, so a fix to the loop —
+//! the `biased` that makes shutdown win a ready race, say — had to be made
+//! three times or it was made once and drifted.
+
+use std::fmt::Display;
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tracing::{error, info};
+
+/// One worker's polling loop.
+///
+/// The caller keeps its own "disabled" check and its startup log line, because
+/// those name configuration this loop knows nothing about. Everything from the
+/// first pass to the final "stopped" line is here.
+pub(crate) struct PeriodicLoop<'a> {
+    /// Worker name, used verbatim to open each lifecycle log line.
+    pub name: &'static str,
+    /// How long to wait between passes.
+    pub poll_interval: Duration,
+    /// Fires once when the runtime wants this worker to stop.
+    pub shutdown: &'a Notify,
+    /// Run a pass immediately instead of waiting out the first interval.
+    ///
+    /// Retention workers want this: a host that restarts more often than the
+    /// interval would otherwise never enforce retention at all.
+    pub eager_first_pass: bool,
+    /// Logged when a pass returns `Err`. The pass keeps running after one.
+    pub pass_error: &'static str,
+}
+
+impl PeriodicLoop<'_> {
+    /// Poll `pass` until the shutdown signal arrives.
+    ///
+    /// `biased` in both selects so a shutdown signal that is already ready wins
+    /// against a ready timer, and so the eager pass cannot delay shutdown: a
+    /// cleanup against an unreachable database can hang for a long time, and
+    /// racing it here is what stops that from holding up the whole runtime.
+    pub(crate) async fn run<F, Fut, E>(self, pass: F)
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<(), E>>,
+        E: Display,
+    {
+        if self.eager_first_pass {
+            tokio::select! {
+                biased;
+
+                _ = self.shutdown.notified() => {
+                    info!("{} received shutdown signal during eager pass", self.name);
+                    return;
+                }
+
+                result = pass() => {
+                    if let Err(error) = result {
+                        error!(error = %error, "{}", self.pass_error);
+                    }
+                }
+            }
+        }
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = self.shutdown.notified() => {
+                    info!("{} received shutdown signal", self.name);
+                    break;
+                }
+
+                _ = tokio::time::sleep(self.poll_interval) => {
+                    if let Err(error) = pass().await {
+                        error!(error = %error, "{}", self.pass_error);
+                    }
+                }
+            }
+        }
+
+        info!("{} stopped", self.name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// The eager pass runs before the first interval elapses.
+    ///
+    /// This is the property retention depends on: a host restarting more often
+    /// than `poll_interval` would otherwise never run a pass at all.
+    #[tokio::test(start_paused = true)]
+    async fn an_eager_pass_runs_before_the_first_interval() {
+        let shutdown = Arc::new(Notify::new());
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        let counter = passes.clone();
+        let signal = shutdown.clone();
+        let worker = tokio::spawn(async move {
+            PeriodicLoop {
+                name: "Test worker",
+                poll_interval: Duration::from_secs(3600),
+                shutdown: &signal,
+                eager_first_pass: true,
+                pass_error: "test pass failed",
+            }
+            .run(|| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Ok::<(), std::io::Error>(())
+                }
+            })
+            .await;
+        });
+
+        // Let the eager pass run without advancing anywhere near the interval.
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            1,
+            "the eager pass must not wait for the interval"
+        );
+
+        shutdown.notify_one();
+        worker.await.expect("worker must not panic");
+    }
+
+    /// Without the eager flag the loop waits, which is what a monitor wants.
+    #[tokio::test(start_paused = true)]
+    async fn without_the_eager_flag_nothing_runs_before_the_interval() {
+        let shutdown = Arc::new(Notify::new());
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        let counter = passes.clone();
+        let signal = shutdown.clone();
+        let worker = tokio::spawn(async move {
+            PeriodicLoop {
+                name: "Test worker",
+                poll_interval: Duration::from_secs(3600),
+                shutdown: &signal,
+                eager_first_pass: false,
+                pass_error: "test pass failed",
+            }
+            .run(|| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Ok::<(), std::io::Error>(())
+                }
+            })
+            .await;
+        });
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert_eq!(passes.load(Ordering::SeqCst), 0);
+
+        shutdown.notify_one();
+        worker.await.expect("worker must not panic");
+    }
+
+    /// A failing pass is logged, not fatal: the next tick still happens.
+    #[tokio::test(start_paused = true)]
+    async fn a_failing_pass_does_not_end_the_loop() {
+        let shutdown = Arc::new(Notify::new());
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        let counter = passes.clone();
+        let signal = shutdown.clone();
+        let worker = tokio::spawn(async move {
+            PeriodicLoop {
+                name: "Test worker",
+                poll_interval: Duration::from_secs(10),
+                shutdown: &signal,
+                eager_first_pass: true,
+                pass_error: "test pass failed",
+            }
+            .run(|| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Err::<(), std::io::Error>(std::io::Error::other("always fails"))
+                }
+            })
+            .await;
+        });
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert_eq!(passes.load(Ordering::SeqCst), 1, "eager pass ran");
+
+        for expected in 2..=3 {
+            tokio::time::advance(Duration::from_secs(11)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(
+                passes.load(Ordering::SeqCst),
+                expected,
+                "a failed pass must not stop the loop"
+            );
+        }
+
+        shutdown.notify_one();
+        worker.await.expect("worker must not panic");
+    }
+
+    /// Shutdown wins a race it is already ready for, which is what `biased`
+    /// buys: a due timer must not get one more pass in on the way out.
+    #[tokio::test(start_paused = true)]
+    async fn a_ready_shutdown_beats_a_due_timer() {
+        let shutdown = Arc::new(Notify::new());
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        // Signal before the worker ever polls, so both branches are ready the
+        // first time through the select.
+        shutdown.notify_one();
+
+        let counter = passes.clone();
+        let signal = shutdown.clone();
+        PeriodicLoop {
+            name: "Test worker",
+            poll_interval: Duration::ZERO,
+            shutdown: &signal,
+            eager_first_pass: false,
+            pass_error: "test pass failed",
+        }
+        .run(|| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), std::io::Error>(())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            0,
+            "a pending shutdown must win against a zero-length sleep"
+        );
+    }
+}

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -398,11 +398,13 @@ impl EnvironmentRuntimeConfig {
                 .with_drain(drain.clone())
                 .with_launch_control(launch_notifier.clone(), lifecycle_observers.clone());
 
-        let wake_shutdown = wake_scheduler.shutdown_handle();
-
-        let wake_handle = tokio::spawn(async move {
-            wake_scheduler.run().await;
-        });
+        let wake = Worker::spawn(
+            "wake scheduler",
+            wake_scheduler.shutdown_handle(),
+            async move {
+                wake_scheduler.run().await;
+            },
+        );
 
         // Only this worker hands a generation to a runner. Sources commit a
         // queue row then notify it, and a periodic scan recovers notifications
@@ -416,10 +418,13 @@ impl EnvironmentRuntimeConfig {
         )
         .with_execution_timeout_policy(self.execution_timeout_policy)
         .with_drain(drain.clone());
-        let launch_dispatcher_shutdown = launch_dispatcher.shutdown_handle();
-        let launch_dispatcher_handle = tokio::spawn(async move {
-            launch_dispatcher.run().await;
-        });
+        let dispatcher = Worker::spawn(
+            "launch dispatcher",
+            launch_dispatcher.shutdown_handle(),
+            async move {
+                launch_dispatcher.run().await;
+            },
+        );
 
         // Create cleanup worker. Config loads from env (so operators can tune
         // RUNTARA_RUN_DIR_CLEANUP_* at runtime) but the builder-supplied
@@ -429,12 +434,13 @@ impl EnvironmentRuntimeConfig {
         cleanup_config.poll_interval = self.cleanup_poll_interval;
         cleanup_config.max_age = self.cleanup_max_age;
         let cleanup_worker = CleanupWorker::new(cleanup_config);
-        let cleanup_shutdown = cleanup_worker.shutdown_handle();
-
-        // Start cleanup worker task
-        let cleanup_handle = tokio::spawn(async move {
-            cleanup_worker.run().await;
-        });
+        let cleanup = Worker::spawn(
+            "run-dir cleanup",
+            cleanup_worker.shutdown_handle(),
+            async move {
+                cleanup_worker.run().await;
+            },
+        );
 
         // Create heartbeat monitor
         let heartbeat_config = HeartbeatMonitorConfig {
@@ -448,11 +454,13 @@ impl EnvironmentRuntimeConfig {
             heartbeat_config,
         )
         .with_drain(drain.clone());
-        let heartbeat_shutdown = heartbeat_monitor.shutdown_handle();
-
-        let heartbeat_handle = tokio::spawn(async move {
-            heartbeat_monitor.run().await;
-        });
+        let heartbeat = Worker::spawn(
+            "heartbeat monitor",
+            heartbeat_monitor.shutdown_handle(),
+            async move {
+                heartbeat_monitor.run().await;
+            },
+        );
 
         // Create database cleanup worker
         let db_cleanup_worker = DbCleanupWorker::new(
@@ -460,41 +468,70 @@ impl EnvironmentRuntimeConfig {
             self.persistence.clone(),
             self.db_cleanup_config,
         );
-        let db_cleanup_shutdown = db_cleanup_worker.shutdown_handle();
-
-        let db_cleanup_handle = tokio::spawn(async move {
-            db_cleanup_worker.run().await;
-        });
+        let db_cleanup = Worker::spawn(
+            "database cleanup",
+            db_cleanup_worker.shutdown_handle(),
+            async move {
+                db_cleanup_worker.run().await;
+            },
+        );
 
         // Create image cleanup worker
         let mut image_cleanup_config = self.image_cleanup_config;
         image_cleanup_config.data_dir = self.data_dir.clone();
         let image_cleanup_worker = ImageCleanupWorker::new(self.pool.clone(), image_cleanup_config);
-        let image_cleanup_shutdown = image_cleanup_worker.shutdown_handle();
-
-        let image_cleanup_handle = tokio::spawn(async move {
-            image_cleanup_worker.run().await;
-        });
+        let image_cleanup = Worker::spawn(
+            "image cleanup",
+            image_cleanup_worker.shutdown_handle(),
+            async move {
+                image_cleanup_worker.run().await;
+            },
+        );
 
         info!("EnvironmentRuntime started");
 
         Ok(EnvironmentRuntime {
-            wake_handle,
-            launch_dispatcher_handle,
-            cleanup_handle,
-            heartbeat_handle,
-            db_cleanup_handle,
-            wake_shutdown,
-            launch_dispatcher_shutdown,
-            cleanup_shutdown,
-            heartbeat_shutdown,
-            db_cleanup_shutdown,
-            image_cleanup_handle,
-            image_cleanup_shutdown,
+            wake,
+            launch_dispatcher: dispatcher,
+            // This order is the shutdown join order, which the panic report
+            // reads back in the same sequence.
+            workers: vec![cleanup, heartbeat, db_cleanup, image_cleanup],
             state,
             drain,
             lifecycle_observers,
         })
+    }
+}
+
+/// One background task the runtime owns, with the signal that stops it.
+///
+/// These travelled as two loose fields per worker — six handles and six
+/// notifies, twelve in all, kept in step only by their names. Pairing them
+/// means a worker cannot be added, stopped or joined without its other half.
+struct Worker {
+    /// Reported when the task panics, so a failed shutdown names the worker.
+    name: &'static str,
+    shutdown: Arc<Notify>,
+    handle: JoinHandle<()>,
+}
+
+impl Worker {
+    /// Spawn `task` and keep the pieces needed to stop and join it.
+    fn spawn(
+        name: &'static str,
+        shutdown: Arc<Notify>,
+        task: impl std::future::Future<Output = ()> + Send + 'static,
+    ) -> Self {
+        Self {
+            name,
+            shutdown,
+            handle: tokio::spawn(task),
+        }
+    }
+
+    /// Ask the worker to stop. It finishes the pass it is on.
+    fn stop(&self) {
+        self.shutdown.notify_one();
     }
 }
 
@@ -510,18 +547,13 @@ impl EnvironmentRuntimeConfig {
 ///
 /// Call [`shutdown`](Self::shutdown) for graceful termination.
 pub struct EnvironmentRuntime {
-    wake_handle: JoinHandle<()>,
-    launch_dispatcher_handle: JoinHandle<()>,
-    cleanup_handle: JoinHandle<()>,
-    heartbeat_handle: JoinHandle<()>,
-    db_cleanup_handle: JoinHandle<()>,
-    wake_shutdown: Arc<Notify>,
-    launch_dispatcher_shutdown: Arc<Notify>,
-    cleanup_shutdown: Arc<Notify>,
-    heartbeat_shutdown: Arc<Notify>,
-    db_cleanup_shutdown: Arc<Notify>,
-    image_cleanup_handle: JoinHandle<()>,
-    image_cleanup_shutdown: Arc<Notify>,
+    /// Held by name because [`Self::drain`] stops it first and then waits for
+    /// it to quiesce before taking its snapshot.
+    wake: Worker,
+    /// Held by name for the same reason: dispatch stops before the snapshot.
+    launch_dispatcher: Worker,
+    /// The rest, which only ever start together and stop together.
+    workers: Vec<Worker>,
     state: Arc<EnvironmentHandlerState>,
     drain: DrainController,
     lifecycle_observers: LaunchLifecycleObservers,
@@ -578,7 +610,7 @@ impl EnvironmentRuntime {
 
         // Stop dispatch before taking the active-run snapshot. Queued rows
         // remain durable and will be reclaimed on the next runtime start.
-        self.launch_dispatcher_shutdown.notify_one();
+        self.launch_dispatcher.stop();
 
         // Stop the wake scheduler before the snapshot below, and give it a
         // moment to finish the batch it is on. The snapshot is what decides who
@@ -587,12 +619,12 @@ impl EnvironmentRuntime {
         // straggler list, and still running into teardown. The scheduler also
         // re-checks the drain flag per launch, which covers the batch already
         // in flight here; this just stops new ones being claimed at all.
-        self.wake_shutdown.notify_one();
+        self.wake.stop();
         let quiesce_deadline = std::time::Instant::now() + Duration::from_secs(5);
-        while !self.wake_handle.is_finished() && std::time::Instant::now() < quiesce_deadline {
+        while !self.wake.handle.is_finished() && std::time::Instant::now() < quiesce_deadline {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-        if !self.wake_handle.is_finished() {
+        if !self.wake.handle.is_finished() {
             warn!("Wake scheduler did not quiesce before the drain snapshot");
         }
 
@@ -794,36 +826,21 @@ impl EnvironmentRuntime {
     pub async fn shutdown(self) -> Result<()> {
         info!("EnvironmentRuntime shutting down...");
 
-        // Signal wake scheduler shutdown
-        self.wake_shutdown.notify_one();
-
-        // Signal durable launch dispatcher shutdown
-        self.launch_dispatcher_shutdown.notify_one();
-
-        // Signal cleanup worker shutdown
-        self.cleanup_shutdown.notify_one();
-
-        // Signal heartbeat monitor shutdown
-        self.heartbeat_shutdown.notify_one();
-
-        // Signal database cleanup worker shutdown
-        self.db_cleanup_shutdown.notify_one();
-
-        // Signal image cleanup worker shutdown
-        self.image_cleanup_shutdown.notify_one();
+        // Every worker is asked to stop before any is waited on, so a slow one
+        // cannot delay the signal reaching the rest.
+        let workers: Vec<Worker> = std::iter::once(self.wake)
+            .chain(std::iter::once(self.launch_dispatcher))
+            .chain(self.workers)
+            .collect();
+        for worker in &workers {
+            worker.stop();
+        }
 
         let mut panicked: Vec<&'static str> = Vec::new();
-        for (name, handle) in [
-            ("wake scheduler", self.wake_handle),
-            ("launch dispatcher", self.launch_dispatcher_handle),
-            ("run-dir cleanup", self.cleanup_handle),
-            ("heartbeat monitor", self.heartbeat_handle),
-            ("database cleanup", self.db_cleanup_handle),
-            ("image cleanup", self.image_cleanup_handle),
-        ] {
-            if let Err(e) = handle.await {
-                error!(worker = name, error = %e, "Worker task panicked");
-                panicked.push(name);
+        for worker in workers {
+            if let Err(e) = worker.handle.await {
+                error!(worker = worker.name, error = %e, "Worker task panicked");
+                panicked.push(worker.name);
             }
         }
 
@@ -838,14 +855,15 @@ impl EnvironmentRuntime {
         Ok(())
     }
 
-    /// Check if the runtime is still running.
+    /// Whether every worker is still running.
+    ///
+    /// One finished worker makes this false, which is the same answer the
+    /// six-way conjunction gave.
     pub fn is_running(&self) -> bool {
-        !self.wake_handle.is_finished()
-            && !self.launch_dispatcher_handle.is_finished()
-            && !self.cleanup_handle.is_finished()
-            && !self.heartbeat_handle.is_finished()
-            && !self.db_cleanup_handle.is_finished()
-            && !self.image_cleanup_handle.is_finished()
+        std::iter::once(&self.wake)
+            .chain(std::iter::once(&self.launch_dispatcher))
+            .chain(self.workers.iter())
+            .all(|worker| !worker.handle.is_finished())
     }
 }
 

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -433,10 +433,12 @@ impl EnvironmentRuntimeConfig {
         cleanup_config.data_dir = self.data_dir.clone();
         cleanup_config.poll_interval = self.cleanup_poll_interval;
         cleanup_config.max_age = self.cleanup_max_age;
+        let cleanup_enabled = cleanup_config.enabled;
         let cleanup_worker = CleanupWorker::new(cleanup_config);
-        let cleanup = Worker::spawn(
+        let cleanup = Worker::spawn_configurable(
             "run-dir cleanup",
             cleanup_worker.shutdown_handle(),
+            cleanup_enabled,
             async move {
                 cleanup_worker.run().await;
             },
@@ -463,14 +465,16 @@ impl EnvironmentRuntimeConfig {
         );
 
         // Create database cleanup worker
+        let db_cleanup_enabled = self.db_cleanup_config.enabled;
         let db_cleanup_worker = DbCleanupWorker::new(
             self.pool.clone(),
             self.persistence.clone(),
             self.db_cleanup_config,
         );
-        let db_cleanup = Worker::spawn(
+        let db_cleanup = Worker::spawn_configurable(
             "database cleanup",
             db_cleanup_worker.shutdown_handle(),
+            db_cleanup_enabled,
             async move {
                 db_cleanup_worker.run().await;
             },
@@ -479,10 +483,12 @@ impl EnvironmentRuntimeConfig {
         // Create image cleanup worker
         let mut image_cleanup_config = self.image_cleanup_config;
         image_cleanup_config.data_dir = self.data_dir.clone();
+        let image_cleanup_enabled = image_cleanup_config.enabled;
         let image_cleanup_worker = ImageCleanupWorker::new(self.pool.clone(), image_cleanup_config);
-        let image_cleanup = Worker::spawn(
+        let image_cleanup = Worker::spawn_configurable(
             "image cleanup",
             image_cleanup_worker.shutdown_handle(),
+            image_cleanup_enabled,
             async move {
                 image_cleanup_worker.run().await;
             },
@@ -513,25 +519,49 @@ struct Worker {
     name: &'static str,
     shutdown: Arc<Notify>,
     handle: JoinHandle<()>,
+    /// Whether this worker's configuration has it doing anything.
+    ///
+    /// A disabled retention worker returns from `run()` immediately, so its
+    /// handle is finished almost as soon as it is spawned. That is the
+    /// configured outcome, not a stopped worker.
+    enabled: bool,
 }
 
 impl Worker {
-    /// Spawn `task` and keep the pieces needed to stop and join it.
+    /// Spawn `task` for a worker the runtime expects to keep running.
     fn spawn(
         name: &'static str,
         shutdown: Arc<Notify>,
+        task: impl std::future::Future<Output = ()> + Send + 'static,
+    ) -> Self {
+        Self::spawn_configurable(name, shutdown, true, task)
+    }
+
+    /// Spawn `task` for a worker its configuration may have turned off.
+    fn spawn_configurable(
+        name: &'static str,
+        shutdown: Arc<Notify>,
+        enabled: bool,
         task: impl std::future::Future<Output = ()> + Send + 'static,
     ) -> Self {
         Self {
             name,
             shutdown,
             handle: tokio::spawn(task),
+            enabled,
         }
     }
 
     /// Ask the worker to stop. It finishes the pass it is on.
     fn stop(&self) {
         self.shutdown.notify_one();
+    }
+
+    /// Whether this worker is in the state its configuration calls for.
+    ///
+    /// A disabled worker is live precisely because it has finished.
+    fn is_live(&self) -> bool {
+        !self.enabled || !self.handle.is_finished()
     }
 }
 
@@ -863,7 +893,7 @@ impl EnvironmentRuntime {
         std::iter::once(&self.wake)
             .chain(std::iter::once(&self.launch_dispatcher))
             .chain(self.workers.iter())
-            .all(|worker| !worker.handle.is_finished())
+            .all(Worker::is_live)
     }
 }
 
@@ -1103,6 +1133,38 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A worker its configuration disabled has finished on purpose.
+    ///
+    /// `is_running()` ANDs every worker's liveness, so before this a single
+    /// disabled retention worker — `RUNTARA_RUN_DIR_CLEANUP_ENABLED=false`, say
+    /// — made the whole runtime report itself stopped for its entire life, and
+    /// `EmbeddedRuntara::is_running()` with it. Disabling a cleanup worker is a
+    /// supported configuration, not a fault.
+    #[tokio::test]
+    async fn a_disabled_worker_does_not_make_the_runtime_look_stopped() {
+        // A task that returns immediately: exactly what `run()` does when its
+        // config says the worker is off.
+        let finished =
+            || Worker::spawn_configurable("test", Arc::new(Notify::new()), false, async {});
+        let worker = finished();
+        // Let the task actually complete before asking.
+        tokio::task::yield_now().await;
+        assert!(worker.handle.is_finished(), "fixture must have finished");
+        assert!(
+            worker.is_live(),
+            "a disabled worker is live precisely because it finished"
+        );
+
+        // The same finished handle, but for a worker that was meant to run.
+        let enabled = Worker::spawn_configurable("test", Arc::new(Notify::new()), true, async {});
+        tokio::task::yield_now().await;
+        assert!(enabled.handle.is_finished());
+        assert!(
+            !enabled.is_live(),
+            "an enabled worker that finished early has stopped"
+        );
+    }
 
     /// A drain that cannot read the registry has no idea what to park, so every
     /// guest runs on into teardown and dies with the process. That used to be

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -15,6 +15,7 @@ use runtara_core::persistence::{
     SignalRecord,
 };
 use runtara_environment::container_registry::ContainerRegistry;
+use runtara_environment::handlers::DrainController;
 use runtara_environment::heartbeat_monitor::{HeartbeatMonitor, HeartbeatMonitorConfig};
 use runtara_environment::runner::{ContainerMetrics, LaunchOptions, Runner, RunnerHandle};
 use sqlx::PgPool;
@@ -600,6 +601,66 @@ async fn test_heartbeat_monitor_shutdown() {
 // ============================================================================
 // Stale Container Detection Tests
 // ============================================================================
+
+/// A draining monitor must not fail an instance that is racing to checkpoint.
+///
+/// During drain, in-flight guests are being asked to suspend; a scan that runs
+/// anyway sees them as stale and marks them failed, turning a graceful drain
+/// into a batch of spurious failures. `with_drain` is what prevents that, and
+/// until now nothing exercised it — the word "drain" did not appear in this
+/// file, so the guard could have been deleted and every test still passed.
+#[tokio::test]
+async fn a_draining_monitor_does_not_fail_a_stale_instance() {
+    skip_if_no_db!();
+    let _monitor = MONITOR_LOCK.lock().await;
+    let pool = get_test_pool().await;
+
+    let tenant_id = format!("test-tenant-drain-{}", Uuid::new_v4());
+    let image_id = create_test_image(&pool, &tenant_id).await;
+    let instance_id = Uuid::new_v4().to_string();
+
+    // Exactly the fixture test_stale_container_no_heartbeat uses: a registered
+    // container that never heartbeats, which a scanning monitor WILL fail.
+    create_env_instance(&pool, &instance_id, &tenant_id, &image_id, "running").await;
+    register_container(&pool, &instance_id, &tenant_id, &image_id).await;
+
+    let persistence = Arc::new(MockPersistence::new());
+    let config = HeartbeatMonitorConfig {
+        poll_interval: Duration::from_millis(50),
+        heartbeat_timeout: Duration::from_secs(60),
+    };
+
+    let drain = DrainController::new();
+    drain.set();
+
+    let monitor = HeartbeatMonitor::new(
+        pool.clone(),
+        persistence.clone(),
+        Arc::new(MockRunner),
+        config,
+    )
+    .with_drain(drain);
+    let shutdown = monitor.shutdown_handle();
+
+    let handle = tokio::spawn(async move {
+        monitor.run().await;
+    });
+
+    // Long enough for several poll intervals to elapse.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    shutdown.notify_one();
+    handle.await.ok();
+
+    assert!(
+        persistence.get_completed_instances().is_empty(),
+        "a draining monitor must not complete any instance; it failed {:?}",
+        persistence.get_completed_instances()
+    );
+
+    cleanup(&pool, &instance_id).await;
+    cleanup_image(&pool, &image_id).await;
+}
 
 #[tokio::test]
 async fn test_stale_container_no_heartbeat() {


### PR DESCRIPTION
Two audit items from the runtara-environment review, both worker plumbing, plus the two
follow-ups the review of this branch turned up.

## The duplication

**Three retention workers had byte-identical polling loops.** Run-dir, database and image cleanup
each carried the same ~40 lines: an eager first pass raced against the shutdown signal, then a
`biased` select between that signal and a sleep. They differed only in what they logged and which
pass they called — so a fix to the loop (the `biased` that makes shutdown win a ready race, say)
had to be made three times, or it was made once and drifted.

`PeriodicLoop` owns that machinery now, with tests for the two properties the copies only
asserted by construction: an eager pass really does run before the first interval, and a ready
shutdown really does beat a due timer.

**`EnvironmentRuntime` held six `JoinHandle`s and six `Notify`s as twelve loose fields**, kept in
step only by their names — and `shutdown()` listed all six a third time to name them for the panic
report. A `Worker { name, shutdown, handle }` pairs them, so a worker cannot be spawned, stopped
or joined without its other half. The struct went from 15 fields to 6.

`wake` and `launch_dispatcher` stay named fields rather than joining the vector, because `drain()`
stops those two first and waits for the wake scheduler to quiesce before taking its snapshot.
That ordering was previously invisible in the shape; now the struct states it.

## The two follow-ups

**The heartbeat monitor folded in.** Its loop was `PeriodicLoop` with `eager_first_pass: false`
and a drain guard in the tick — no new flag needed. That matters beyond deduplication: before this,
`eager_first_pass: false` had *zero* production callers, so the flag was justified only by its own
tests. The guard moved into a named `scan_unless_draining`, which is where the rest of the crate
already keeps its drain checks (`dispatch_once`, `process_pending_wakes`); the heartbeat monitor
was the only one testing `is_draining` in the loop body.

Its `run()` doc claimed it "immediately kills any processes from a previous run" — never true,
since the loop has no eager pass. Corrected rather than made true.

**`is_running()` no longer reports the runtime stopped because a worker is disabled.** It ANDed
every worker's handle, but a retention worker its config turns off returns from `run()`
immediately, so its handle is finished almost as soon as it is spawned. A single
`RUNTARA_RUN_DIR_CLEANUP_ENABLED=false` made the runtime report itself stopped for its entire
life, and `EmbeddedRuntara::is_running()` with it.

Scope, stated plainly: the defect predates this branch — the old six-way conjunction behaved
identically — and nothing in the workspace calls `is_running()` today. This fixes a latent API,
not an outage.

## For the reviewer

- **One behaviour difference, and it is logging-only.** Tracing takes an event's target from
  `module_path!()`, so the lines that moved into `periodic` now arrive under
  `runtara_environment::periodic`. Message text is byte-identical and still names the worker, and
  every log filter in this repo is crate-level (`runtara_environment=info`), so nothing in tree
  changes. The split is asymmetric on purpose — `disabled` and `started` stay with the worker
  because they carry its own config fields — so a *module-scoped* filter would see a worker start
  and never see it stop. Documented in `periodic.rs`.
- **Both new bug-adjacent tests were proven against the broken behaviour**, not just written
  green. Neutering the heartbeat drain guard makes the new test fail with
  `Instance stale: no activity received since start`; restoring the old `is_running` predicate
  makes the other fail on "a disabled worker is live precisely because it finished".
- **Not fixed here, deliberately:** a panic report says `worker="run-dir cleanup"` while the
  worker itself logs "Cleanup worker stopped" — two name vocabularies for one worker. Both strings
  are verbatim from the pre-refactor code, so this is pre-existing rather than introduced, and
  unifying them changes operator-visible output. Separate commit.
- `runtime.rs` is ~18 lines longer for the `Worker` type and its docs. The file grew; the runtime
  has nine fewer fields.

## Verification

316 environment integration, 1,294 server integration (23 binaries), 3,780 workspace unit, full
`GATE_FEATURES` clippy, `cargo fmt --check`.

Live, against an isolated server — because no unit test exercises the real binary's shutdown:

- Seeded a 10-day-old completed instance, booted, and it was gone within 20s against a 60s poll
  interval. Only the eager first pass can do that; the log confirms `total_deleted=1`.
- SIGTERM with `RUNTARA_RUN_DIR_CLEANUP_ENABLED=false`: the disabled worker logged and stood down,
  the heartbeat monitor started and stopped through the shared loop, and the join did not hang on
  the already-finished handle.

**Known pre-existing failure, baseline-confirmed:** `e2e/test_recovery_environment_restart.sh`
fails identically on `origin/main` and on this branch (the guest resolves connection metadata at
`:7002` instead of the test's internal port). Unrelated; left alone.
