### PR TITLE
Hand the server repositories instead of a database pool

### DIFF
--- a/crates/runtara-environment/src/db.rs
+++ b/crates/runtara-environment/src/db.rs
@@ -234,6 +234,36 @@ pub async fn count_instances_by_status(
     Ok(count.0)
 }
 
+/// Count a tenant's instances in the given statuses, with no ceiling.
+///
+/// The sibling above stops at a bound because its caller only needs to know
+/// whether a cap is reached. A viewer wants the real figure and pays for it:
+/// this is O(matching rows), which for `suspended` means the largest set in the
+/// table. It belongs on a slow tick, never on an intake path.
+pub async fn count_instances_by_status_unbounded(
+    pool: &PgPool,
+    tenant_id: &str,
+    statuses: &[String],
+) -> Result<i64, sqlx::Error> {
+    // Same predicate and the same `idx_instances_status` plan as the capped
+    // form, minus the LIMIT subquery — so the two cannot drift apart on which
+    // rows they consider.
+    let count: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)
+        FROM instances
+        WHERE tenant_id = $1
+          AND status = ANY($2::instance_status[])
+        "#,
+    )
+    .bind(tenant_id)
+    .bind(statuses)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(count.0)
+}
+
 /// Count instances matching filters (for pagination total_count).
 pub async fn count_instances(
     pool: &PgPool,

--- a/crates/runtara-environment/src/db.rs
+++ b/crates/runtara-environment/src/db.rs
@@ -245,9 +245,13 @@ pub async fn count_instances_by_status_unbounded(
     tenant_id: &str,
     statuses: &[String],
 ) -> Result<i64, sqlx::Error> {
-    // Same predicate and the same `idx_instances_status` plan as the capped
-    // form, minus the LIMIT subquery — so the two cannot drift apart on which
-    // rows they consider.
+    // Same predicate as the capped form minus its LIMIT subquery, so the two
+    // cannot drift apart on which rows they consider. Not the same plan,
+    // though: `idx_instances_status` is a plain index on `status`, and the
+    // caller that wants this asks for `suspended` — the value that dominates
+    // the table — so the planner will reasonably prefer a sequential scan.
+    // That cost is the point of the ceiling on the capped form, and the reason
+    // this one belongs on a slow tick behind a slow-query warning.
     let count: (i64,) = sqlx::query_as(
         r#"
         SELECT COUNT(*)

--- a/crates/runtara-environment/src/handlers.rs
+++ b/crates/runtara-environment/src/handlers.rs
@@ -100,7 +100,14 @@ fn tail_chars(s: &str, max: usize) -> String {
 /// Contains database connection, runner, and configuration shared across all handlers.
 pub struct EnvironmentHandlerState {
     /// PostgreSQL connection pool (for Environment-specific tables: images, containers, etc.).
-    pub pool: PgPool,
+    ///
+    /// Crate-private: a pool is authority over every table in the database, so
+    /// handing one out makes anything reachable from it part of this crate's
+    /// public surface whether or not that was intended. Callers outside the
+    /// crate take a repository instead — see [`Self::instances`],
+    /// [`Self::images`] and [`Self::launches`] — which grant exactly the reads
+    /// and writes their table owner has thought about.
+    pub(crate) pool: PgPool,
     /// Core persistence layer (for instance lifecycle, checkpoints, signals).
     ///
     /// Everything core reasons about — status, termination, sleep — changes
@@ -141,6 +148,21 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const START_GATE_MONITOR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl EnvironmentHandlerState {
+    /// The repository that owns the `instances` row.
+    pub fn instances(&self) -> InstanceRepository {
+        InstanceRepository::new(self.pool.clone())
+    }
+
+    /// The registry that owns the `images` table.
+    pub fn images(&self) -> ImageRegistry {
+        ImageRegistry::new(self.pool.clone())
+    }
+
+    /// The repository that owns the durable launch queue.
+    pub fn launches(&self) -> LaunchRepository {
+        LaunchRepository::new(self.pool.clone())
+    }
+
     /// Create a new environment handler state.
     ///
     /// # Arguments

--- a/crates/runtara-environment/src/instance_repository.rs
+++ b/crates/runtara-environment/src/instance_repository.rs
@@ -278,6 +278,20 @@ impl InstanceRepository {
         Ok(crate::db::count_instances_by_status(&self.pool, tenant_id, statuses, ceiling).await?)
     }
 
+    /// Count a tenant's instances in the given statuses, with no ceiling.
+    ///
+    /// [`Self::count_by_status`] bounds its scan because the admission gate
+    /// only needs to know whether the cap is reached. A viewer reporting how
+    /// many instances are parked needs the actual number, and this is the read
+    /// that costs what that answer costs — O(matching rows), for a slow tick.
+    pub async fn count_by_status_unbounded(
+        &self,
+        tenant_id: &str,
+        statuses: &[String],
+    ) -> Result<i64> {
+        Ok(crate::db::count_instances_by_status_unbounded(&self.pool, tenant_id, statuses).await?)
+    }
+
     /// Record what the process used, and read back the status the guest
     /// reported, in one statement.
     ///

--- a/crates/runtara-environment/src/instance_repository.rs
+++ b/crates/runtara-environment/src/instance_repository.rs
@@ -292,6 +292,24 @@ impl InstanceRepository {
         Ok(crate::db::count_instances_by_status_unbounded(&self.pool, tenant_id, statuses).await?)
     }
 
+    /// How many of a tenant's instances are parked.
+    ///
+    /// Which statuses count as parked is this crate's knowledge, so it is
+    /// spelled here rather than at the call site: a viewer asking "how many are
+    /// waiting" should not have to know that the answer is `suspended`, and a
+    /// server crate holding that literal is a second spelling of a vocabulary
+    /// it does not own.
+    ///
+    /// Unbounded, and deliberately so — see [`Self::count_by_status_unbounded`]
+    /// for what that costs.
+    pub async fn count_parked(&self, tenant_id: &str) -> Result<i64> {
+        self.count_by_status_unbounded(
+            tenant_id,
+            &[crate::core_types::status_name(InstanceStatus::Suspended).to_string()],
+        )
+        .await
+    }
+
     /// Record what the process used, and read back the status the guest
     /// reported, in one statement.
     ///

--- a/crates/runtara-environment/tests/handlers_test.rs
+++ b/crates/runtara-environment/tests/handlers_test.rs
@@ -2349,3 +2349,65 @@ async fn every_stored_status_reads_back_as_itself() {
         cleanup(&pool, Some(instance_id), None).await;
     }
 }
+
+/// The unbounded count reports the real figure; the capped one stops early.
+///
+/// These two exist for different callers and the difference is the whole point:
+/// the admission gate only needs to know whether a ceiling is reached, while a
+/// viewer showing "N parked" needs N. A single implementation would either
+/// throttle intake on a large parked population or display a number that
+/// silently stops climbing.
+#[tokio::test]
+async fn the_unbounded_status_count_ignores_the_ceiling_the_capped_one_obeys() {
+    skip_if_no_db!();
+    let pool = get_test_pool().await;
+    let instances = InstanceRepository::new(pool.clone());
+    let persistence = PostgresPersistence::new(pool.clone());
+    let tenant_id = format!("count-tenant-{}", Uuid::new_v4());
+
+    let mut created = Vec::new();
+    for _ in 0..5 {
+        let instance_id = format!("count-{}", Uuid::new_v4());
+        persistence
+            .register_instance(&instance_id, &tenant_id)
+            .await
+            .expect("register instance");
+        persistence
+            .update_instance_status(&instance_id, CoreInstanceStatus::Suspended, None)
+            .await
+            .expect("park it");
+        created.push(instance_id);
+    }
+
+    let statuses = vec!["suspended".to_string()];
+
+    let capped = instances
+        .count_by_status(Some(&tenant_id), &statuses, 3)
+        .await
+        .expect("capped count");
+    assert_eq!(
+        capped, 3,
+        "the capped count must stop at its ceiling, not report the true total"
+    );
+
+    let unbounded = instances
+        .count_by_status_unbounded(&tenant_id, &statuses)
+        .await
+        .expect("unbounded count");
+    assert_eq!(
+        unbounded, 5,
+        "the unbounded count must report every matching row"
+    );
+
+    // Both must agree on WHICH rows match, so a tenant with none reads zero
+    // rather than picking up another tenant's parked instances.
+    let other = instances
+        .count_by_status_unbounded(&format!("count-tenant-{}", Uuid::new_v4()), &statuses)
+        .await
+        .expect("unbounded count for an empty tenant");
+    assert_eq!(other, 0);
+
+    for instance_id in &created {
+        cleanup(&pool, Some(instance_id), None).await;
+    }
+}

--- a/crates/runtara-server/src/environment_client.rs
+++ b/crates/runtara-server/src/environment_client.rs
@@ -98,12 +98,12 @@ impl EnvironmentClient {
     /// something has to cross a socket and not when the caller is linked
     /// against the same crate.
     fn image_registry(&self) -> ImageRegistry {
-        ImageRegistry::new(self.state.pool.clone())
+        self.state.images()
     }
 
     /// The repository that owns the `instances` row.
     fn instances(&self) -> InstanceRepository {
-        InstanceRepository::new(self.state.pool.clone())
+        self.state.instances()
     }
 
     // =========================================================================

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -1726,12 +1726,12 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
             // Readers for the runtime database, where `instances` and
             // `instance_launches` live — not the server pool that most of this
             // function passes around.
-            instances: embedded_runtara
+            runtime: embedded_runtara
                 .as_ref()
-                .map(|r| r.environment_state().instances()),
-            launches: embedded_runtara
-                .as_ref()
-                .map(|r| r.environment_state().launches()),
+                .map(|r| workers::pipeline_sampler::RuntimeReaders {
+                    instances: r.environment_state().instances(),
+                    launches: r.environment_state().launches(),
+                }),
             tenant_id: tenant_id.clone(),
             admission_limit: config::max_concurrent_executions() as u64,
             engine: Some(Arc::clone(&execution_engine)),

--- a/crates/runtara-server/src/server.rs
+++ b/crates/runtara-server/src/server.rs
@@ -1723,11 +1723,15 @@ pub async fn start(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
                     cfg.trigger_consumer_group.clone(),
                 )
             }),
-            // The runtime database, where `instances` lives — not the server
-            // pool that most of this function passes around.
-            pool: embedded_runtara
+            // Readers for the runtime database, where `instances` and
+            // `instance_launches` live — not the server pool that most of this
+            // function passes around.
+            instances: embedded_runtara
                 .as_ref()
-                .map(|r| r.environment_state().pool.clone()),
+                .map(|r| r.environment_state().instances()),
+            launches: embedded_runtara
+                .as_ref()
+                .map(|r| r.environment_state().launches()),
             tenant_id: tenant_id.clone(),
             admission_limit: config::max_concurrent_executions() as u64,
             engine: Some(Arc::clone(&execution_engine)),

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -481,13 +481,16 @@ pub struct SamplerInputs {
     pub valkey: Option<redis::aio::ConnectionManager>,
     /// Trigger stream key and consumer group.
     pub stream: Option<(String, String)>,
-    /// The **runtime** database pool, for durable launch-state and parked
-    /// counts.
+    /// Readers for the two runtime tables this samples, taken from the
+    /// embedded environment rather than built from a pool of our own.
     ///
-    /// Not the server pool: `instances` lives in the runtime database, and
-    /// pointing this at the server one makes every parked count fail silently
-    /// and the stage read as permanently unmeasured.
-    pub pool: Option<sqlx::PgPool>,
+    /// These used to be one `PgPool`, which meant this worker held authority
+    /// over every table in the runtime database in order to run two counts.
+    /// `None` when the embedded environment is disabled, which is what makes
+    /// both readings absent rather than zero.
+    pub instances: Option<runtara_environment::instance_repository::InstanceRepository>,
+    /// See [`Self::instances`].
+    pub launches: Option<runtara_environment::launch_queue::LaunchRepository>,
     /// Tenant whose instances are counted.
     pub tenant_id: String,
     /// Composed admission cap.
@@ -531,8 +534,8 @@ pub async fn run(
         // carry its last value between slow ticks.
         if last_slow.elapsed() >= SLOW_TICK {
             last_slow = Instant::now();
-            parked = match inputs.pool.as_ref() {
-                Some(pool) => count_parked(pool, &inputs.tenant_id).await,
+            parked = match inputs.instances.as_ref() {
+                Some(instances) => count_parked(instances, &inputs.tenant_id).await,
                 None => None,
             };
         }
@@ -542,8 +545,8 @@ pub async fn run(
         // with no launch owner at all. Read the durable generation state
         // instead, including its queue deadline outcome and the workflows
         // responsible for the current backlog.
-        let launches = match inputs.pool.as_ref() {
-            Some(pool) => count_launch_telemetry(pool, &inputs.tenant_id).await,
+        let launches = match inputs.launches.as_ref() {
+            Some(launches) => count_launch_telemetry(launches, &inputs.tenant_id).await,
             None => None,
         };
 
@@ -652,11 +655,10 @@ const TOP_LAUNCH_WORKFLOWS: i64 = 3;
 /// recovery. This query reads only the small actionable state set; `parked`
 /// remains deliberately separate in [`count_parked`].
 async fn count_launch_telemetry(
-    pool: &sqlx::PgPool,
+    launches: &runtara_environment::launch_queue::LaunchRepository,
     tenant_id: &str,
 ) -> Option<LaunchTelemetryReading> {
     let started = Instant::now();
-    let launches = runtara_environment::launch_queue::LaunchRepository::new(pool.clone());
 
     // The SQL lives with the table it reads. This used to be two queries here,
     // carrying their own copies of the launch state names and of three
@@ -744,14 +746,17 @@ fn launch_stage_reading_mut<'a>(
 /// because it only needs to know whether the cap is reached, but a viewer wants
 /// the actual figure. That is why this runs on [`SLOW_TICK`] and never on the
 /// fast one.
-async fn count_parked(pool: &sqlx::PgPool, tenant_id: &str) -> Option<u64> {
+async fn count_parked(
+    instances: &runtara_environment::instance_repository::InstanceRepository,
+    tenant_id: &str,
+) -> Option<u64> {
     let started = Instant::now();
-    let result = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM instances WHERE tenant_id = $1 AND status = 'suspended'",
-    )
-    .bind(tenant_id)
-    .fetch_one(pool)
-    .await;
+    // The predicate lives with the table now. This used to be a raw
+    // `SELECT COUNT(*) FROM instances` here — a second spelling of a status
+    // the environment crate owns, in a crate that does not own the table.
+    let result = instances
+        .count_by_status_unbounded(tenant_id, &["suspended".to_string()])
+        .await;
 
     match result {
         Ok(count) => {

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -469,6 +469,16 @@ impl PipelineLatest {
     }
 }
 
+/// The runtime-database readers the sampler needs, through the repositories
+/// that own those tables.
+#[derive(Clone)]
+pub struct RuntimeReaders {
+    /// Owner of the `instances` row; answers the parked count.
+    pub instances: runtara_environment::instance_repository::InstanceRepository,
+    /// Owner of the durable launch queue; answers the per-stage telemetry.
+    pub launches: runtara_environment::launch_queue::LaunchRepository,
+}
+
 /// What the sampler needs to read the world.
 pub struct SamplerInputs {
     /// Intake counters.
@@ -481,16 +491,15 @@ pub struct SamplerInputs {
     pub valkey: Option<redis::aio::ConnectionManager>,
     /// Trigger stream key and consumer group.
     pub stream: Option<(String, String)>,
-    /// Readers for the two runtime tables this samples, taken from the
-    /// embedded environment rather than built from a pool of our own.
+    /// Readers for the two runtime tables this samples, taken from the embedded
+    /// environment rather than built from a pool of our own.
     ///
-    /// These used to be one `PgPool`, which meant this worker held authority
-    /// over every table in the runtime database in order to run two counts.
-    /// `None` when the embedded environment is disabled, which is what makes
-    /// both readings absent rather than zero.
-    pub instances: Option<runtara_environment::instance_repository::InstanceRepository>,
-    /// See [`Self::instances`].
-    pub launches: Option<runtara_environment::launch_queue::LaunchRepository>,
+    /// This used to be one `PgPool`, which meant the worker held authority over
+    /// every table in the runtime database in order to run two counts. One
+    /// `Option` around both, not one each: they come from the same embedded
+    /// environment and are absent for the same reason, so a half-configured
+    /// sampler should not be representable.
+    pub runtime: Option<RuntimeReaders>,
     /// Tenant whose instances are counted.
     pub tenant_id: String,
     /// Composed admission cap.
@@ -534,8 +543,8 @@ pub async fn run(
         // carry its last value between slow ticks.
         if last_slow.elapsed() >= SLOW_TICK {
             last_slow = Instant::now();
-            parked = match inputs.instances.as_ref() {
-                Some(instances) => count_parked(instances, &inputs.tenant_id).await,
+            parked = match inputs.runtime.as_ref() {
+                Some(runtime) => count_parked(&runtime.instances, &inputs.tenant_id).await,
                 None => None,
             };
         }
@@ -545,8 +554,8 @@ pub async fn run(
         // with no launch owner at all. Read the durable generation state
         // instead, including its queue deadline outcome and the workflows
         // responsible for the current backlog.
-        let launches = match inputs.launches.as_ref() {
-            Some(launches) => count_launch_telemetry(launches, &inputs.tenant_id).await,
+        let launches = match inputs.runtime.as_ref() {
+            Some(runtime) => count_launch_telemetry(&runtime.launches, &inputs.tenant_id).await,
             None => None,
         };
 
@@ -751,12 +760,11 @@ async fn count_parked(
     tenant_id: &str,
 ) -> Option<u64> {
     let started = Instant::now();
-    // The predicate lives with the table now. This used to be a raw
-    // `SELECT COUNT(*) FROM instances` here — a second spelling of a status
-    // the environment crate owns, in a crate that does not own the table.
-    let result = instances
-        .count_by_status_unbounded(tenant_id, &["suspended".to_string()])
-        .await;
+    // Both the predicate and the vocabulary live with the table now. This used
+    // to be a raw `SELECT COUNT(*) FROM instances ... status = 'suspended'`
+    // here — the query and the status name both spelled in a crate that owns
+    // neither.
+    let result = instances.count_parked(tenant_id).await;
 
     match result {
         Ok(count) => {

--- a/docs/environment-wire-shape-plan.md
+++ b/docs/environment-wire-shape-plan.md
@@ -223,15 +223,35 @@ only to exercise its `Debug`/`Clone` derives, and two byte-identical copies of
 those in `wake_scheduler_test.rs`. Nothing else was deleted — the behavioural
 tests that looked like duplicates were retargeted, not dropped.
 
-### Still open
+### The pool, closed afterwards
 
-`EnvironmentHandlerState.pool` is `pub PgPool`, and `EnvironmentClient` builds
-both repositories out of it. So the boundary is narrowed, not enforced:
-everything reachable from that pool is still de facto public API, and
-`pipeline_sampler.rs` still runs its own `SELECT COUNT(*) FROM instances`
-against this crate's table rather than calling `InstanceRepository`. Closing
-that means handing the server repositories instead of a pool, which is a change
-to how the crate is embedded and wants its own review.
+This section used to read "still open", because two PRs in a row had to
+describe the boundary as narrowed rather than enforced: `pool` was `pub PgPool`,
+so everything reachable from the runtime database was de facto public API, and
+`pipeline_sampler.rs` ran its own `SELECT COUNT(*) FROM instances` against a
+table it does not own.
+
+Both are gone. The field is `pub(crate)`; callers outside the crate take
+`instances()`, `images()` or `launches()`; and the parked count is
+`InstanceRepository::count_parked`, which spells `suspended` inside the crate
+that owns the vocabulary rather than in the crate that merely displays it.
+
+`runner` stays `pub` on purpose. It is an `Arc<dyn Runner>`, and a trait object
+exposes only what its trait exposes; a `PgPool` exposes the database. Closing
+both for symmetry would be a worse boundary, not a tighter one.
+
+What is genuinely still open is narrower than it was. `create_runtara_pool()`
+in `runtara-server` remains public and builds a runtime pool from
+`RUNTARA_DATABASE_URL`, so the server can still reach that database — but by
+constructing a connection from a URL it already owns, which is a visible act at
+startup rather than a field quietly handed out by a shared state struct. And
+`count_parked` has no index to sit on: `idx_instances_status` is status-only,
+and `suspended` is the value that dominates the table. Migration
+`019_index_instances_pending_tenant_created.sql` is the precedent for fixing
+that — a partial composite index for exactly this shape of per-tenant status
+count — and a `suspended` sibling would be the forward migration to add. The
+cost is pre-existing, not introduced here; it is now documented rather than
+implied.
 
 ### Fixed along the way
 


### PR DESCRIPTION
Two PRs in a row had to describe this crate's boundary as *narrowed, not enforced*, because
`EnvironmentHandlerState.pool` was `pub PgPool`. A pool is authority over every table in the
database, so handing one out makes everything reachable from it part of the crate's public surface
whether or not anyone meant it to be.

The pipeline sampler was the proof. It took that pool in order to run two counts, and wrote one of
them as raw `SELECT COUNT(*) FROM instances WHERE ... status = 'suspended'` — a table it does not
own, and a status vocabulary it does not own either.

## What changed

- `pool` is `pub(crate)`. Callers outside the crate take a repository instead: `instances()`,
  `images()`, `launches()` — each granting the reads and writes its table owner has thought about.
- `pipeline_sampler` takes those repositories rather than a pool, behind a single `RuntimeReaders`
  option so a half-configured sampler is not representable.
- The parked count is `InstanceRepository::count_parked`, backed by a new
  `count_by_status_unbounded`. The capped sibling stops at a ceiling because its caller is an
  admission gate that only needs to know whether the cap is reached; a viewer needs the real
  number.

**`runner` stays `pub`, deliberately.** It is an `Arc<dyn Runner>`, and a trait object exposes only
what its trait exposes; a `PgPool` exposes the database. Closing both for symmetry would be a
worse boundary, not a tighter one.

## Three things review caught, and what they changed

This was reviewed adversarially — three lenses (remaining leaks, query equivalence, behaviour
drift) then a refutation pass. Four findings survived, and three of them are now fixed in this
branch rather than argued with.

**The status vocabulary hadn't moved with the predicate.** The first commit left
`&["suspended".to_string()]` at the call site, so only half of what "the predicate lives with the
table" claimed was true. `count_parked` owns both now, routed through the crate's own
`status_name(InstanceStatus::Suspended)`.

**A comment I wrote about the query plan was wrong.** It claimed the same `idx_instances_status`
plan as the capped sibling. That index is status-only, and the one caller asks for `suspended` —
the value that dominates the table — so the planner will reasonably prefer a sequential scan. The
capped form's index claim holds because it counts *active* statuses, which are rare; that
reasoning does not carry over. Corrected to say what is actually true, which is that the cost is
real and is why this sits on a slow tick behind a slow-query warning.

**The plan doc contradicted the code.** `docs/environment-wire-shape-plan.md` still listed this
exact work under "Still open". Reconciled, including what remains genuinely open.

## What this does *not* close

Stated plainly, because two PRs have already over-promised here:

- `create_runtara_pool()` in `runtara-server` is public and builds a runtime pool from
  `RUNTARA_DATABASE_URL`. The server can still reach that database — but by constructing a
  connection from a URL it already owns, at startup, which is a visible act rather than a field
  quietly handed out by a shared state struct.
- `count_parked` has no index to sit on. Migration `019_index_instances_pending_tenant_created.sql`
  is the precedent — a partial composite index for exactly this shape of per-tenant status count —
  and a `suspended` sibling is the forward migration to add. The cost is pre-existing rather than
  introduced here; it is now documented instead of implied.

## Verification

317 environment integration, 1,294 server integration (23 binaries), 3,780 workspace unit, full
`GATE_FEATURES` clippy, `cargo fmt --check`. A new test pins the distinction the two counts exist
for: with five parked instances and a ceiling of three, the capped count returns 3 and the
unbounded one returns 5.

Live, against an isolated server, because the System page is the observable outcome:

```
  parked=9        <- 9 suspended rows, correctly excluding 7 completed
  launchQueued=6  -> drains to 0 as they start
  launchRunning=4 -> 10
  admission=10, runPermits=10
```

Both readings arrive through their repositories, and the parked count held steady at 9 across the
burst while the launch stages moved — so neither path is reading a stale or shared value.
