### PR TITLE
Add optional workflow execution labels to Finish steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,6 +4778,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "runtara-dsl",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5022,6 +5023,7 @@ name = "runtara-workflow-runtime"
 version = "8.9.10"
 dependencies = [
  "runtara-sdk",
+ "serde_json",
  "wit-bindgen 0.58.0",
 ]
 
@@ -5030,6 +5032,7 @@ name = "runtara-workflow-stdlib"
 version = "8.9.10"
 dependencies = [
  "minijinja",
+ "runtara-dsl",
  "serde",
  "serde_json",
  "wit-bindgen 0.58.0",

--- a/crates/runtara-component-host/src/runtime_host.rs
+++ b/crates/runtara-component-host/src/runtime_host.rs
@@ -126,6 +126,15 @@ pub trait RuntimeHost: Send + Sync {
     fn instance_id(&self) -> Result<String, String>;
     /// Report terminal success with the output payload.
     async fn complete(&self, output: Vec<u8>) -> Result<(), String>;
+    /// Complete with optional label metadata. Hosts without label support still
+    /// complete successfully; optional metadata must not prevent completion.
+    async fn complete_with_label(
+        &self,
+        output: Vec<u8>,
+        _run_label: Vec<u8>,
+    ) -> Result<(), String> {
+        self.complete(output).await
+    }
     /// Report terminal failure with the error payload.
     async fn fail(&self, error: Vec<u8>) -> Result<(), String>;
     /// Emit a custom event (`kind` becomes the event subtype).
@@ -252,6 +261,14 @@ pub fn add_runtime_to_linker(linker: &mut Linker<WorkflowState>) -> anyhow::Resu
         |mut store: StoreContextMut<'_, WorkflowState>, (output,): (Vec<u8>,)| {
             let host = require_host(&mut store);
             Box::new(async move { Ok((host?.complete(output).await,)) })
+        },
+    )?;
+
+    inst.func_wrap_async(
+        "complete-with-label",
+        |mut store: StoreContextMut<'_, WorkflowState>, (output, run_label): (Vec<u8>, Vec<u8>)| {
+            let host = require_host(&mut store);
+            Box::new(async move { Ok((host?.complete_with_label(output, run_label).await,)) })
         },
     )?;
 

--- a/crates/runtara-core/Cargo.toml
+++ b/crates/runtara-core/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 test-support = []
 
 [dependencies]
+runtara-dsl = { path = "../runtara-dsl", default-features = false }
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/crates/runtara-core/src/instance_handlers/event.rs
+++ b/crates/runtara-core/src/instance_handlers/event.rs
@@ -33,6 +33,24 @@ pub async fn handle_instance_event(
     state: &InstanceHandlerState,
     event: InstanceEvent,
 ) -> Result<InstanceEventResponse> {
+    handle_instance_event_with_run_label(state, event, None).await
+}
+
+/// Complete an execution with optional label metadata in the guarded update.
+/// Other event types must not supply a label.
+pub async fn handle_instance_event_with_run_label(
+    state: &InstanceHandlerState,
+    event: InstanceEvent,
+    run_label: Option<&str>,
+) -> Result<InstanceEventResponse> {
+    let run_label = runtara_dsl::run_label::adopt_run_label(run_label);
+    if run_label.is_some() && !matches!(event.event_type(), InstanceEventType::EventCompleted) {
+        return Err(CoreError::ValidationError {
+            field: "runLabel".into(),
+            message: "Run labels require successful completion".into(),
+        }
+        .into());
+    }
     debug!(
         event_type = ?event.event_type,
         checkpoint_id = ?event.checkpoint_id,
@@ -104,6 +122,9 @@ pub async fn handle_instance_event(
                     .if_running();
             if let Some(o) = output {
                 params = params.with_output(o);
+            }
+            if let Some(label) = run_label.as_deref() {
+                params = params.with_run_label(label);
             }
             let applied = state.persistence.complete_instance(params).await?;
             if applied {

--- a/crates/runtara-core/src/instance_handlers/mock_persistence.rs
+++ b/crates/runtara-core/src/instance_handlers/mock_persistence.rs
@@ -135,6 +135,7 @@ pub fn make_instance(
     status: CoreInstanceStatus,
 ) -> InstanceRecord {
     InstanceRecord {
+        run_label: None,
         instance_id: instance_id.to_string(),
         tenant_id: tenant_id.to_string(),
         definition_version: 1,
@@ -241,6 +242,7 @@ impl Persistence for MockPersistence {
         &self,
         params: CompleteInstanceParams<'_>,
     ) -> std::result::Result<bool, CoreError> {
+        let run_label = params.normalized_run_label()?;
         let mut instances = self.instances.lock().unwrap();
         let Some(inst) = instances.get_mut(params.instance_id) else {
             return match params.guard {
@@ -258,6 +260,7 @@ impl Persistence for MockPersistence {
             return Ok(false);
         }
         inst.status = params.status;
+        inst.run_label = run_label;
         // Output and error are replaced, including when the caller passes None.
         inst.output = params.output.map(|o| o.to_vec());
         inst.error = params.error.map(|e| e.to_string());

--- a/crates/runtara-core/src/instance_handlers/mod.rs
+++ b/crates/runtara-core/src/instance_handlers/mod.rs
@@ -37,7 +37,9 @@ mod types;
 pub mod mock_persistence;
 
 pub use self::checkpoint::{handle_checkpoint, handle_get_checkpoint, handle_sleep};
-pub use self::event::{handle_instance_event, handle_retry_attempt};
+pub use self::event::{
+    handle_instance_event, handle_instance_event_with_run_label, handle_retry_attempt,
+};
 pub use self::registration::handle_register_instance;
 pub use self::signal::{handle_poll_signals, handle_signal_ack, handle_signal_ack_decision};
 pub use self::state::{InstanceEventObserver, InstanceHandlerState};

--- a/crates/runtara-core/src/persistence/memory.rs
+++ b/crates/runtara-core/src/persistence/memory.rs
@@ -159,6 +159,7 @@ impl Persistence for InMemoryPersistence {
         store.instances.insert(
             instance_id.to_string(),
             InstanceRecord {
+                run_label: None,
                 instance_id: instance_id.to_string(),
                 tenant_id: tenant_id.to_string(),
                 definition_version: 1,
@@ -222,6 +223,7 @@ impl Persistence for InMemoryPersistence {
         &self,
         params: CompleteInstanceParams<'_>,
     ) -> Result<bool, CoreError> {
+        let run_label = params.normalized_run_label()?;
         let mut store = self.store.lock().unwrap();
         let Some(inst) = store.instances.get_mut(params.instance_id) else {
             return match params.guard {
@@ -238,6 +240,7 @@ impl Persistence for InMemoryPersistence {
         }
 
         inst.status = params.status;
+        inst.run_label = run_label;
         // Replaced: a transition that carries no output or error clears the
         // previous one, so a failure cannot be read as still holding a stale
         // success payload.

--- a/crates/runtara-core/src/persistence/mod.rs
+++ b/crates/runtara-core/src/persistence/mod.rs
@@ -43,6 +43,8 @@ pub struct InstanceRecord {
     pub finished_at: Option<DateTime<Utc>>,
     /// Input data provided at launch time.
     pub input: Option<Vec<u8>>,
+    /// Optional user-defined execution label.
+    pub run_label: Option<String>,
     /// Output data from successful completion.
     pub output: Option<Vec<u8>>,
     /// Error message from failure.
@@ -371,6 +373,8 @@ pub struct CompleteInstanceParams<'a> {
     pub guard: CompleteInstanceGuard,
     /// Output blob from successful completion.
     pub output: Option<&'a [u8]>,
+    /// Execution label persisted with successful completion.
+    pub run_label: Option<&'a str>,
     /// Error message from failure.
     pub error: Option<&'a str>,
     /// Container stderr captured at termination time.
@@ -391,6 +395,7 @@ impl<'a> CompleteInstanceParams<'a> {
             instance_id,
             status,
             guard: CompleteInstanceGuard::Any,
+            run_label: None,
             output: None,
             error: None,
             stderr: None,
@@ -412,6 +417,25 @@ impl<'a> CompleteInstanceParams<'a> {
     #[must_use]
     pub fn with_output(mut self, output: &'a [u8]) -> Self {
         self.output = Some(output);
+        self
+    }
+
+    /// Normalize optional metadata without letting invalid labels prevent completion.
+    pub fn normalized_run_label(&self) -> Result<Option<String>, CoreError> {
+        let label = runtara_dsl::run_label::adopt_run_label(self.run_label);
+        if label.is_some() && self.status != InstanceStatus::Completed {
+            return Err(CoreError::ValidationError {
+                field: "runLabel".into(),
+                message: "Run labels require successful completion".into(),
+            });
+        }
+        Ok(label)
+    }
+
+    /// Attach an execution label; persistence normalizes or ignores it before writing.
+    #[must_use]
+    pub fn with_run_label(mut self, run_label: &'a str) -> Self {
+        self.run_label = Some(run_label);
         self
     }
 

--- a/crates/runtara-dsl/README.md
+++ b/crates/runtara-dsl/README.md
@@ -29,6 +29,38 @@ assert_eq!(workflow.memory_tier.unwrap_or(MemoryTier::XL).total_memory_bytes(), 
 
 Enable the `utoipa` feature if you need `ToSchema` derives for OpenAPI generation.
 
+## Execution labels
+
+A top-level Finish may set optional `runLabel` metadata independently of its
+`inputMapping` output:
+
+```json
+{
+  "id": "finish",
+  "stepType": "Finish",
+  "runLabel": { "valueType": "template", "value": "Order/{{ data.orderId }} [done]" },
+  "inputMapping": { "success": { "valueType": "immediate", "value": true } }
+}
+```
+
+Literal strings and references are supported too. The resolved string is trimmed
+of surrounding spaces and may contain up to 250 ASCII letters, digits, spaces,
+dots, dashes, forward slashes, parentheses, or square brackets. Omitted, null,
+and empty labels mean no label. A supplied nonempty label must contain at least
+one letter or digit; whitespace-only, punctuation-only, and invisible characters
+are invalid. Duplicate labels are allowed. Invalid literals
+fail workflow validation; invalid dynamic results (including evaluation errors)
+are ignored and Finish completes normally without a label. Labels longer than
+250 characters are truncated, then trailing spaces are removed. The retained
+text must still contain a letter or digit.
+
+The label is saved with successful completion and replaces the workflow name in
+execution lists. Executions that have not reached Finish retain their workflow
+name. Finish steps inside Split, While, or onWait subgraphs cannot set labels;
+inline child workflows and workflow agent capabilities cannot rename their parent.
+The execution list supports case-insensitive literal substring `search` and an
+exact `runLabel` filter, both applied before pagination and counting.
+
 ## Inside Runtara
 
 - Consumed by `runtara-workflows` (compiler/executor), `runtara-agents` (capability metadata), and `runtara-server` (REST validation + OpenAPI surface).

--- a/crates/runtara-dsl/src/lib.rs
+++ b/crates/runtara-dsl/src/lib.rs
@@ -32,6 +32,9 @@ pub const DEFAULT_STEP_TIMEOUT_MS: u64 = 180_000;
 // Include the schema types
 include!("schema_types.rs");
 
+/// Execution label validation.
+pub mod run_label;
+
 // Path utilities
 pub mod paths;
 
@@ -1925,6 +1928,7 @@ mod tests {
         steps.insert(
             "finish".to_string(),
             Step::Finish(FinishStep {
+                run_label: None,
                 id: "finish".to_string(),
                 name: None,
                 input_mapping: None,
@@ -2070,6 +2074,7 @@ mod tests {
         steps.insert(
             "finish".to_string(),
             Step::Finish(FinishStep {
+                run_label: None,
                 id: "finish".to_string(),
                 name: None,
                 input_mapping: None,

--- a/crates/runtara-dsl/src/run_label.rs
+++ b/crates/runtara-dsl/src/run_label.rs
@@ -1,0 +1,92 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Validation shared by workflow authoring and execution boundaries.
+
+/// Maximum length of a resolved execution label.
+pub const MAX_RUN_LABEL_LENGTH: usize = 250;
+
+/// Normalize an optional label. Only ordinary spaces are trimmed; tabs and
+/// newlines remain invalid rather than silently disappearing.
+pub fn normalize_run_label(label: Option<&str>) -> Result<Option<String>, String> {
+    let Some(label) = label else { return Ok(None) };
+    if label.is_empty() {
+        return Ok(None);
+    }
+    let label = label.trim_matches(' ');
+    if !label
+        .bytes()
+        .all(|c| c.is_ascii_alphanumeric() || b" .-/()[]".contains(&c))
+    {
+        return Err("Run label may contain only letters A-Z, numbers, spaces, dots, dashes, forward slashes, parentheses, and square brackets".into());
+    }
+    // The alphabet above is ASCII, so slicing cannot split a code point.
+    let label = label[..label.len().min(MAX_RUN_LABEL_LENGTH)].trim_end_matches(' ');
+    if !label.bytes().any(|c| c.is_ascii_alphanumeric()) {
+        return Err("Run label must contain at least one letter or digit".into());
+    }
+    Ok(Some(label.to_owned()))
+}
+
+/// Runtime metadata is best-effort: invalid values are treated as absent.
+pub fn adopt_run_label(label: Option<&str>) -> Option<String> {
+    normalize_run_label(label).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn optional_and_normalized() {
+        for label in [None, Some("")] {
+            assert_eq!(normalize_run_label(label).unwrap(), None);
+        }
+        assert_eq!(
+            normalize_run_label(Some("  Order/AZ09-1.2 (done) [x]  "))
+                .unwrap()
+                .as_deref(),
+            Some("Order/AZ09-1.2 (done) [x]")
+        );
+    }
+
+    #[test]
+    fn boundaries_and_characters() {
+        for valid in ["A", "0", "--[1]/--", " a "] {
+            assert!(normalize_run_label(Some(valid)).is_ok());
+        }
+        assert!(normalize_run_label(Some(&"a".repeat(250))).is_ok());
+        assert_eq!(
+            normalize_run_label(Some(&"a".repeat(251))).unwrap(),
+            Some("a".repeat(250))
+        );
+        assert_eq!(
+            adopt_run_label(Some(&format!("{}A", "-".repeat(250)))),
+            None
+        );
+        assert_eq!(
+            adopt_run_label(Some(&format!("{} z", "a".repeat(249)))),
+            Some("a".repeat(249))
+        );
+        for invalid in [
+            "x_y",
+            "x%y",
+            "x\\y",
+            "x\ny",
+            "\tx",
+            "é",
+            "🙂",
+            "<x>",
+            "   ",
+            "---",
+            "./()[] -",
+            "\u{200b}",
+            "x\u{200b}y",
+            "\u{a0}",
+            "\u{feff}",
+            "\u{200e}",
+        ] {
+            assert!(normalize_run_label(Some(invalid)).is_err(), "{invalid:?}");
+            assert_eq!(adopt_run_label(Some(invalid)), None);
+        }
+    }
+}

--- a/crates/runtara-dsl/src/schema_types.rs
+++ b/crates/runtara-dsl/src/schema_types.rs
@@ -417,6 +417,11 @@ pub struct FinishStep {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_mapping: Option<InputMapping>,
 
+    /// Optional execution label, resolved when the top-level Finish completes.
+    /// Supports literal strings, references, and templates; at most 250 characters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_label: Option<MappingValue>,
+
     /// When true, execution pauses before this step in debug mode
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub breakpoint: Option<bool>,

--- a/crates/runtara-dsl/src/schema_types.rs
+++ b/crates/runtara-dsl/src/schema_types.rs
@@ -418,7 +418,17 @@ pub struct FinishStep {
     pub input_mapping: Option<InputMapping>,
 
     /// Optional execution label, resolved when the top-level Finish completes.
-    /// Supports literal strings, references, and templates; at most 250 characters.
+    /// Use a MappingValue with valueType immediate, reference, or template.
+    /// Separate from inputMapping/output; duplicate labels are allowed.
+    /// Allowed characters: ASCII letters, digits, ordinary spaces, . - / ( ) [ ].
+    /// Surrounding spaces are trimmed; valid long labels are truncated to 250
+    /// characters and trailing spaces removed. The retained label must contain
+    /// a letter or digit. Invalid literals fail authoring validation; invalid
+    /// dynamic values (including non-strings and evaluation errors) are ignored
+    /// without failing Finish or changing its output. Omitted, null, and empty
+    /// strings mean no label. Execution lists display runLabel when present,
+    /// otherwise the workflow name. Not supported inside Split, While, or onWait
+    /// subgraphs; inline child workflows cannot rename their parent execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_label: Option<MappingValue>,
 

--- a/crates/runtara-environment/src/db.rs
+++ b/crates/runtara-environment/src/db.rs
@@ -13,6 +13,8 @@ use crate::instance_repository::ListInstancesOptions;
 /// Instance with image info (joined from instance_images).
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct InstanceWithImage {
+    /// Optional label assigned at successful workflow completion.
+    pub run_label: Option<String>,
     /// Unique identifier for the instance.
     pub instance_id: String,
     /// Tenant identifier for multi-tenancy isolation.
@@ -36,6 +38,8 @@ pub struct InstanceWithImage {
 /// Full instance record with image info and heartbeat.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct InstanceFull {
+    /// Optional label assigned at successful workflow completion.
+    pub run_label: Option<String>,
     /// Unique identifier for the instance.
     pub instance_id: String,
     /// Tenant identifier for multi-tenancy isolation.
@@ -101,7 +105,7 @@ pub async fn get_instance_full(
     sqlx::query_as::<_, InstanceFull>(
         r#"
         SELECT i.instance_id, i.tenant_id, ii.image_id, img.name as image_name,
-               i.status::TEXT as status, i.input, i.output, i.error, i.stderr, i.checkpoint_id,
+               i.status::TEXT as status, i.run_label, i.input, i.output, i.error, i.stderr, i.checkpoint_id,
                i.created_at, i.started_at, i.finished_at,
                i.attempt, i.max_attempts,
                i.memory_peak_bytes, i.cpu_usage_usec,
@@ -132,69 +136,109 @@ fn status_filter(options: &ListInstancesOptions) -> Option<&[String]> {
         .filter(|statuses| !statuses.is_empty())
 }
 
-/// List instances with optional filters.
+/// Escape LIKE metacharacters so a search term is always literal.
+pub fn escape_like_literal(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// One predicate builder for both the page and its unpaged count.
+fn push_instance_filters(
+    query: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>,
+    options: &ListInstancesOptions,
+) {
+    query.push(" WHERE TRUE");
+    if let Some(tenant) = &options.tenant_id {
+        query.push(" AND i.tenant_id = ").push_bind(tenant.clone());
+    }
+    if let Some(statuses) = status_filter(options) {
+        query
+            .push(" AND i.status = ANY(")
+            .push_bind(statuses.to_vec())
+            .push("::instance_status[])");
+    }
+    if let Some(image_id) = &options.image_id {
+        query
+            .push(" AND ii.image_id = ")
+            .push_bind(image_id.clone());
+    }
+    if let Some(prefix) = &options.image_name_prefix {
+        query
+            .push(" AND img.name LIKE ")
+            .push_bind(format!("{}%", escape_like_literal(prefix)));
+    }
+    for (column, value) in [
+        ("i.created_at >= ", options.created_after),
+        ("i.created_at < ", options.created_before),
+        ("i.finished_at >= ", options.finished_after),
+        ("i.finished_at < ", options.finished_before),
+    ] {
+        if let Some(value) = value {
+            query.push(" AND ").push(column).push_bind(value);
+        }
+    }
+    if let Some(label) = &options.run_label {
+        query.push(" AND i.run_label = ").push_bind(label.clone());
+    }
+    if let Some(search) = options
+        .search
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let pattern = format!("%{}%", escape_like_literal(search));
+        query
+            .push(" AND (i.run_label ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" OR i.instance_id ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" OR img.name ILIKE ")
+            .push_bind(pattern.clone())
+            .push(
+                " OR (CASE WHEN i.status = 'pending' THEN 'queued' ELSE i.status::text END) ILIKE ",
+            )
+            .push_bind(pattern)
+            .push(" OR split_part(img.name, ':', 1) = ANY(")
+            .push_bind(options.search_workflow_ids.clone())
+            .push("))");
+    }
+}
+
+/// List instances with optional filters, with a deterministic tie-breaker.
 pub async fn list_instances(
     pool: &PgPool,
     options: &ListInstancesOptions,
 ) -> Result<Vec<InstanceWithImage>, sqlx::Error> {
-    // Build ORDER BY clause based on order_by option
-    let order_clause = match options.order_by.as_deref() {
-        Some("created_at_asc") => "ORDER BY i.created_at ASC",
-        Some("finished_at_desc") => "ORDER BY i.finished_at DESC NULLS LAST",
-        Some("finished_at_asc") => "ORDER BY i.finished_at ASC NULLS LAST",
-        _ => "ORDER BY i.created_at DESC", // default: created_at_desc
-    };
-
-    // Escape the image name prefix for LIKE pattern (escape % and _)
-    let image_name_pattern = options.image_name_prefix.as_ref().map(|prefix| {
-        let escaped = prefix.replace('%', "\\%").replace('_', "\\_");
-        format!("{}%", escaped)
-    });
-
-    let query = format!(
-        r#"
-        SELECT i.instance_id, i.tenant_id, i.status::TEXT as status,
-               i.created_at, i.started_at, i.finished_at,
-               i.error, ii.image_id, img.name as image_name
-        FROM instances i
-        LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
-        LEFT JOIN images img ON ii.image_id = img.image_id
-        WHERE ($1::TEXT IS NULL OR i.tenant_id = $1)
-          AND ($2::TEXT[] IS NULL OR i.status::TEXT = ANY($2::TEXT[]))
-          AND ($3::TEXT IS NULL OR ii.image_id = $3)
-          AND ($4::TEXT IS NULL OR img.name LIKE $4)
-          AND ($5::TIMESTAMPTZ IS NULL OR i.created_at >= $5)
-          AND ($6::TIMESTAMPTZ IS NULL OR i.created_at < $6)
-          AND ($7::TIMESTAMPTZ IS NULL OR i.finished_at >= $7)
-          AND ($8::TIMESTAMPTZ IS NULL OR i.finished_at < $8)
-        {}
-        LIMIT $9 OFFSET $10
-        "#,
-        order_clause
+    let mut query = sqlx::QueryBuilder::new(
+        "SELECT i.instance_id, i.tenant_id, i.status::TEXT as status,
+         i.created_at, i.started_at, i.finished_at, i.error, i.run_label,
+         ii.image_id, img.name as image_name
+         FROM instances i
+         LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
+         LEFT JOIN images img ON ii.image_id = img.image_id",
     );
-
-    sqlx::query_as::<_, InstanceWithImage>(&query)
-        .bind(options.tenant_id.as_deref())
-        .bind(status_filter(options))
-        .bind(options.image_id.as_deref())
-        .bind(image_name_pattern.as_deref())
-        .bind(options.created_after)
-        .bind(options.created_before)
-        .bind(options.finished_after)
-        .bind(options.finished_before)
-        .bind(options.limit)
-        .bind(options.offset)
-        .fetch_all(pool)
-        .await
+    push_instance_filters(&mut query, options);
+    query.push(match options.order_by.as_deref() {
+        Some("created_at_asc") => " ORDER BY i.created_at ASC, i.instance_id ASC",
+        Some("finished_at_desc") => " ORDER BY i.finished_at DESC NULLS LAST, i.instance_id DESC",
+        Some("finished_at_asc") => " ORDER BY i.finished_at ASC NULLS LAST, i.instance_id ASC",
+        _ => " ORDER BY i.created_at DESC, i.instance_id DESC",
+    });
+    query
+        .push(" LIMIT ")
+        .push_bind(options.limit)
+        .push(" OFFSET ")
+        .push_bind(options.offset);
+    query.build_query_as().fetch_all(pool).await
 }
 
 /// Count a tenant's instances in the given statuses.
 ///
 /// Separate from [`count_instances`] on purpose. That one backs pagination, so
-/// it carries every optional filter and joins the image tables; the optional
-/// filters are written `$n IS NULL OR col = $n`, which is not sargable, and the
-/// status compare casts the enum to text, so neither `idx_instances_status` nor
-/// any other index applies and it degrades to a sequential scan.
+/// it carries every optional filter and joins the image tables. The admission
+/// gate needs only a tenant/status predicate, without those extra joins.
 ///
 /// The admission gate only ever wants "how many are active for this tenant",
 /// and it runs on every intake. Binding the status list as the enum array and
@@ -273,40 +317,14 @@ pub async fn count_instances(
     pool: &PgPool,
     options: &ListInstancesOptions,
 ) -> Result<i64, sqlx::Error> {
-    // Escape the image name prefix for LIKE pattern (escape % and _)
-    let image_name_pattern = options.image_name_prefix.as_ref().map(|prefix| {
-        let escaped = prefix.replace('%', "\\%").replace('_', "\\_");
-        format!("{}%", escaped)
-    });
-
-    let count: (i64,) = sqlx::query_as(
-        r#"
-        SELECT COUNT(*)
-        FROM instances i
-        LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
-        LEFT JOIN images img ON ii.image_id = img.image_id
-        WHERE ($1::TEXT IS NULL OR i.tenant_id = $1)
-          AND ($2::TEXT[] IS NULL OR i.status::TEXT = ANY($2::TEXT[]))
-          AND ($3::TEXT IS NULL OR ii.image_id = $3)
-          AND ($4::TEXT IS NULL OR img.name LIKE $4)
-          AND ($5::TIMESTAMPTZ IS NULL OR i.created_at >= $5)
-          AND ($6::TIMESTAMPTZ IS NULL OR i.created_at < $6)
-          AND ($7::TIMESTAMPTZ IS NULL OR i.finished_at >= $7)
-          AND ($8::TIMESTAMPTZ IS NULL OR i.finished_at < $8)
-        "#,
-    )
-    .bind(options.tenant_id.as_deref())
-    .bind(status_filter(options))
-    .bind(options.image_id.as_deref())
-    .bind(image_name_pattern.as_deref())
-    .bind(options.created_after)
-    .bind(options.created_before)
-    .bind(options.finished_after)
-    .bind(options.finished_before)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(count.0)
+    let mut query = sqlx::QueryBuilder::new(
+        "SELECT COUNT(*) FROM instances i
+         LEFT JOIN instance_images ii ON i.instance_id = ii.instance_id
+         LEFT JOIN images img ON ii.image_id = img.image_id",
+    );
+    push_instance_filters(&mut query, options);
+    let (count,): (i64,) = query.build_query_as().fetch_one(pool).await?;
+    Ok(count)
 }
 
 // ============================================================================
@@ -573,6 +591,7 @@ mod tests {
             order_by: Some("finished_at_desc".to_string()),
             limit: 25,
             offset: 50,
+            ..Default::default()
         };
 
         assert_eq!(options.tenant_id, Some("tenant-1".to_string()));
@@ -628,6 +647,7 @@ mod tests {
     #[test]
     fn test_instance_with_image_debug() {
         let instance = InstanceWithImage {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             status: "running".to_string(),
@@ -648,6 +668,7 @@ mod tests {
     #[test]
     fn test_instance_with_image_clone() {
         let instance = InstanceWithImage {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             status: "running".to_string(),
@@ -668,6 +689,7 @@ mod tests {
     #[test]
     fn test_instance_with_image_no_image() {
         let instance = InstanceWithImage {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             status: "pending".to_string(),
@@ -690,6 +712,7 @@ mod tests {
     #[test]
     fn test_instance_full_debug() {
         let instance = InstanceFull {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             image_id: Some("img-123".to_string()),
@@ -721,6 +744,7 @@ mod tests {
     fn test_instance_full_clone() {
         let now = Utc::now();
         let instance = InstanceFull {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             image_id: Some("img-123".to_string()),
@@ -753,6 +777,7 @@ mod tests {
     #[test]
     fn test_instance_full_no_heartbeat() {
         let instance = InstanceFull {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             tenant_id: "tenant-1".to_string(),
             image_id: None,
@@ -782,6 +807,7 @@ mod tests {
     #[test]
     fn test_instance_full_with_metrics() {
         let instance = InstanceFull {
+            run_label: None,
             instance_id: "inst-metrics".to_string(),
             tenant_id: "tenant-1".to_string(),
             image_id: Some("img-123".to_string()),
@@ -812,6 +838,7 @@ mod tests {
         // Simulates an instance where metrics couldn't be collected
         // (e.g., container exited too quickly or cgroup read failed)
         let instance = InstanceFull {
+            run_label: None,
             instance_id: "inst-no-metrics".to_string(),
             tenant_id: "tenant-1".to_string(),
             image_id: Some("img-123".to_string()),

--- a/crates/runtara-environment/src/db/integration_tests.rs
+++ b/crates/runtara-environment/src/db/integration_tests.rs
@@ -17,6 +17,123 @@ use uuid::Uuid;
 
 use super::*;
 
+#[tokio::test]
+async fn run_label_search_filters_before_pagination_and_counts_duplicates() {
+    use runtara_core::{domain::InstanceStatus, persistence::CompleteInstanceParams};
+    let pool = crate::test_support::pool().await;
+    let persistence = PostgresPersistence::new(pool.clone());
+    let tenant = format!("run-label-{}", Uuid::new_v4());
+    let other_tenant = format!("run-label-other-{}", Uuid::new_v4());
+    for index in 0..28 {
+        let id = format!("{tenant}-{index:02}");
+        persistence
+            .register_instance(&id, if index == 27 { &other_tenant } else { &tenant })
+            .await
+            .unwrap();
+        let params = CompleteInstanceParams::new(&id, InstanceStatus::Completed).with_output(b"{}");
+        persistence
+            .complete_instance(if index % 3 == 0 {
+                params.with_run_label("Order/12 [done] (v1.2)")
+            } else {
+                params
+            })
+            .await
+            .unwrap();
+        // Identical timestamps exercise the ordering tie-breaker.
+        sqlx::query(
+            "UPDATE instances SET created_at = $2, finished_at = $2 WHERE instance_id = $1",
+        )
+        .bind(&id)
+        .bind(epoch(1_000))
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    let mut options = ListInstancesOptions {
+        tenant_id: Some(tenant.clone()),
+        search: Some("ORDER/12 [done]".into()),
+        limit: 4,
+        ..Default::default()
+    };
+    let mut ids = Vec::new();
+    for page in 0..3 {
+        options.offset = page * 4;
+        assert_eq!(count_instances(&pool, &options).await.unwrap(), 9);
+        ids.extend(
+            list_instances(&pool, &options)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|i| i.instance_id),
+        );
+    }
+    assert_eq!(ids.len(), 9);
+    assert_eq!(
+        ids.iter().collect::<std::collections::HashSet<_>>().len(),
+        9
+    );
+    options.offset = 100;
+    assert!(list_instances(&pool, &options).await.unwrap().is_empty());
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 9);
+    options.offset = 0;
+    options.search = None;
+    options.run_label = Some("Order/12 [done] (v1.2)".into());
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 9);
+    options.statuses = Some(vec!["failed".into()]);
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 0);
+    options.statuses = None;
+    options.created_after = Some(epoch(1_001));
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 0);
+    options.created_after = None;
+    options.run_label = None;
+    for term in ["%", "_", "\\"] {
+        options.search = Some(term.into());
+        assert_eq!(count_instances(&pool, &options).await.unwrap(), 0);
+    }
+    // A workflow filter must intersect the label predicate before pagination.
+    let image_id = format!("{tenant}-image");
+    sqlx::query("INSERT INTO images (image_id, tenant_id, name, binary_path) VALUES ($1, $2, 'invoice:1', '/test-only')")
+        .bind(&image_id).bind(&tenant).execute(&pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO instance_images (instance_id, image_id, tenant_id) VALUES ($1, $2, $3)",
+    )
+    .bind(format!("{tenant}-00"))
+    .bind(&image_id)
+    .bind(&tenant)
+    .execute(&pool)
+    .await
+    .unwrap();
+    options.search = Some("Order/12".into());
+    options.image_name_prefix = Some("invoice:".into());
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 1);
+    assert_eq!(list_instances(&pool, &options).await.unwrap().len(), 1);
+    options.search = Some("search by workflow name".into());
+    options.search_workflow_ids = vec!["invoice".into()];
+    assert_eq!(count_instances(&pool, &options).await.unwrap(), 1);
+    assert_eq!(list_instances(&pool, &options).await.unwrap().len(), 1);
+    // The database enforces the same constraints even outside application code.
+    let id = format!("{tenant}-00");
+    for invalid in [
+        "bad_label".to_owned(),
+        "--- ./()[]".to_owned(),
+        "   ".to_owned(),
+        "\u{200b}".to_owned(),
+        "x\u{a0}y".to_owned(),
+        "x".repeat(251),
+        " padded ".to_owned(),
+        "".into(),
+    ] {
+        assert!(
+            sqlx::query("UPDATE instances SET run_label = $2 WHERE instance_id = $1")
+                .bind(&id)
+                .bind(invalid)
+                .execute(&pool)
+                .await
+                .is_err()
+        );
+    }
+}
+
 // ============================================================================
 // Tenant metrics aggregation
 //

--- a/crates/runtara-environment/src/instance_repository.rs
+++ b/crates/runtara-environment/src/instance_repository.rs
@@ -42,6 +42,8 @@ use crate::error::{Error, Result};
 /// turning `found: false` back into an error.
 #[derive(Debug)]
 pub struct InstanceDetail {
+    /// Optional label assigned at successful workflow completion.
+    pub run_label: Option<String>,
     /// Instance id.
     pub instance_id: String,
     /// Lifecycle status.
@@ -85,6 +87,8 @@ pub struct InstanceDetail {
 /// One instance as a list reports it.
 #[derive(Debug)]
 pub struct InstanceListItem {
+    /// Optional label assigned at successful workflow completion.
+    pub run_label: Option<String>,
     /// Instance id.
     pub instance_id: String,
     /// Owning tenant.
@@ -125,6 +129,12 @@ pub struct InstanceImageBinding {
 /// Options for listing instances.
 #[derive(Debug, Clone, Default)]
 pub struct ListInstancesOptions {
+    /// Case-insensitive literal substring search across run metadata.
+    pub search: Option<String>,
+    /// Exact normalized execution label filter.
+    pub run_label: Option<String>,
+    /// Workflow IDs whose names match search, resolved in the server database.
+    pub search_workflow_ids: Vec<String>,
     /// Filter by tenant ID.
     pub tenant_id: Option<String>,
     /// Filter by status — a row matches if it holds any one of these. `None`
@@ -207,6 +217,7 @@ impl InstanceRepository {
         Ok(Some(InstanceDetail {
             status: runtara_store_postgres::encoding::status_from_str(&inst.status)?,
             instance_id: inst.instance_id,
+            run_label: inst.run_label,
             tenant_id: inst.tenant_id,
             image_id: inst.image_id,
             image_name: inst.image_name,
@@ -229,19 +240,10 @@ impl InstanceRepository {
 
     /// List instances matching `options`.
     ///
-    /// A failing count degrades to `0` rather than failing the call: the page is
-    /// the answer the caller asked for, and losing it because a second query
-    /// stumbled would be the worse outcome.
+    /// Count failures propagate: a successful page must have truthful totals.
     pub async fn list(&self, options: &ListInstancesOptions) -> Result<InstancePage> {
         let instances = crate::db::list_instances(&self.pool, options).await?;
-
-        let total_count = match crate::db::count_instances(&self.pool, options).await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!("Count instances error: {}", e);
-                0
-            }
-        };
+        let total_count = crate::db::count_instances(&self.pool, options).await?;
 
         Ok(InstancePage {
             instances: instances
@@ -250,6 +252,7 @@ impl InstanceRepository {
                     Ok(InstanceListItem {
                         status: runtara_store_postgres::encoding::status_from_str(&inst.status)?,
                         instance_id: inst.instance_id,
+                        run_label: inst.run_label,
                         tenant_id: inst.tenant_id,
                         image_id: inst.image_id,
                         image_name: inst.image_name,

--- a/crates/runtara-environment/src/runtime_host.rs
+++ b/crates/runtara-environment/src/runtime_host.rs
@@ -387,6 +387,28 @@ impl RuntimeHost for PersistenceRuntimeHost {
             .await
     }
 
+    async fn complete_with_label(&self, output: Vec<u8>, run_label: Vec<u8>) -> Result<(), String> {
+        self.escalate_if_cancel_ignored().await;
+        let label = serde_json::from_slice::<Option<String>>(&run_label)
+            .ok()
+            .flatten();
+        runtara_core::instance_handlers::handle_instance_event_with_run_label(
+            &self.state,
+            InstanceEvent {
+                instance_id: self.instance_id.clone(),
+                event_type: InstanceEventType::EventCompleted as i32,
+                checkpoint_id: None,
+                payload: output,
+                timestamp_ms: chrono::Utc::now().timestamp_millis(),
+                subtype: None,
+            },
+            label.as_deref(),
+        )
+        .await
+        .map_err(Self::err)?;
+        Ok(())
+    }
+
     async fn fail(&self, error: Vec<u8>) -> Result<(), String> {
         self.escalate_if_cancel_ignored().await;
         self.event(InstanceEventType::EventFailed, None, error, None)
@@ -698,6 +720,71 @@ mod tests {
         let inst = p.get_instance(inst_id.as_str()).await.unwrap().unwrap();
         assert_eq!(inst.status, CoreInstanceStatus::Completed);
         assert_eq!(inst.output.as_deref(), Some(b"{\"result\":1}".as_slice()));
+    }
+
+    #[tokio::test]
+    async fn run_label_completion_is_validated_atomic_and_replay_safe() {
+        let (p, host, id) = setup().await;
+        for invalid in [
+            serde_json::json!(42),
+            serde_json::json!("x_y"),
+            serde_json::json!("--- ./()[]"),
+            serde_json::json!("   "),
+            serde_json::json!("\u{200b}"),
+            serde_json::json!({"x":1}),
+        ] {
+            let (p, host, id) = setup().await;
+            host.complete_with_label(b"{}".to_vec(), serde_json::to_vec(&invalid).unwrap())
+                .await
+                .unwrap();
+            let instance = p.get_instance(&id).await.unwrap().unwrap();
+            assert_eq!(instance.status, CoreInstanceStatus::Completed);
+            assert!(instance.run_label.is_none());
+            assert_eq!(instance.output.as_deref(), Some(b"{}".as_slice()));
+        }
+        {
+            let (p, host, id) = setup().await;
+            host.complete_with_label(
+                b"{}".to_vec(),
+                serde_json::to_vec(&"x".repeat(300)).unwrap(),
+            )
+            .await
+            .unwrap();
+            let instance = p.get_instance(&id).await.unwrap().unwrap();
+            assert_eq!(instance.run_label, Some("x".repeat(250)));
+            assert_eq!(instance.status, CoreInstanceStatus::Completed);
+        }
+        host.complete_with_label(
+            b"{\"result\":1}".to_vec(),
+            br#"" Order/12 [done] ""#.to_vec(),
+        )
+        .await
+        .unwrap();
+        host.complete_with_label(b"{\"result\":2}".to_vec(), br#""replacement""#.to_vec())
+            .await
+            .unwrap();
+        let instance = p.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(instance.status, CoreInstanceStatus::Completed);
+        assert_eq!(instance.run_label.as_deref(), Some("Order/12 [done]"));
+        assert_eq!(
+            instance.output.as_deref(),
+            Some(b"{\"result\":1}".as_slice())
+        );
+
+        let (p, host, id) = setup().await;
+        p.complete_instance(runtara_core::persistence::CompleteInstanceParams::new(
+            &id,
+            CoreInstanceStatus::Cancelled,
+        ))
+        .await
+        .unwrap();
+        host.complete_with_label(b"{}".to_vec(), br#""too late""#.to_vec())
+            .await
+            .unwrap();
+        let instance = p.get_instance(&id).await.unwrap().unwrap();
+        assert_eq!(instance.status, CoreInstanceStatus::Cancelled);
+        assert!(instance.run_label.is_none());
+        assert!(instance.output.is_none());
     }
 
     #[tokio::test]

--- a/crates/runtara-environment/tests/heartbeat_monitor_test.rs
+++ b/crates/runtara-environment/tests/heartbeat_monitor_test.rs
@@ -242,6 +242,7 @@ impl MockPersistence {
         started_at: DateTime<Utc>,
     ) -> Self {
         let record = InstanceRecord {
+            run_label: None,
             instance_id: instance_id.to_string(),
             tenant_id: tenant_id.to_string(),
             definition_version: 1,
@@ -1116,6 +1117,7 @@ async fn test_completed_instance_in_core_not_flagged() {
     let persistence = Arc::new(MockPersistence::new());
     {
         let record = InstanceRecord {
+            run_label: None,
             instance_id: instance_id.clone(),
             tenant_id: tenant_id.clone(),
             definition_version: 1,

--- a/crates/runtara-sdk/src/backend/embedded.rs
+++ b/crates/runtara-sdk/src/backend/embedded.rs
@@ -210,13 +210,19 @@ impl SdkBackend for EmbeddedBackend {
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, output), fields(instance_id = %self.instance_id, output_size = output.len())))]
     fn completed(&self, output: &[u8]) -> Result<()> {
+        self.completed_with_label(output, None)
+    }
+
+    fn completed_with_label(&self, output: &[u8], run_label: Option<&str>) -> Result<()> {
+        let mut params =
+            CompleteInstanceParams::new(&self.instance_id, CoreInstanceStatus::Completed)
+                .if_running()
+                .with_output(output);
+        if let Some(label) = run_label {
+            params = params.with_run_label(label);
+        }
         self.rt
-            .block_on(
-                self.persistence.complete_instance(
-                    CompleteInstanceParams::new(&self.instance_id, CoreInstanceStatus::Completed)
-                        .with_output(output),
-                ),
-            )
+            .block_on(self.persistence.complete_instance(params))
             .map_err(|e| SdkError::Internal(e.to_string()))?;
 
         let event = EventRecord {
@@ -666,6 +672,7 @@ mod tests {
             Ok(instances
                 .get(instance_id)
                 .map(|inst| runtara_core::persistence::InstanceRecord {
+                    run_label: None,
                     instance_id: instance_id.to_string(),
                     tenant_id: inst.tenant_id.clone(),
                     definition_version: 1,

--- a/crates/runtara-sdk/src/backend/http.rs
+++ b/crates/runtara-sdk/src/backend/http.rs
@@ -573,7 +573,11 @@ impl SdkBackend for HttpBackend {
     }
 
     fn completed(&self, output: &[u8]) -> Result<()> {
-        let body = serde_json::json!({ "output": encode_b64(output) });
+        self.completed_with_label(output, None)
+    }
+
+    fn completed_with_label(&self, output: &[u8], run_label: Option<&str>) -> Result<()> {
+        let body = serde_json::json!({ "output": encode_b64(output), "runLabel": run_label });
         let resp: SuccessResp = self.post(&self.url("completed"), &body)?;
 
         if resp.success {

--- a/crates/runtara-sdk/src/backend/mod.rs
+++ b/crates/runtara-sdk/src/backend/mod.rs
@@ -50,6 +50,11 @@ pub trait SdkBackend: Send + Sync {
     /// Send a completed event.
     fn completed(&self, output: &[u8]) -> Result<()>;
 
+    /// Atomically complete with execution label metadata.
+    fn completed_with_label(&self, output: &[u8], _run_label: Option<&str>) -> Result<()> {
+        self.completed(output)
+    }
+
     /// Send a failed event.
     fn failed(&self, error: &str) -> Result<()>;
 

--- a/crates/runtara-sdk/src/client.rs
+++ b/crates/runtara-sdk/src/client.rs
@@ -299,6 +299,11 @@ impl RuntaraSdk {
         self.backend.completed(output)
     }
 
+    /// Complete with an optional label, preserving the output payload.
+    pub fn completed_with_label(&self, output: &[u8], run_label: Option<&str>) -> Result<()> {
+        self.backend.completed_with_label(output, run_label)
+    }
+
     /// Send a failed event with error message.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(instance_id = %self.backend.instance_id())))]
     pub fn failed(&self, error: &str) -> Result<()> {

--- a/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryColumns.tsx
+++ b/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryColumns.tsx
@@ -1,3 +1,4 @@
+import { executionDisplayName } from '@/features/workflows/utils/run-label';
 import { ColumnDef } from '@tanstack/react-table';
 import { Link } from 'react-router';
 import { ExternalLink, Eye, Zap, MessageSquare, Bug } from 'lucide-react';
@@ -56,26 +57,33 @@ export const invocationHistoryColumns: ColumnDef<ExecutionHistoryItem>[] = [
   {
     id: 'workflowId',
     accessorKey: 'workflowName',
-    header: 'Workflow',
+    header: 'Execution',
     enableSorting: false,
     cell: ({ row }) => {
       const workflowId = row.original.workflowId;
-      const workflowName = row.original.workflowName || workflowId;
+      const workflowName = executionDisplayName(row.original);
       const instanceId = row.original.instanceId;
 
       return (
         <div className="flex flex-col gap-0.5">
-          {workflowName ? (
+          {workflowId ? (
             <Link
               to={`/workflows/${workflowId}`}
               className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary"
             >
-              {workflowName}
+              <span className="max-w-80 truncate" title={workflowName}>
+                {workflowName}
+              </span>
               <ExternalLink className="size-3 text-muted-foreground transition-colors group-hover/link:text-primary" />
             </Link>
           ) : (
             <span className="text-sm font-medium italic text-muted-foreground">
-              Ad-hoc invocation
+              {workflowName}
+            </span>
+          )}
+          {row.original.runLabel && row.original.workflowName && (
+            <span className="text-xs text-muted-foreground">
+              {row.original.workflowName}
             </span>
           )}
           <span className="font-mono text-xs text-muted-foreground">

--- a/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryFilters.tsx
+++ b/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryFilters.tsx
@@ -26,6 +26,7 @@ export function countActiveInvocationFilters(
   filters: ExecutionHistoryFilters
 ): number {
   return [
+    filters.runLabel,
     filters.workflowId,
     filters.status,
     filters.createdFrom,
@@ -105,6 +106,26 @@ export function InvocationHistoryFilters({ filters, onFiltersChange }: Props) {
 
   return (
     <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label
+          htmlFor="run-label-filter"
+          className="text-xs text-muted-foreground"
+        >
+          Run label (exact)
+        </Label>
+        <Input
+          id="run-label-filter"
+          value={filters.runLabel ?? ''}
+          maxLength={250}
+          placeholder="All labels"
+          onChange={(e) =>
+            onFiltersChange({
+              ...filters,
+              runLabel: e.target.value || undefined,
+            })
+          }
+        />
+      </div>
       <div className="space-y-1.5">
         <Label className="text-xs text-muted-foreground">Workflow</Label>
         <Select

--- a/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryTable.test.tsx
+++ b/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryTable.test.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutionHistoryFilters } from '../types';
+import { InvocationHistoryTable } from './InvocationHistoryTable';
+
+const query = vi.hoisted(() => vi.fn());
+vi.mock('@/shared/hooks/api', () => ({ useTableQuery: query }));
+vi.mock('../queries', () => ({ getAllExecutions: vi.fn() }));
+vi.mock('./InvocationHistoryColumns', () => ({ invocationHistoryColumns: [] }));
+vi.mock('./InvocationHistoryFilters', () => ({
+  InvocationHistoryFilters: () => null,
+  countActiveInvocationFilters: () => 0,
+}));
+vi.mock('@/shared/components/table', () => ({
+  DataTable: ({ data }: { data: { instanceId: string }[] }) => (
+    <div>
+      {data.map((row) => (
+        <span key={row.instanceId}>{row.instanceId}</span>
+      ))}
+    </div>
+  ),
+}));
+vi.mock('@/shared/components/console', () => ({
+  Breadcrumb: () => null,
+  ConsoleTableShell: ({
+    toolbar,
+    footer,
+    children,
+  }: Record<string, React.ReactNode>) => (
+    <div>
+      {toolbar}
+      {children}
+      {footer}
+    </div>
+  ),
+  ConsoleToolbar: ({ search }: { search: React.ReactNode }) => (
+    <div>{search}</div>
+  ),
+  FilterPopover: () => null,
+  ToolbarSearch: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder: string;
+  }) => (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  ),
+  TableStatusFooter: ({ left, right }: Record<string, React.ReactNode>) => (
+    <div>
+      {left}
+      {right}
+    </div>
+  ),
+  TablePagination: ({
+    pageIndex,
+    onPageChange,
+  }: {
+    pageIndex: number;
+    onPageChange: (page: number) => void;
+  }) => <button onClick={() => onPageChange(pageIndex + 1)}>Next page</button>,
+}));
+
+function Harness() {
+  const [filters, setFilters] = useState<ExecutionHistoryFilters>({
+    sortBy: 'createdAt',
+  });
+  return (
+    <InvocationHistoryTable filters={filters} onFiltersChange={setFilters} />
+  );
+}
+
+describe('execution search pagination', () => {
+  it('sends search in the query key, resets a later page, and trusts the server results and totals', async () => {
+    query.mockImplementation(() => ({
+      data: [{ instanceId: 'server-result' }],
+      totalPages: 8,
+      totalElements: 73,
+      isFetching: false,
+    }));
+    render(<Harness />);
+    fireEvent.click(screen.getByText('Next page'));
+    const params = () => query.mock.lastCall![0].queryKey.at(-1);
+    expect(params().pageIndex).toBe(1);
+    fireEvent.change(screen.getByPlaceholderText('Search executions…'), {
+      target: { value: 'Order/12 [done]' },
+    });
+    await waitFor(() =>
+      expect(params().filters.search).toBe('Order/12 [done]')
+    );
+    expect(params().pageIndex).toBe(0);
+    // No second client-side filter should discard a backend match.
+    expect(screen.getByText('server-result')).toBeInTheDocument();
+    expect(
+      screen.getByText('73 executions · 1 on this page')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Next page'));
+    expect(params().pageIndex).toBe(1);
+    expect(params().filters.search).toBe('Order/12 [done]');
+  });
+  it('restores search when navigation changes the URL filters', async () => {
+    query.mockImplementation(() => ({
+      data: [],
+      totalPages: 0,
+      totalElements: 0,
+      isFetching: false,
+    }));
+    const onFiltersChange = vi.fn();
+    const { rerender } = render(
+      <InvocationHistoryTable
+        filters={{ search: 'First' }}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+    rerender(
+      <InvocationHistoryTable
+        filters={{ search: 'Restored/12' }}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+    expect(screen.getByPlaceholderText('Search executions…')).toHaveValue(
+      'Restored/12'
+    );
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(onFiltersChange).not.toHaveBeenCalled();
+  });
+});

--- a/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryTable.tsx
+++ b/crates/runtara-server/frontend/src/features/invocation-history/components/InvocationHistoryTable.tsx
@@ -14,7 +14,7 @@ import { useTableQuery } from '@/shared/hooks/api';
 import { usePagination } from '@/shared/hooks/usePagination';
 import { queryKeys } from '@/shared/queries/query-keys';
 import { getAllExecutions } from '../queries';
-import { ExecutionHistoryFilters, ExecutionHistoryItem } from '../types';
+import { ExecutionHistoryFilters } from '../types';
 import { invocationHistoryColumns } from './InvocationHistoryColumns';
 import {
   InvocationHistoryFilters,
@@ -38,7 +38,20 @@ export function InvocationHistoryTable({
   onFiltersChange,
 }: InvocationHistoryTableProps) {
   const { pagination, setPagination } = usePagination();
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(filters.search ?? '');
+  useEffect(() => {
+    setSearch(filters.search ?? '');
+  }, [filters.search]);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const nextSearch = search.trim() || undefined;
+      if (nextSearch !== filters.search) {
+        setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+        onFiltersChange({ ...filters, search: nextSearch });
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search, filters, onFiltersChange, setPagination]);
 
   // Convert filters to table sorting state
   const sorting = useMemo<SortingState>(() => {
@@ -46,7 +59,7 @@ export function InvocationHistoryTable({
     return [{ id: filters.sortBy, desc: filters.sortOrder === 'desc' }];
   }, [filters.sortBy, filters.sortOrder]);
 
-  const { data, totalPages, isFetching } = useTableQuery({
+  const { data, totalPages, totalElements, isFetching } = useTableQuery({
     queryKey: queryKeys.executions.list({
       pageIndex: pagination.pageIndex,
       pageSize: pagination.pageSize,
@@ -90,26 +103,7 @@ export function InvocationHistoryTable({
     [filters, onFiltersChange]
   );
 
-  // Client-side quick search over the currently loaded page (mirrors the mockup)
-  const query = search.trim().toLowerCase();
-  const filteredData = useMemo(() => {
-    if (!query) return data;
-    return (data as ExecutionHistoryItem[]).filter((item) =>
-      [
-        item.workflowName,
-        item.workflowId,
-        item.instanceId,
-        item.status,
-        item.version,
-      ]
-        .filter((v) => v !== undefined && v !== null)
-        .some((v) => String(v).toLowerCase().includes(query))
-    );
-  }, [data, query]);
-
-  const footerLeft = query
-    ? `${filteredData.length} match “${search.trim()}” on this page`
-    : `${data.length} on this page`;
+  const footerLeft = `${totalElements} executions · ${data.length} on this page`;
 
   const handlePageChange = (page: number) =>
     setPagination((prev) => ({ ...prev, pageIndex: page }));
@@ -120,6 +114,7 @@ export function InvocationHistoryTable({
   const handleClearFilters = () =>
     onFiltersChange({
       ...filters,
+      runLabel: undefined,
       workflowId: undefined,
       status: undefined,
       createdFrom: undefined,
@@ -137,7 +132,7 @@ export function InvocationHistoryTable({
             <ToolbarSearch
               value={search}
               onChange={setSearch}
-              placeholder="Search this page…"
+              placeholder="Search executions…"
               className="w-56"
             />
           }
@@ -171,7 +166,7 @@ export function InvocationHistoryTable({
     >
       <DataTable
         columns={invocationHistoryColumns}
-        data={filteredData}
+        data={data}
         pagination={{
           ...pagination,
           onPageChange: handlePageChange,

--- a/crates/runtara-server/frontend/src/features/invocation-history/pages/InvocationHistory/index.tsx
+++ b/crates/runtara-server/frontend/src/features/invocation-history/pages/InvocationHistory/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { usePageTitle } from '@/shared/hooks/usePageTitle';
 import { InvocationHistoryTable } from '../../components/InvocationHistoryTable';
@@ -13,7 +13,25 @@ export function InvocationHistory() {
     sortOrder: 'desc',
     workflowId: searchParams.get('workflowId') || undefined,
     status: searchParams.get('status') || undefined,
+    search: searchParams.get('search') || undefined,
+    runLabel: searchParams.get('runLabel') || undefined,
   }));
+
+  useEffect(() => {
+    setFilters((previous) => {
+      const fromUrl = {
+        workflowId: searchParams.get('workflowId') || undefined,
+        status: searchParams.get('status') || undefined,
+        search: searchParams.get('search') || undefined,
+        runLabel: searchParams.get('runLabel') || undefined,
+      };
+      return (Object.keys(fromUrl) as (keyof typeof fromUrl)[]).every(
+        (key) => previous[key] === fromUrl[key]
+      )
+        ? previous
+        : { ...previous, ...fromUrl };
+    });
+  }, [searchParams]);
 
   const handleFiltersChange = (newFilters: ExecutionHistoryFilters) => {
     setFilters(newFilters);
@@ -28,6 +46,10 @@ export function InvocationHistory() {
       params.set('status', newFilters.status);
     } else {
       params.delete('status');
+    }
+    for (const key of ['search', 'runLabel'] as const) {
+      if (newFilters[key]) params.set(key, newFilters[key]);
+      else params.delete(key);
     }
     setSearchParams(params, { replace: true });
   };

--- a/crates/runtara-server/frontend/src/features/invocation-history/queries/index.test.ts
+++ b/crates/runtara-server/frontend/src/features/invocation-history/queries/index.test.ts
@@ -1,0 +1,58 @@
+import { expect, it, vi } from 'vitest';
+import { getAllExecutions } from './index';
+
+const list = vi.hoisted(() => vi.fn());
+vi.mock('@/shared/queries', () => ({
+  RuntimeREST: { api: { listAllExecutionsHandler: list } },
+}));
+vi.mock('@/shared/queries/utils', () => ({ createAuthHeaders: () => ({}) }));
+
+it('forwards search, exact label, and pagination and retains labels and server totals', async () => {
+  list.mockResolvedValue({
+    data: {
+      data: {
+        content: [
+          {
+            id: 'run',
+            workflowId: 'workflow',
+            runLabel: 'Order/12',
+            workflowName: 'Orders',
+            created: '2026-09-07',
+            status: 'completed',
+            usedVersion: 1,
+          },
+        ],
+        number: 2,
+        size: 10,
+        totalElements: 23,
+        totalPages: 3,
+      },
+    },
+  });
+  const result = await getAllExecutions('', {
+    queryKey: [
+      'executions',
+      {
+        pageIndex: 2,
+        pageSize: 10,
+        filters: {
+          search: 'order',
+          runLabel: 'Order/12',
+          workflowId: 'workflow',
+        },
+      },
+    ],
+  });
+  expect(list.mock.calls[0][0]).toMatchObject({
+    page: 2,
+    size: 10,
+    search: 'order',
+    runLabel: 'Order/12',
+    workflowId: 'workflow',
+  });
+  expect(result.content[0]).toMatchObject({
+    runLabel: 'Order/12',
+    workflowName: 'Orders',
+  });
+  expect(result).toMatchObject({ totalElements: 23, totalPages: 3, number: 2 });
+});

--- a/crates/runtara-server/frontend/src/features/invocation-history/queries/index.ts
+++ b/crates/runtara-server/frontend/src/features/invocation-history/queries/index.ts
@@ -33,6 +33,8 @@ export async function getAllExecutions(
     {
       page: pageIndex,
       size: pageSize,
+      search: filters.search || undefined,
+      runLabel: filters.runLabel || undefined,
       workflowId: filters.workflowId || undefined,
       status: filters.status || undefined,
       createdFrom: filters.createdFrom || undefined,
@@ -56,6 +58,7 @@ export async function getAllExecutions(
       instanceId: instance.id,
       workflowId: instance.workflowId,
       workflowName: instance.workflowName ?? undefined,
+      runLabel: instance.runLabel ?? undefined,
       createdAt: instance.created,
       startedAt: instance.started || null,
       completedAt: instance.finished || instance.updated || null,

--- a/crates/runtara-server/frontend/src/features/invocation-history/types/index.ts
+++ b/crates/runtara-server/frontend/src/features/invocation-history/types/index.ts
@@ -14,6 +14,7 @@ export interface ExecutionHistoryItem {
   instanceId: string;
   workflowId: string;
   workflowName?: string;
+  runLabel?: string;
   createdAt: string;
   startedAt?: string | null;
   completedAt?: string | null;
@@ -31,6 +32,8 @@ export interface ExecutionHistoryItem {
  * Filter options for the invocation history table.
  */
 export interface ExecutionHistoryFilters {
+  search?: string;
+  runLabel?: string;
   workflowId?: string;
   status?: string;
   createdFrom?: string;

--- a/crates/runtara-server/frontend/src/features/workflows/components/ValidationPanel/HistoryPanelContent.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/ValidationPanel/HistoryPanelContent.tsx
@@ -206,6 +206,14 @@ export function HistoryPanelContent({ workflowId }: HistoryPanelContentProps) {
                 onClick={() => setSelectedInstanceId(instance.instanceId)}
               >
                 <div className="min-w-0">
+                  {instance.runLabel && (
+                    <div
+                      className="truncate text-xs font-medium"
+                      title={instance.runLabel}
+                    >
+                      {instance.runLabel}
+                    </div>
+                  )}
                   <div className="truncate text-xs font-medium">
                     {formatDate(instance.createdAt)}
                   </div>

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/CustomNodes/utils.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/CustomNodes/utils.test.ts
@@ -54,6 +54,22 @@ function roundTripStep(graph: ExecutionGraphDto & { entryPoint: string }) {
   return (round!.steps as Record<string, any>)[stepId];
 }
 
+describe('Finish runLabel round trip', () => {
+  it.each([
+    undefined,
+    { valueType: 'immediate', value: 'Order/12 [done]' },
+    { valueType: 'reference', value: 'data.order_id', default: 'Unknown' },
+    { valueType: 'template', value: 'Order/{{ data.order_id }}' },
+  ])('preserves label metadata separately from outputs: %j', (runLabel) => {
+    const inputMapping = { result: { valueType: 'immediate', value: 'ok' } };
+    const result = roundTripStep(
+      makeGraph({ id: 'finish', stepType: 'Finish', runLabel, inputMapping })
+    );
+    expect(result.runLabel).toEqual(runLabel);
+    expect(result.inputMapping).toEqual(inputMapping);
+  });
+});
+
 function makeLayoutNode(
   id: string,
   type: NodeTypeId = NODE_TYPES.BasicNode,

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/FinishStepField.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/FinishStepField.tsx
@@ -1,3 +1,4 @@
+import { RunLabelField } from './RunLabelField';
 import { Fragment, useContext, useEffect, useRef, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { SchemaPreview } from '@/features/workflows/components/SchemaPreview';
@@ -227,6 +228,7 @@ export function FinishStepField({ name }: FinishStepFieldProps) {
 
   return (
     <div className="space-y-4">
+      <RunLabelField />
       <div className="flex items-start justify-between gap-2">
         <div>
           <p className="text-sm font-medium">Output configuration</p>

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/NodeFormItem.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/NodeFormItem.tsx
@@ -1,3 +1,4 @@
+import { runLabelSchema } from '@/features/workflows/utils/run-label';
 /* eslint-disable react-refresh/only-export-components */
 // This file exports both components and configuration because the field configs
 // contain JSX (renderFormField, renderComponent) which tightly couples them to components.
@@ -604,6 +605,7 @@ export const schema = () =>
       agentId: z.string().optional(),
       capabilityId: z.string().optional(),
       connectionId: z.string().optional(),
+      runLabel: runLabelSchema.nullable().optional(),
       breakpoint: z.boolean().nullable().optional(),
       durable: z.boolean().nullable().optional(),
       timeout: z.any().optional(),

--- a/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/RunLabelField.tsx
+++ b/crates/runtara-server/frontend/src/features/workflows/components/WorkflowEditor/NodeForm/RunLabelField.tsx
@@ -1,0 +1,68 @@
+import { useContext } from 'react';
+import { useFormContext } from 'react-hook-form';
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/components/ui/form';
+import { MappingValueInput } from './InputMappingField/MappingValueInput';
+import { NodeFormContext } from './NodeFormContext';
+import {
+  MAX_RUN_LABEL_LENGTH,
+  RUN_LABEL_HELP,
+} from '@/features/workflows/utils/run-label';
+
+export function RunLabelField() {
+  const form = useFormContext();
+  const { isInsideSplit, isInsideWhileLoop, isInsideWaitScope } =
+    useContext(NodeFormContext);
+  const valueError = form.getFieldState('runLabel.value', form.formState).error;
+  const labelError = form.getFieldState('runLabel', form.formState).error;
+  if (isInsideSplit || isInsideWhileLoop || isInsideWaitScope) return null;
+
+  return (
+    <FormField
+      control={form.control}
+      name="runLabel"
+      render={({ field }) => {
+        const label = field.value ?? { valueType: 'immediate', value: '' };
+        const labelLength = (
+          typeof label.value === 'string' ? label.value : ''
+        ).replace(/^ +| +$/g, '').length;
+        return (
+          <FormItem>
+            <FormLabel>Run label (optional)</FormLabel>
+            <MappingValueInput
+              fieldName="runLabel"
+              fieldType="string"
+              value={label.value}
+              valueType={label.valueType}
+              modes={['immediate', 'reference', 'template']}
+              placeholder="Order/123 [processed]"
+              onChange={(value) => field.onChange({ ...label, value })}
+              onValueTypeChange={(valueType) =>
+                field.onChange({ valueType, value: '' })
+              }
+              defaultValue={label.default}
+              onDefaultValueChange={(value) =>
+                field.onChange({ ...label, default: value })
+              }
+            />
+            <p className="text-xs text-muted-foreground">{RUN_LABEL_HELP}</p>
+            {label.valueType === 'immediate' && (
+              <p className="text-xs text-muted-foreground">
+                {labelLength}/{MAX_RUN_LABEL_LENGTH}
+                {labelLength > MAX_RUN_LABEL_LENGTH && ' — will be truncated'}
+              </p>
+            )}
+            {labelError?.message && <FormMessage />}
+            {valueError && (
+              <p className="text-sm text-destructive">{valueError.message}</p>
+            )}
+          </FormItem>
+        );
+      }}
+    />
+  );
+}

--- a/crates/runtara-server/frontend/src/features/workflows/utils/run-label.test.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/utils/run-label.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { executionDisplayName, runLabelSchema } from './run-label';
+
+describe('run labels', () => {
+  it('validates literal boundaries and punctuation', () => {
+    for (const value of [
+      null,
+      '',
+      'A',
+      '0',
+      '--[1]/--',
+      'Order/AZ09-1.2 (done) [x]',
+      'x'.repeat(250),
+      'x'.repeat(251),
+      'x'.repeat(500),
+    ]) {
+      expect(
+        runLabelSchema.safeParse({ valueType: 'immediate', value }).success
+      ).toBe(true);
+    }
+    for (const value of [
+      '-'.repeat(250) + 'A',
+      'x_y',
+      '   ',
+      '---',
+      './()[] -',
+      '\u200b',
+      'x\u200by',
+      '\u00a0',
+      '\ufeff',
+      '\u200e',
+      'x%y',
+      'x\\y',
+      'x\ny',
+      '\tx',
+      'é',
+      '🙂',
+      '<x>',
+      123,
+    ]) {
+      expect(
+        runLabelSchema.safeParse({ valueType: 'immediate', value }).success
+      ).toBe(false);
+    }
+  });
+
+  it('accepts references and templates without validating their syntax as literal labels', () => {
+    for (const label of [
+      { valueType: 'reference', value: 'data.order_id', default: 'Unknown' },
+      { valueType: 'template', value: 'Order/{{ data.order_id }}' },
+    ])
+      expect(runLabelSchema.parse(label)).toEqual(label);
+  });
+
+  it('shows the label with existing fallbacks', () => {
+    expect(
+      executionDisplayName({
+        runLabel: 'Order/12',
+        workflowName: 'Orders',
+        workflowId: 'id',
+      })
+    ).toBe('Order/12');
+    expect(
+      executionDisplayName({ runLabel: null, workflowName: 'Orders' })
+    ).toBe('Orders');
+    expect(executionDisplayName({ workflowId: 'id' })).toBe('id');
+    expect(executionDisplayName({})).toBe('Ad-hoc invocation');
+  });
+});

--- a/crates/runtara-server/frontend/src/features/workflows/utils/run-label.ts
+++ b/crates/runtara-server/frontend/src/features/workflows/utils/run-label.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const MAX_RUN_LABEL_LENGTH = 250;
+export const RUN_LABEL_HELP =
+  'Letters A-Z, numbers, spaces, dots, dashes, /, ( ), and [ ]. Must contain at least one letter or digit. Long labels are truncated to 250 characters. Invalid resolved labels are ignored; Finish still completes.';
+
+export const runLabelSchema = z
+  .object({
+    valueType: z.enum(['immediate', 'reference', 'template']),
+    value: z.string().nullable(),
+  })
+  .passthrough()
+  .superRefine((label, ctx) => {
+    if (label.valueType !== 'immediate') {
+      if (!label.value?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Enter a reference or template',
+          path: ['value'],
+        });
+      }
+      return;
+    }
+    const value = (label.value ?? '').replace(/^ +| +$/g, '');
+    if (
+      !/^[A-Za-z0-9 ./()[\]-]*$/.test(value) ||
+      (label.value != null &&
+        label.value !== '' &&
+        !/[A-Za-z0-9]/.test(value.slice(0, MAX_RUN_LABEL_LENGTH)))
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: RUN_LABEL_HELP,
+        path: ['value'],
+      });
+    }
+  });
+
+export function executionDisplayName(run: {
+  runLabel?: string | null;
+  workflowName?: string | null;
+  workflowId?: string | null;
+}) {
+  return (
+    run.runLabel || run.workflowName || run.workflowId || 'Ad-hoc invocation'
+  );
+}

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -2492,6 +2492,11 @@ export interface FinishStep {
   inputMapping?: null | HashMap;
   /** Human-readable step name */
   name?: string | null;
+  /**
+   * Optional execution label, resolved when the top-level Finish completes.
+   * Supports literal strings, references, and templates; at most 250 characters.
+   */
+  runLabel?: null | MappingValue;
 }
 
 /** Workflows held directly at one folder path */
@@ -6145,6 +6150,8 @@ export interface WorkflowInstanceDto {
   processingOverheadSeconds?: number | null;
   /** @format double */
   queueDurationSeconds?: number | null;
+  /** Optional label assigned at successful workflow completion. */
+  runLabel?: string | null;
   /** Current execution status */
   status: ExecutionStatus;
   steps?: WorkflowStepDto[];
@@ -7254,6 +7261,10 @@ export class Api<
      */
     listAllExecutionsHandler: (
       query?: {
+        /** Case-insensitive literal substring search across execution labels and metadata. */
+        search?: string;
+        /** Exact execution label (duplicates are returned). */
+        runLabel?: string;
         /**
          * Page number (0-based, default: 0)
          * @format int32

--- a/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
+++ b/crates/runtara-server/frontend/src/generated/RuntaraRuntimeApi.ts
@@ -2494,7 +2494,17 @@ export interface FinishStep {
   name?: string | null;
   /**
    * Optional execution label, resolved when the top-level Finish completes.
-   * Supports literal strings, references, and templates; at most 250 characters.
+   * Use a MappingValue with valueType immediate, reference, or template.
+   * Separate from inputMapping/output; duplicate labels are allowed.
+   * Allowed characters: ASCII letters, digits, ordinary spaces, . - / ( ) [ ].
+   * Surrounding spaces are trimmed; valid long labels are truncated to 250
+   * characters and trailing spaces removed. The retained label must contain
+   * a letter or digit. Invalid literals fail authoring validation; invalid
+   * dynamic values (including non-strings and evaluation errors) are ignored
+   * without failing Finish or changing its output. Omitted, null, and empty
+   * strings mean no label. Execution lists display runLabel when present,
+   * otherwise the workflow name. Not supported inside Split, While, or onWait
+   * subgraphs; inline child workflows cannot rename their parent execution.
    */
   runLabel?: null | MappingValue;
 }

--- a/crates/runtara-server/src/api/dto/executions.rs
+++ b/crates/runtara-server/src/api/dto/executions.rs
@@ -7,6 +7,11 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct ListAllExecutionsQuery {
+    /// Case-insensitive literal substring search across execution labels and metadata.
+    pub search: Option<String>,
+    /// Exact execution label (duplicates are returned).
+    #[serde(rename = "runLabel")]
+    pub run_label: Option<String>,
     /// Page number (0-based, default: 0)
     #[serde(default)]
     pub page: Option<i32>,
@@ -59,6 +64,8 @@ pub struct ListAllExecutionsResponse {
 /// Filter parameters passed to repository
 #[derive(Debug, Clone)]
 pub struct ExecutionFilters {
+    pub search: Option<String>,
+    pub run_label: Option<String>,
     pub workflow_id: Option<String>,
     pub statuses: Option<Vec<String>>,
     pub created_from: Option<DateTime<Utc>>,
@@ -72,6 +79,8 @@ pub struct ExecutionFilters {
 impl Default for ExecutionFilters {
     fn default() -> Self {
         Self {
+            search: None,
+            run_label: None,
             workflow_id: None,
             statuses: None,
             created_from: None,

--- a/crates/runtara-server/src/api/dto/workflows.rs
+++ b/crates/runtara-server/src/api/dto/workflows.rs
@@ -54,6 +54,12 @@ impl ValidationErrorDto {
         use runtara_workflows::validation::ValidationError;
 
         let (message, step_id, field_name, related_step_ids) = match error {
+            ValidationError::InvalidRunLabel { step_id, message } => (
+                message.clone(),
+                Some(step_id.clone()),
+                Some("runLabel".into()),
+                None,
+            ),
             ValidationError::StepIdMismatch { step_key, .. } => (
                 error.to_string(),
                 Some(step_key.clone()),
@@ -898,6 +904,9 @@ pub struct WorkflowVersionInfoDto {
 #[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct WorkflowInstanceDto {
+    /// Optional label assigned at successful workflow completion.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "runLabel")]
+    pub run_label: Option<String>,
     pub id: String,
     pub created: String,
     pub updated: String,

--- a/crates/runtara-server/src/api/handlers/executions.rs
+++ b/crates/runtara-server/src/api/handlers/executions.rs
@@ -130,7 +130,19 @@ fn parse_filters(query: &ListAllExecutionsQuery) -> Result<ExecutionFilters, Str
         }
     };
 
+    let search = query
+        .search
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    if search.as_ref().is_some_and(|s| s.chars().count() > 250) {
+        return Err("Search must be at most 250 characters".into());
+    }
+    let run_label = runtara_dsl::run_label::normalize_run_label(query.run_label.as_deref())?;
     Ok(ExecutionFilters {
+        search,
+        run_label,
         workflow_id: query.workflow_id.clone(),
         statuses,
         created_from: query.created_from,
@@ -148,6 +160,8 @@ mod tests {
 
     fn query_with_status(status: Option<&str>) -> ListAllExecutionsQuery {
         ListAllExecutionsQuery {
+            search: None,
+            run_label: None,
             page: None,
             size: None,
             workflow_id: None,
@@ -166,6 +180,26 @@ mod tests {
         let filters = parse_filters(&query_with_status(None)).expect("valid query");
 
         assert!(filters.statuses.is_none());
+    }
+
+    #[test]
+    fn run_label_and_search_filters_are_optional_normalized_and_bounded() {
+        let mut query = query_with_status(None);
+        query.search = Some(" Order/12 [done] ".into());
+        query.run_label = Some(" Order/12 [done] ".into());
+        let filters = parse_filters(&query).unwrap();
+        assert_eq!(filters.search.as_deref(), Some("Order/12 [done]"));
+        assert_eq!(filters.run_label.as_deref(), Some("Order/12 [done]"));
+        query.run_label = Some("bad_label".into());
+        assert!(parse_filters(&query).is_err());
+        query.run_label = None;
+        query.search = Some("x".repeat(251));
+        assert!(parse_filters(&query).is_err());
+        query.search = Some("%_\\".into());
+        assert!(
+            parse_filters(&query).is_ok(),
+            "Search punctuation is literal, not label validation"
+        );
     }
 
     #[test]

--- a/crates/runtara-server/src/api/repositories/workflows.rs
+++ b/crates/runtara-server/src/api/repositories/workflows.rs
@@ -2307,6 +2307,29 @@ impl WorkflowRepository {
             .flatten())
     }
 
+    /// Resolve name matches before the runtime database applies pagination.
+    pub async fn workflow_ids_matching_execution_search(
+        &self,
+        tenant_id: &str,
+        search: &str,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        let pattern = format!(
+            "%{}%",
+            search
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_")
+        );
+        sqlx::query_scalar(
+            "SELECT DISTINCT workflow_id FROM workflow_definitions
+             WHERE tenant_id = $1 AND deleted_at IS NULL AND definition->>'name' ILIKE $2",
+        )
+        .bind(tenant_id)
+        .bind(pattern)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     /// Get workflow names for multiple workflow IDs in bulk
     ///
     /// Returns a HashMap mapping workflow_id -> (name, current_version).

--- a/crates/runtara-server/src/core_runtime/http_server.rs
+++ b/crates/runtara-server/src/core_runtime/http_server.rs
@@ -538,6 +538,7 @@ async fn completed_handler(
         }
     };
 
+    let run_label = body.get("runLabel").and_then(Value::as_str);
     let event = HandlerInstanceEvent {
         instance_id,
         event_type: HandlerEventType::EventCompleted as i32,
@@ -547,7 +548,7 @@ async fn completed_handler(
         subtype: None,
     };
 
-    match instance_handlers::handle_instance_event(&state, event).await {
+    match instance_handlers::handle_instance_event_with_run_label(&state, event, run_label).await {
         Ok(_) => Json(SuccessResponse { success: true }).into_response(),
         Err(e) => core_error_response("COMPLETED_ERROR", "Completed handler error", e),
     }

--- a/crates/runtara-server/src/environment_client.rs
+++ b/crates/runtara-server/src/environment_client.rs
@@ -121,6 +121,7 @@ impl EnvironmentClient {
 
         Ok(InstanceInfo {
             instance_id: inst.instance_id,
+            run_label: inst.run_label,
             image_id: inst.image_id.unwrap_or_default(),
             image_name: inst.image_name.unwrap_or_default(),
             tenant_id: inst.tenant_id,
@@ -177,6 +178,7 @@ impl EnvironmentClient {
                 .into_iter()
                 .map(|inst| InstanceSummary {
                     instance_id: inst.instance_id,
+                    run_label: inst.run_label,
                     tenant_id: inst.tenant_id,
                     image_id: inst.image_id.unwrap_or_default(),
                     image_name: inst.image_name.unwrap_or_default(),
@@ -796,6 +798,9 @@ fn list_instances_options(
     options: &ListInstancesOptions,
 ) -> instance_repository::ListInstancesOptions {
     instance_repository::ListInstancesOptions {
+        search: options.search.clone(),
+        run_label: options.run_label.clone(),
+        search_workflow_ids: options.search_workflow_ids.clone(),
         tenant_id: options.tenant_id.clone(),
         statuses: (!options.statuses.is_empty()).then(|| {
             options

--- a/crates/runtara-server/src/mcp/server.rs
+++ b/crates/runtara-server/src/mcp/server.rs
@@ -229,7 +229,9 @@ impl SmoMcpServer {
 
     // ===== Execution Monitoring Tools =====
 
-    #[tool(description = "List execution instances with filtering by workflow, status, and date.")]
+    #[tool(
+        description = "List execution instances with workflow/status filters, case-insensitive literal substring search, and an exact case-sensitive run_label filter. Search and filters apply before pagination and total counting; duplicate labels are allowed. Results include optional runLabel metadata assigned by Finish. Display runLabel when present, otherwise workflowName; use the execution ID to identify a unique run."
+    )]
     async fn list_executions(
         &self,
         params: Parameters<tools::executions::ListExecutionsParams>,
@@ -237,7 +239,9 @@ impl SmoMcpServer {
         tools::executions::list_executions(self, params.0).await
     }
 
-    #[tool(description = "Get execution result including status, outputs, timing, and errors.")]
+    #[tool(
+        description = "Get execution result including status, outputs, timing, errors, and optional runLabel metadata. Finish assigns runLabel separately from outputs on successful completion. Display runLabel when present, otherwise workflowName. Valid long labels are truncated to 250 characters; invalid resolved labels are absent and do not fail Finish. Labels are not unique; identify executions by instance_id."
+    )]
     async fn get_execution(
         &self,
         params: Parameters<tools::executions::GetExecutionParams>,
@@ -1226,6 +1230,7 @@ impl ServerHandler for SmoMcpServer {
                 **References**: Use `steps.<stepId>.outputs.<field>` to reference step outputs (PLURAL `outputs`, not `output`). Use `data.<field>` for workflow inputs. Use `variables.<name>` for variables. A mistyped tail into a known-shape output (e.g. indexing an array output by a name) now fails at preflight_compile and at runtime — it no longer silently resolves to null — so bad references surface instead of producing a green-but-wrong run.\n\
                 **Step output shapes** (each step type's `outputShape` is in get_step_type_schema / list_step_types): Split `outputs` is the collected ARRAY of per-item results (index it as `steps.s.outputs.0`, NOT `.result`; with `dontStopOnFailed` also `steps.s.data.{success,error,...}`, `.stats.*`, `.hasFailures`); Filter `outputs` is `{items, count}` (NOT a bare array — the filtered array is `steps.f.outputs.items`); While `outputs` is `{iterations, outputs}`; Conditional `outputs` is `{result}`; Agent/AiAgent/GroupBy/Switch/EmbedWorkflow outputs are shaped by the capability/data (see get_capability).\n\
                 **inputMapping** (SINGULAR, not inputMappings): Use it only on step types whose schema declares it: `{\"fieldName\": {\"valueType\": \"reference\", \"value\": \"steps.myStep.outputs.items\"}}` or `{\"fieldName\": {\"valueType\": \"immediate\", \"value\": \"literal\"}}`. Call get_step_type_schema for built-in step fields.\n\
+                **Execution labels**: Top-level Finish supports optional `runLabel` as an immediate, reference, or template MappingValue, separate from `inputMapping`. Valid long labels are truncated to 250 characters; invalid dynamic values or label evaluation errors are ignored without failing Finish or changing output. Labels must contain a letter or digit and use only ASCII letters/digits, ordinary spaces, . - / ( ) [ ]; invalid literals fail authoring validation. Labels need not be unique. `list_executions` and `get_execution` return `runLabel`; display it when present, otherwise `workflowName`. Search with `list_executions(search=...)` or exact case-sensitive `run_label=...`; filters apply before pagination and total counting. See `get_workflow_authoring_schema` for normalization rules and examples.\n\
                 **Condition expressions**: `{\"type\": \"operation\", \"op\": \"LT\", \"arguments\": [{\"valueType\": \"reference\", \"value\": \"steps.rng.outputs.value\"}, {\"valueType\": \"immediate\", \"value\": 0.5}]}`.\n\
                 **Edge fields**: Use `fromStep` and `toStep` (not `fromStepId`/`toStepId`) in executionPlan edges.\n\
                 **Conditional routing**: Put the predicate in the Conditional step's `condition` field, then connect outgoing edges with labels `\"true\"` and `\"false\"`. Do not put `condition` on edges from a Conditional step, and do not route those edges via `steps.<conditionalId>.outputs.result`; that boolean is for inspection/later mappings only.\n\

--- a/crates/runtara-server/src/mcp/tools/executions.rs
+++ b/crates/runtara-server/src/mcp/tools/executions.rs
@@ -26,9 +26,13 @@ fn push_query_param(query: &mut Vec<String>, key: &str, value: &str) {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ListExecutionsParams {
-    /// Literal substring search across labels and execution metadata.
+    /// Case-insensitive literal substring search across run labels, workflow names/IDs,
+    /// execution IDs, and statuses. Applied before pagination and total counting;
+    /// punctuation is literal, not a wildcard pattern.
     pub search: Option<String>,
-    /// Exact execution label filter.
+    /// Exact, case-sensitive match on the stored runLabel. Labels are not unique;
+    /// all matches contribute to the filtered total before pagination. Use the
+    /// normalized, possibly truncated label returned by list_executions/get_execution.
     pub run_label: Option<String>,
     #[schemars(description = "Filter by workflow ID")]
     pub workflow_id: Option<String>,

--- a/crates/runtara-server/src/mcp/tools/executions.rs
+++ b/crates/runtara-server/src/mcp/tools/executions.rs
@@ -26,6 +26,10 @@ fn push_query_param(query: &mut Vec<String>, key: &str, value: &str) {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ListExecutionsParams {
+    /// Literal substring search across labels and execution metadata.
+    pub search: Option<String>,
+    /// Exact execution label filter.
+    pub run_label: Option<String>,
     #[schemars(description = "Filter by workflow ID")]
     pub workflow_id: Option<String>,
     #[schemars(
@@ -139,6 +143,12 @@ pub async fn list_executions(
 
 fn list_executions_query_string(params: &ListExecutionsParams) -> String {
     let mut query = Vec::new();
+    if let Some(search) = &params.search {
+        push_query_param(&mut query, "search", search);
+    }
+    if let Some(label) = &params.run_label {
+        push_query_param(&mut query, "runLabel", label);
+    }
     if let Some(sid) = &params.workflow_id {
         push_query_param(&mut query, "workflowId", sid);
     }
@@ -2202,6 +2212,8 @@ mod tests {
     #[test]
     fn list_executions_query_uses_api_parameter_names() {
         let query = list_executions_query_string(&ListExecutionsParams {
+            search: None,
+            run_label: None,
             workflow_id: Some("workflow/needs encoding".to_string()),
             status: Some("running,queued".to_string()),
             page: Some(2),

--- a/crates/runtara-server/src/mcp/tools/workflows.rs
+++ b/crates/runtara-server/src/mcp/tools/workflows.rs
@@ -485,6 +485,29 @@ pub(crate) fn workflow_authoring_schema(agent_id: &str, capability_id: &str) -> 
                 },
                 "discovery": "Call get_step_type_schema for the exact fields accepted by a built-in step type."
             },
+            "Finish": {
+                "optionalFields": ["inputMapping", "runLabel"],
+                "runLabel": {
+                    "purpose": "Optional execution label metadata, separate from inputMapping/output. Use a MappingValue with valueType immediate, reference, or template; do not put runLabel inside inputMapping.",
+                    "scope": "Only top-level Finish may label its execution. Not supported inside Split, While, or onWait subgraphs. Inline child workflows and workflow agent capabilities cannot rename their parent execution.",
+                    "allowedCharacters": "ASCII letters A-Z/a-z, digits 0-9, ordinary spaces, dots, dashes, forward slashes, parentheses, and square brackets.",
+                    "maxStoredLength": runtara_dsl::run_label::MAX_RUN_LABEL_LENGTH,
+                    "normalization": "Trim surrounding ordinary spaces. Truncate valid long labels to 250 characters, then remove trailing spaces. The retained label must contain at least one letter or digit; whitespace-only, punctuation-only, and invisible-character values are invalid.",
+                    "invalidValues": "Invalid literals fail authoring validation. Invalid dynamic values, non-string results, and label evaluation errors are ignored: Finish still completes with its original output and no label. Omitted, null, and empty strings also mean no label.",
+                    "display": "Saved on successful completion as runLabel in list_executions/get_execution responses. Use runLabel as the display title when present, otherwise workflowName. Labels are not unique; identify runs by execution ID.",
+                    "searchAndPagination": "list_executions search is a case-insensitive literal substring search across labels and execution metadata. The MCP run_label parameter is an exact case-sensitive filter on the stored label. Both apply before pagination and total counting, and duplicate labels remain separate results. Use the normalized/truncated stored value for exact matching.",
+                    "listExamples": [
+                        {"search": "order/1042", "page": 0, "size": 10},
+                        {"run_label": "Order/1042 [done]", "page": 0, "size": 10}
+                    ]
+                },
+                "example": {
+                    "id": "finish",
+                    "stepType": "Finish",
+                    "runLabel": {"valueType": "template", "value": "Order/{{ data.orderId }} [done]"},
+                    "inputMapping": {"success": {"valueType": "immediate", "value": true}}
+                }
+            },
             "Error": {
                 "required": ["id", "stepType", "code", "message"],
                 "doesNotAccept": ["inputMapping"],

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -899,6 +899,7 @@ mod classify_observed_status_tests {
     fn info(status: InstanceStatus) -> InstanceInfo {
         let created = Utc::now();
         InstanceInfo {
+            run_label: None,
             instance_id: "inst-1".to_string(),
             image_id: "img-1".to_string(),
             image_name: "wf:1".to_string(),

--- a/crates/runtara-server/src/runtime_types.rs
+++ b/crates/runtara-server/src/runtime_types.rs
@@ -179,6 +179,9 @@ pub struct HealthStatus {
 /// Instance status response with full details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceInfo {
+    /// Optional label assigned at successful workflow completion.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "runLabel")]
+    pub run_label: Option<String>,
     // Identity
     /// Instance ID.
     pub instance_id: String,
@@ -238,6 +241,9 @@ pub struct InstanceInfo {
 /// Summary of an instance (used in list results).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceSummary {
+    /// Optional label assigned at successful workflow completion.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "runLabel")]
+    pub run_label: Option<String>,
     /// Instance ID.
     pub instance_id: String,
     /// Tenant ID.
@@ -410,6 +416,13 @@ impl ListInstancesOrder {
 /// Options for listing instances.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ListInstancesOptions {
+    /// Case-insensitive literal substring search across run metadata.
+    pub search: Option<String>,
+    /// Exact normalized execution label filter.
+    pub run_label: Option<String>,
+    /// Workflow IDs whose names match search, resolved in the server database.
+    #[serde(default)]
+    pub search_workflow_ids: Vec<String>,
     /// Filter by tenant ID.
     pub tenant_id: Option<String>,
     /// Filter by status — an instance matches if it holds any one of these.
@@ -1874,6 +1887,7 @@ mod tests {
     #[test]
     fn test_instance_info_with_metrics() {
         let info = InstanceInfo {
+            run_label: None,
             instance_id: "inst-123".to_string(),
             image_id: "img-456".to_string(),
             image_name: "my-workflow:v1".to_string(),
@@ -1904,6 +1918,7 @@ mod tests {
     #[test]
     fn test_instance_info_without_metrics() {
         let info = InstanceInfo {
+            run_label: None,
             instance_id: "inst-123".to_string(),
             image_id: "img-456".to_string(),
             image_name: "my-workflow:v1".to_string(),
@@ -1934,6 +1949,7 @@ mod tests {
     #[test]
     fn test_instance_info_serde_with_metrics() {
         let info = InstanceInfo {
+            run_label: None,
             instance_id: "inst-123".to_string(),
             image_id: "img-456".to_string(),
             image_name: "workflow".to_string(),
@@ -1971,6 +1987,7 @@ mod tests {
     #[test]
     fn test_instance_info_with_stderr() {
         let info = InstanceInfo {
+            run_label: None,
             instance_id: "inst-123".to_string(),
             image_id: "img-456".to_string(),
             image_name: "my-workflow:v1".to_string(),

--- a/crates/runtara-server/src/workers/execution_engine.rs
+++ b/crates/runtara-server/src/workers/execution_engine.rs
@@ -1874,6 +1874,16 @@ impl ExecutionEngine {
             .with_limit(size as u32)
             .with_offset((page * size) as u32);
 
+        options.search = filters.search.clone();
+        options.run_label = filters.run_label.clone();
+        if let Some(search) = filters.search.as_deref() {
+            options.search_workflow_ids = self
+                .workflow_repo
+                .workflow_ids_matching_execution_search(tenant_id, search)
+                .await
+                .map_err(|e| ExecutionError::DatabaseError(e.to_string()))?;
+        }
+
         if let Some(ref workflow_id) = filters.workflow_id {
             let image_name_prefix = format!("{}:", workflow_id);
             options = options.with_image_name_prefix(&image_name_prefix);

--- a/crates/runtara-server/src/workers/runtara_dto.rs
+++ b/crates/runtara-server/src/workers/runtara_dto.rs
@@ -164,6 +164,7 @@ pub fn runtara_instance_to_dto_with_info(
 
     WorkflowInstanceDto {
         id: inst.instance_id.clone(),
+        run_label: inst.run_label,
         created: inst.created_at.to_rfc3339(),
         updated: inst
             .finished_at
@@ -215,6 +216,7 @@ pub fn runtara_info_to_dto(info: InstanceInfo) -> WorkflowInstanceDto {
 
     WorkflowInstanceDto {
         id: info.instance_id.clone(),
+        run_label: info.run_label.clone(),
         created,
         updated,
         status,
@@ -263,6 +265,7 @@ pub fn runtara_info_to_execution_with_metadata(
 
     let instance = WorkflowInstanceDto {
         id: info.instance_id.clone(),
+        run_label: info.run_label.clone(),
         created,
         updated,
         status,

--- a/crates/runtara-server/tests/core_instance_api.rs
+++ b/crates/runtara-server/tests/core_instance_api.rs
@@ -89,6 +89,81 @@ async fn register(addr: SocketAddr, instance_id: &str, tenant_id: &str) -> u16 {
         .as_u16()
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn run_label_completion_http_validates_and_preserves_output() {
+    use base64::Engine;
+    use runtara_core::domain::InstanceStatus;
+    let persistence: Arc<dyn Persistence> = Arc::new(PostgresPersistence::new(test_pool().await));
+    let (runtime, addr) = start(persistence.clone(), 100).await;
+    let tenant = format!("run-label-{}", Uuid::new_v4());
+    let id = format!("{tenant}-1");
+    assert_eq!(register(addr, &id, &tenant).await, 200);
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/api/v1/instances/{id}/completed");
+    let output = base64::engine::general_purpose::STANDARD.encode(b"{\"result\":42}");
+    for (index, label) in [
+        json!(123),
+        json!({"x":1}),
+        json!("bad_label"),
+        json!("x".repeat(300)),
+        json!("--- ./()[]"),
+        json!("   "),
+        json!("\u{200b}"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let case_id = format!("{tenant}-case-{index}");
+        assert_eq!(register(addr, &case_id, &tenant).await, 200);
+        assert!(
+            client
+                .post(format!(
+                    "http://{addr}/api/v1/instances/{case_id}/completed"
+                ))
+                .json(&json!({"output":output,"runLabel":label}))
+                .send()
+                .await
+                .unwrap()
+                .status()
+                .is_success()
+        );
+        let record = persistence.get_instance(&case_id).await.unwrap().unwrap();
+        assert_eq!(record.status, InstanceStatus::Completed);
+        assert_eq!(
+            record.run_label,
+            if index == 3 {
+                Some("x".repeat(250))
+            } else {
+                None
+            }
+        );
+        assert_eq!(
+            record.output.as_deref(),
+            Some(b"{\"result\":42}".as_slice())
+        );
+    }
+    for label in [" Order/12 [done] ", "replacement"] {
+        assert!(
+            client
+                .post(&url)
+                .json(&json!({"output":output,"runLabel":label}))
+                .send()
+                .await
+                .unwrap()
+                .status()
+                .is_success()
+        );
+    }
+    let record = persistence.get_instance(&id).await.unwrap().unwrap();
+    assert_eq!(record.status, InstanceStatus::Completed);
+    assert_eq!(record.run_label.as_deref(), Some("Order/12 [done]"));
+    assert_eq!(
+        record.output.as_deref(),
+        Some(b"{\"result\":42}".as_slice())
+    );
+    runtime.shutdown().await.unwrap();
+}
+
 /// The cap is enforced by the handlers, not merely accepted by the builder —
 /// and it counts running work only, so parking an instance frees its slot.
 ///

--- a/crates/runtara-store-postgres/migrations/postgresql/025_instance_run_label.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/025_instance_run_label.sql
@@ -1,0 +1,17 @@
+-- Labels belong to an execution and deliberately need not be unique.
+ALTER TABLE instances ADD COLUMN run_label VARCHAR(250);
+ALTER TABLE instances ADD CONSTRAINT valid_run_label CHECK (
+    run_label IS NULL OR (
+        char_length(run_label) BETWEEN 1 AND 250
+        AND run_label = btrim(run_label, ' ')
+        AND run_label COLLATE "C" ~ '[A-Za-z0-9]'
+        AND run_label COLLATE "C" ~ '^[A-Za-z0-9 ./()\[\]-]+$'
+    )
+);
+
+CREATE INDEX idx_instances_tenant_run_label ON instances (tenant_id, run_label)
+    WHERE run_label IS NOT NULL;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_instances_run_label_search ON instances
+    USING gin (run_label gin_trgm_ops) WHERE run_label IS NOT NULL;

--- a/crates/runtara-store-postgres/src/ops_common/ops/instances.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/instances.rs
@@ -125,7 +125,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason, \
+                            created_at, started_at, finished_at, output, run_label, error, sleep_until, wake_reason, \
                             recovery_attempts, recovery_marker \
                      FROM instances \
                      WHERE instance_id = {p1}"
@@ -153,7 +153,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, input, output, error, sleep_until, wake_reason, \
+                            created_at, started_at, finished_at, input, output, run_label, error, sleep_until, wake_reason, \
                             recovery_attempts, recovery_marker \
                      FROM instances \
                      WHERE instance_id = {p1}"
@@ -331,7 +331,7 @@ macro_rules! impl_instance_ops {
             }
 
             /// The one `complete_instance` op: every status transition
-            /// that carries output, error, or termination detail goes
+            /// that carries output, run_label, error, or termination detail goes
             /// through it, shaped by [`CompleteInstanceParams`].
             ///
             /// Semantics:
@@ -355,6 +355,7 @@ macro_rules! impl_instance_ops {
                 pool: &$Pool,
                 params: ::runtara_core::persistence::CompleteInstanceParams<'_>,
             ) -> ::core::result::Result<bool, ::runtara_core::error::CoreError> {
+                let run_label = params.normalized_run_label()?;
                 use ::runtara_core::persistence::CompleteInstanceGuard;
                 use crate::ops_common::error::{RowsAffected, not_found_if_empty};
                 use crate::dialect::{Dialect, EnumKind};
@@ -366,6 +367,7 @@ macro_rules! impl_instance_ops {
                 let p6 = <$Dialect>::placeholder(6);
                 let p7 = <$Dialect>::placeholder(7);
                 let p8 = <$Dialect>::placeholder(8);
+                let p9 = <$Dialect>::placeholder(9);
                 let status_cast = <$Dialect>::enum_cast(EnumKind::InstanceStatus);
                 let term_cast = <$Dialect>::enum_cast(EnumKind::TerminationReason);
                 let now = <$Dialect>::NOW;
@@ -378,7 +380,7 @@ macro_rules! impl_instance_ops {
                      SET status = {p2}{status_cast}, \
                          termination_reason = COALESCE({p3}{term_cast}, termination_reason), \
                          exit_code = COALESCE({p4}, exit_code), \
-                         output = {p5}, \
+                         output = {p5}, run_label = {p9}, \
                          error = {p6}, \
                          stderr = COALESCE({p7}, stderr), \
                          checkpoint_id = COALESCE({p8}, checkpoint_id), \
@@ -397,6 +399,7 @@ macro_rules! impl_instance_ops {
                     .bind(params.error)
                     .bind(params.stderr)
                     .bind(params.checkpoint_id)
+                    .bind(run_label.as_deref())
                     .execute(pool)
                     .await
                     .map_err(|e| ::runtara_core::error::CoreError::PersistenceError {
@@ -464,7 +467,7 @@ macro_rules! impl_instance_ops {
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, exit_code, checkpoint_id, \
                             attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason \
+                            created_at, started_at, finished_at, output, run_label, error, sleep_until, wake_reason \
                      FROM instances \
                      WHERE ({p1} IS NULL OR tenant_id = {p1}) \
                        AND ({p2} IS NULL OR status = {p2}{status_cast}) \

--- a/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
+++ b/crates/runtara-store-postgres/src/ops_common/ops/sleep.rs
@@ -128,7 +128,7 @@ macro_rules! impl_sleep_ops {
                 let sql = format!(
                     "SELECT instance_id, tenant_id, definition_version, \
                             {status_col}, {termination_col}, checkpoint_id, attempt, max_attempts, \
-                            created_at, started_at, finished_at, output, error, sleep_until, wake_reason \
+                            created_at, started_at, finished_at, output, run_label, error, sleep_until, wake_reason \
                      FROM instances \
                      WHERE sleep_until IS NOT NULL \
                        AND {lhs} <= {rhs} \
@@ -196,7 +196,7 @@ macro_rules! impl_sleep_ops {
                      ) \
                      RETURNING instance_id, tenant_id, definition_version, \
                                {status_col}, {termination_col}, checkpoint_id, attempt, max_attempts, \
-                               created_at, started_at, finished_at, output, error, sleep_until, wake_reason"
+                               created_at, started_at, finished_at, output, run_label, error, sleep_until, wake_reason"
                 );
                 let records = ::sqlx::query_as::<_, crate::rows::InstanceRow>(&sql)
                     .bind(limit)

--- a/crates/runtara-store-postgres/src/rows.rs
+++ b/crates/runtara-store-postgres/src/rows.rs
@@ -38,6 +38,7 @@ impl<'r> FromRow<'r, PgRow> for InstanceRow {
             finished_at: row.try_get("finished_at")?,
             input: row.try_get("input").unwrap_or_default(),
             output: row.try_get("output")?,
+            run_label: row.try_get("run_label")?,
             error: row.try_get("error")?,
             sleep_until: row.try_get("sleep_until")?,
             wake_reason: row

--- a/crates/runtara-workflow-runtime/Cargo.toml
+++ b/crates/runtara-workflow-runtime/Cargo.toml
@@ -18,5 +18,6 @@ native = ["runtara-sdk/native"]
 wasi = ["runtara-sdk/wasi"]
 
 [dependencies]
+serde_json = { workspace = true }
 runtara-sdk = { path = "../runtara-sdk", version = "8.9", default-features = false, features = ["http"] }
 wit-bindgen = "0.58"

--- a/crates/runtara-workflow-runtime/src/lib.rs
+++ b/crates/runtara-workflow-runtime/src/lib.rs
@@ -307,6 +307,16 @@ mod component {
             super::complete(&output)
         }
 
+        fn complete_with_label(output: Vec<u8>, run_label: Vec<u8>) -> Result<(), String> {
+            let label = serde_json::from_slice::<Option<String>>(&run_label)
+                .ok()
+                .flatten();
+            super::with_sdk(|sdk| {
+                sdk.completed_with_label(&output, label.as_deref())
+                    .map_err(super::sdk_error)
+            })
+        }
+
         fn fail(error: Vec<u8>) -> Result<(), String> {
             super::fail(&error)
         }

--- a/crates/runtara-workflow-stdlib/Cargo.toml
+++ b/crates/runtara-workflow-stdlib/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 direct-component = ["dep:wit-bindgen"]
 
 [dependencies]
+runtara-dsl = { path = "../runtara-dsl", default-features = false }
 # Export glue for the wasm32-wasip2 component build.
 wit-bindgen = { version = "0.58", optional = true }
 

--- a/crates/runtara-workflow-stdlib/src/direct_json.rs
+++ b/crates/runtara-workflow-stdlib/src/direct_json.rs
@@ -475,9 +475,19 @@ impl DirectJsonManifest {
             .mappings
             .get(&mapping_id)
             .ok_or_else(|| format!("unknown direct mapping id {mapping_id}"))?;
-        let mut output = self
+        let resolved = self
             .compiled_mapping(mapping_id, &mapping.value)
-            .eval(&source)?;
+            .eval(&source);
+        if mapping.purpose == "finish.runLabel" {
+            // A label is optional metadata; even an evaluation failure must not
+            // change the workflow's output or prevent successful completion.
+            let output = resolved.unwrap_or(Value::Null);
+            let label = runtara_dsl::run_label::adopt_run_label(
+                output.get("runLabel").and_then(Value::as_str),
+            );
+            return serde_json::to_vec(&label).map_err(|err| err.to_string());
+        }
+        let mut output = resolved?;
         if mapping.purpose == "finish.inputMapping" {
             output = unwrap_finish_outputs(output);
         }

--- a/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
+++ b/crates/runtara-workflow-wit/wit/runtime/runtara-workflow-runtime.wit
@@ -33,6 +33,10 @@ interface runtime {
 
     complete: func(output: list<u8>) -> result<_, string>;
 
+    /// Additive completion API. run-label is a JSON string or null, separate
+    /// from the unchanged output bytes. Hosts validate it before persistence.
+    complete-with-label: func(output: list<u8>, run-label: list<u8>) -> result<_, string>;
+
     fail: func(error: list<u8>) -> result<_, string>;
 
     custom-event: func(

--- a/crates/runtara-workflows/src/direct_wasm/compile/agent_error.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/agent_error.rs
@@ -585,10 +585,7 @@ fn emit_terminal_run_plan_mapping(
         // suppression (omit-runtime, and AgentCapabilities where the caller
         // owns instance lifecycle).
         if indices.report_terminal_status() {
-            body.instruction(&Instruction::LocalGet(output_ptr_local));
-            body.instruction(&Instruction::LocalGet(output_len_local));
-            push_retptr_arg(body);
-            body.instruction(&Instruction::Call(indices.runtime_complete));
+            super::core_module::emit_complete(body, indices, output_ptr_local, output_len_local);
         }
         match indices.abi {
             crate::direct_wasm::component::WorkflowAbi::CliRunHttp => {

--- a/crates/runtara-workflows/src/direct_wasm/compile/core_imports.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/core_imports.rs
@@ -24,6 +24,7 @@ use super::abi::push_core_type;
 pub(super) struct DirectCoreImportIndices {
     runtime_load_input: Option<u32>,
     runtime_complete: Option<u32>,
+    runtime_complete_with_label: Option<u32>,
     runtime_fail: Option<u32>,
     runtime_custom_event: Option<u32>,
     runtime_debug_mode_enabled: Option<u32>,
@@ -166,12 +167,14 @@ impl DirectCoreImportIndices {
         abi: crate::direct_wasm::component::WorkflowAbi,
         omit_runtime: bool,
         has_connections: bool,
+        has_run_label: bool,
     ) -> Result<DirectCoreFunctionIndices, DirectCompileError> {
         let _stdlib_agent_error_info =
             require_import(self.stdlib_agent_error_info, "stdlib.agent-error-info")?;
         Ok(DirectCoreFunctionIndices {
             abi,
             omit_runtime,
+            has_run_label,
             connection_resolver_describe: require_connection_resolver(
                 self.connection_resolver_describe,
                 has_connections,
@@ -179,6 +182,11 @@ impl DirectCoreImportIndices {
             runtime_load_input: require_runtime(
                 self.runtime_load_input,
                 "runtime.load-input",
+                omit_runtime,
+            )?,
+            runtime_complete_with_label: require_runtime(
+                self.runtime_complete_with_label,
+                "runtime.complete-with-label",
                 omit_runtime,
             )?,
             runtime_complete: require_runtime(
@@ -649,10 +657,12 @@ pub(super) struct DirectCoreFunctionIndices {
     /// return value. Runtime index fields hold a poison sentinel and must never
     /// be called (see [`RUNTIME_OMITTED_POISON`]).
     pub(super) omit_runtime: bool,
+    pub(super) has_run_label: bool,
     pub(super) connection_resolver_describe: u32,
     pub(super) runtime_load_input: u32,
     // (see `report_terminal_status` below for when complete/fail lower)
     pub(super) runtime_complete: u32,
+    pub(super) runtime_complete_with_label: u32,
     pub(super) runtime_fail: u32,
     pub(super) runtime_custom_event: u32,
     pub(super) runtime_debug_mode_enabled: u32,
@@ -964,6 +974,8 @@ pub(super) fn import_core_function(
         import_indices.connection_resolver_describe = Some(function_index);
     } else if is_runtime_import(resolve, interface, function, "load-input") {
         import_indices.runtime_load_input = Some(function_index);
+    } else if is_runtime_import(resolve, interface, function, "complete-with-label") {
+        import_indices.runtime_complete_with_label = Some(function_index);
     } else if is_runtime_import(resolve, interface, function, "complete") {
         import_indices.runtime_complete = Some(function_index);
     } else if is_runtime_import(resolve, interface, function, "fail") {

--- a/crates/runtara-workflows/src/direct_wasm/compile/core_module.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/core_module.rs
@@ -43,6 +43,7 @@ pub(super) struct DirectCoreConfig {
     pub(super) run_plan: DirectRunPlan,
     pub(super) static_data: DirectCoreStaticData,
     pub(super) track_events: bool,
+    pub(super) has_run_label: bool,
     /// Top-level export shape (see `component::WorkflowAbi`). Defaults to the
     /// legacy `wasi:cli/run`; set via [`Self::with_abi`].
     pub(super) abi: crate::direct_wasm::component::WorkflowAbi,
@@ -106,6 +107,11 @@ impl DirectCoreConfig {
         Ok(Self {
             abi: crate::direct_wasm::component::WorkflowAbi::default(),
             omit_runtime: false,
+            has_run_label: manifest
+                .graph
+                .mappings
+                .iter()
+                .any(|mapping| mapping.purpose == "finish.runLabel"),
             run_plan: direct_run_plan(manifest)?,
             static_data: DirectCoreStaticData::new_with_child_workflows(
                 &manifest.graph,
@@ -342,6 +348,7 @@ pub(super) fn emit_direct_core_module(
         config.abi,
         config.omit_runtime,
         config.static_data.has_connections(),
+        config.has_run_label,
     )?;
 
     for (name, export) in &world.exports {
@@ -649,6 +656,8 @@ pub(super) const CANONICAL_LOCAL_GROUPS: &[(u32, ValType)] = &[
     (2, ValType::I64),
     (2, ValType::I32),
     (2, ValType::I64),
+    // 142-143: resolved terminal run label JSON, separate from workflow output.
+    (2, ValType::I32),
 ];
 
 /// Drop `n` leading local slots from `groups`, splitting (never merging) the
@@ -783,10 +792,7 @@ fn direct_run_function(
     // instance, so completing it here would finish the parent mid-flight. The
     // capability return value is the sole terminal result.
     if !config.omit_runtime && !matches!(config.abi, WorkflowAbi::AgentCapabilities) {
-        body.instruction(&Instruction::LocalGet(OUTPUT_PTR_LOCAL));
-        body.instruction(&Instruction::LocalGet(OUTPUT_LEN_LOCAL));
-        push_retptr_arg(&mut body);
-        body.instruction(&Instruction::Call(indices.runtime_complete));
+        emit_complete(&mut body, indices, OUTPUT_PTR_LOCAL, OUTPUT_LEN_LOCAL);
     }
     match config.abi {
         WorkflowAbi::CliRunHttp => {
@@ -804,6 +810,41 @@ fn direct_run_function(
     }
     body.instruction(&Instruction::End);
     body
+}
+
+/// Locals live in the invocation frame; child/loop scratch cannot overwrite them.
+pub(super) const RUN_LABEL_PTR_LOCAL: u32 = 142;
+pub(super) const RUN_LABEL_LEN_LOCAL: u32 = 143;
+
+/// Both normal and handled-error terminal paths use the same completion API.
+pub(super) fn emit_complete(
+    body: &mut WasmFunction,
+    indices: &DirectCoreFunctionIndices,
+    output_ptr: u32,
+    output_len: u32,
+) {
+    if !indices.has_run_label {
+        body.instruction(&Instruction::LocalGet(output_ptr));
+        body.instruction(&Instruction::LocalGet(output_len));
+        push_retptr_arg(body);
+        body.instruction(&Instruction::Call(indices.runtime_complete));
+        return;
+    }
+    body.instruction(&Instruction::LocalGet(RUN_LABEL_LEN_LOCAL));
+    body.instruction(&Instruction::If(BlockType::Empty));
+    body.instruction(&Instruction::LocalGet(output_ptr));
+    body.instruction(&Instruction::LocalGet(output_len));
+    body.instruction(&Instruction::LocalGet(RUN_LABEL_PTR_LOCAL));
+    body.instruction(&Instruction::LocalGet(RUN_LABEL_LEN_LOCAL));
+    push_retptr_arg(body);
+    body.instruction(&Instruction::Call(indices.runtime_complete_with_label));
+    body.instruction(&Instruction::Else);
+    body.instruction(&Instruction::LocalGet(output_ptr));
+    body.instruction(&Instruction::LocalGet(output_len));
+    push_retptr_arg(body);
+    body.instruction(&Instruction::Call(indices.runtime_complete));
+    body.instruction(&Instruction::End);
+    emit_fail_if_retptr_error(body, indices, output_ptr, output_len);
 }
 
 /// Write `Ok(outcome::completed(output))` for the invoke export into the

--- a/crates/runtara-workflows/src/direct_wasm/compile/dispatcher.rs
+++ b/crates/runtara-workflows/src/direct_wasm/compile/dispatcher.rs
@@ -62,6 +62,7 @@ pub(super) fn emit_run_plan_mapping(
         DirectRunPlan::Finish {
             step_id,
             mapping_id,
+            run_label_mapping_id,
             breakpoint,
         } => {
             emit_step_debug_event(
@@ -91,6 +92,23 @@ pub(super) fn emit_run_plan_mapping(
                 route_len_local,
                 failure_target,
             );
+            if let Some(label_mapping_id) = run_label_mapping_id {
+                emit_apply_mapping_step_error(
+                    body,
+                    indices,
+                    static_data,
+                    track_events,
+                    *label_mapping_id,
+                    step_id,
+                    source_ptr_local,
+                    source_len_local,
+                    super::core_module::RUN_LABEL_PTR_LOCAL,
+                    super::core_module::RUN_LABEL_LEN_LOCAL,
+                    route_ptr_local,
+                    route_len_local,
+                    failure_target,
+                );
+            }
             emit_step_breakpoint(
                 body,
                 indices,

--- a/crates/runtara-workflows/src/direct_wasm/manifest.rs
+++ b/crates/runtara-workflows/src/direct_wasm/manifest.rs
@@ -480,6 +480,8 @@ pub struct DirectEdgeManifest {
 /// Errors returned while building or serializing a direct workflow manifest.
 #[derive(Debug)]
 pub enum DirectManifestError {
+    /// A label declaration has invalid value or scope.
+    InvalidRunLabel(String),
     /// A DSL map key and the step's declared ID disagree.
     StepIdMismatch {
         /// JSON pointer to the graph containing this step; empty for the root.
@@ -503,6 +505,7 @@ impl fmt::Display for DirectManifestError {
             } => {
                 write!(f, "{}", identity_message(graph_path, step_key, step_id))
             }
+            DirectManifestError::InvalidRunLabel(message) => write!(f, "{message}"),
             DirectManifestError::Serialize(err) => {
                 write!(f, "failed to serialize direct workflow manifest: {err}")
             }
@@ -534,6 +537,12 @@ pub fn build_direct_workflow_manifest_with_child_workflows_and_agent_catalog(
     child_workflows: &[DirectManifestChildWorkflowInput<'_>],
     agent_catalog: Option<&AgentCatalog>,
 ) -> Result<DirectWorkflowManifest, DirectManifestError> {
+    for candidate in std::iter::once(graph).chain(child_workflows.iter().map(|c| c.execution_graph))
+    {
+        if let Some(error) = crate::validation::run_label_errors(candidate).first() {
+            return Err(DirectManifestError::InvalidRunLabel(error.to_string()));
+        }
+    }
     let mut mismatches = identity_mismatches(graph, "");
     for (index, child) in child_workflows.iter().enumerate() {
         mismatches.extend(identity_mismatches(
@@ -582,12 +591,17 @@ pub fn build_direct_workflow_manifest_with_child_workflows_and_agent_catalog(
         .into_iter()
         .map(|child| {
             let child_durable = child.execution_graph.durable.unwrap_or(true);
-            let graph = graph_manifest(
+            let mut graph = graph_manifest(
                 child.execution_graph,
                 child_durable,
                 &mut state,
                 agent_catalog,
             )?;
+            // Inline children share the parent's instance; their standalone label
+            // declaration must never assign metadata to that parent execution.
+            graph
+                .mappings
+                .retain(|mapping| mapping.purpose != "finish.runLabel");
             Ok(DirectChildWorkflowGraphManifest {
                 step_id: child.step_id.to_string(),
                 workflow_id: child.workflow_id.to_string(),
@@ -805,6 +819,15 @@ fn step_manifest(
     let mut nested_graphs = Vec::new();
     match step {
         Step::Finish(step) => {
+            if let Some(label) = &step.run_label {
+                collections.mappings.push(DirectMappingManifest {
+                    id: state.allocate_mapping_id(),
+                    step_id: step.id.clone(),
+                    step_type: "Finish".into(),
+                    purpose: "finish.runLabel".into(),
+                    value: serde_json::json!({"runLabel": label}),
+                });
+            }
             let value = step
                 .input_mapping
                 .as_ref()

--- a/crates/runtara-workflows/src/direct_wasm/plan.rs
+++ b/crates/runtara-workflows/src/direct_wasm/plan.rs
@@ -37,6 +37,7 @@ pub(super) enum DirectRunPlan {
     Finish {
         step_id: String,
         mapping_id: u32,
+        run_label_mapping_id: Option<u32>,
         breakpoint: bool,
     },
     Filter {
@@ -543,6 +544,11 @@ fn step_run_plan_inner(
         "Finish" => Ok(DirectRunPlan::Finish {
             step_id: step_id.to_string(),
             mapping_id: finish_mapping_id(graph, step_id)?,
+            run_label_mapping_id: graph
+                .mappings
+                .iter()
+                .find(|m| m.step_id == step_id && m.purpose == "finish.runLabel")
+                .map(|m| m.id),
             breakpoint: step_breakpoint_enabled(graph, step),
         }),
         "Filter" => {

--- a/crates/runtara-workflows/src/validation.rs
+++ b/crates/runtara-workflows/src/validation.rs
@@ -128,6 +128,8 @@ impl ValidationResult {
 #[derive(Debug, Clone)]
 #[allow(missing_docs)] // Fields are self-documenting from variant docs
 pub enum ValidationError {
+    /// Invalid value or scope for an optional execution label.
+    InvalidRunLabel { step_id: String, message: String },
     // === Graph Structure Errors ===
     /// A map key disagrees with the step's inner ID. Enforcing equality also
     /// guarantees unique IDs within each graph, since map keys are unique.
@@ -479,6 +481,7 @@ impl ValidationError {
     /// rendered text and the structured code can never disagree.
     pub fn code(&self) -> &'static str {
         match self {
+            Self::InvalidRunLabel { .. } => "E131",
             Self::EntryPointNotFound { .. } => "E001",
             Self::UnreachableStep { .. } => "E002",
             Self::UnreachableFinish { .. } => "E003",
@@ -537,6 +540,9 @@ impl ValidationError {
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            ValidationError::InvalidRunLabel { step_id, message } => {
+                write!(f, "[E131] Finish '{step_id}' runLabel: {message}")
+            }
             ValidationError::StepIdMismatch {
                 graph_path,
                 step_key,
@@ -1518,6 +1524,8 @@ pub fn validate_workflow(
             }),
     );
 
+    result.errors.extend(run_label_errors(graph));
+
     // Phase 1: Graph structure validation
     validate_graph_structure(graph, &mut result);
 
@@ -2345,6 +2353,7 @@ fn validate_references_with_inherited(
         let connection_ref = match step {
             Step::Agent(agent_step) => agent_step.connection_ref.as_ref(),
             Step::AiAgent(ai_step) => ai_step.connection_ref.as_ref(),
+            Step::Finish(finish) => finish.run_label.as_ref(),
             _ => None,
         };
         if let Some(value) = connection_ref {
@@ -2630,6 +2639,55 @@ fn validate_step_output_reference(
     }
 }
 
+/// Validate every label declaration, even in unreachable nested graphs.
+pub(crate) fn run_label_errors(graph: &ExecutionGraph) -> Vec<ValidationError> {
+    fn visit(graph: &ExecutionGraph, nested: bool, errors: &mut Vec<ValidationError>) {
+        for (id, step) in &graph.steps {
+            match step {
+                Step::Finish(finish) => {
+                    if let Some(label) = &finish.run_label {
+                        let error = if nested {
+                            Some("Run labels are only allowed on a Finish ending the workflow execution".into())
+                        } else {
+                            match label {
+                                MappingValue::Immediate(value) => match &value.value {
+                                    serde_json::Value::Null => None,
+                                    serde_json::Value::String(label) => {
+                                        runtara_dsl::run_label::normalize_run_label(Some(label))
+                                            .err()
+                                    }
+                                    _ => Some("Run label must be a string or null".into()),
+                                },
+                                MappingValue::Composite(_) => Some(
+                                    "Run label must be a string, reference, or template".into(),
+                                ),
+                                _ => None,
+                            }
+                        };
+                        if let Some(message) = error {
+                            errors.push(ValidationError::InvalidRunLabel {
+                                step_id: id.clone(),
+                                message,
+                            });
+                        }
+                    }
+                }
+                Step::Split(step) => visit(&step.subgraph, true, errors),
+                Step::While(step) => visit(&step.subgraph, true, errors),
+                Step::WaitForSignal(step) => {
+                    if let Some(graph) = &step.on_wait {
+                        visit(graph, true, errors);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut errors = Vec::new();
+    visit(graph, false, &mut errors);
+    errors
+}
+
 /// Collect all input mappings from a step.
 fn collect_step_mappings(step: &Step) -> Vec<&InputMapping> {
     let mut mappings = Vec::new();
@@ -2702,6 +2760,21 @@ fn validate_execution_order(graph: &ExecutionGraph, result: &mut ValidationResul
 
     // Check each step's references
     for (step_id, step) in &graph.steps {
+        if let Step::Finish(finish) = step
+            && let Some(label) = &finish.run_label
+        {
+            for referenced_step_id in extract_step_ids_from_mapping_value(label) {
+                if referenced_step_id != *step_id
+                    && graph.steps.contains_key(&referenced_step_id)
+                    && !has_path(&adjacency, &referenced_step_id, step_id)
+                {
+                    result.errors.push(ValidationError::StepNotYetExecuted {
+                        step_id: step_id.clone(),
+                        referenced_step_id,
+                    });
+                }
+            }
+        }
         let mappings = collect_step_mappings(step);
 
         for mapping in mappings {
@@ -5444,6 +5517,9 @@ fn collect_references_from_step(step: &Step) -> Vec<String> {
             if let Some(ref outputs) = finish_step.input_mapping {
                 extract_references_from_input_mapping(outputs, &mut refs);
             }
+            if let Some(label) = &finish_step.run_label {
+                extract_references_from_mapping_value(label, &mut refs);
+            }
         }
         Step::Log(log_step) => {
             if let Some(ref context) = log_step.context {
@@ -5564,6 +5640,9 @@ fn collect_template_static_references_from_step(step: &Step) -> Vec<String> {
         Step::Finish(finish_step) => {
             if let Some(ref outputs) = finish_step.input_mapping {
                 extract_template_static_references_from_input_mapping(outputs, &mut refs);
+            }
+            if let Some(label) = &finish_step.run_label {
+                extract_template_static_references_from_mapping_value(label, &mut refs);
             }
         }
         Step::Log(log_step) => {
@@ -6025,6 +6104,7 @@ mod tests {
 
     fn create_finish_step(id: &str, mapping: Option<InputMapping>) -> Step {
         Step::Finish(FinishStep {
+            run_label: None,
             id: id.to_string(),
             name: None,
             input_mapping: mapping,
@@ -7331,6 +7411,7 @@ mod tests {
         sub_steps.insert(
             "finish_iter".to_string(),
             Step::Finish(runtara_dsl::FinishStep {
+                run_label: None,
                 id: "finish_iter".to_string(),
                 name: None,
                 input_mapping: None,
@@ -7377,6 +7458,7 @@ mod tests {
         top_steps.insert(
             "finish".to_string(),
             Step::Finish(runtara_dsl::FinishStep {
+                run_label: None,
                 id: "finish".to_string(),
                 name: None,
                 input_mapping: None,

--- a/crates/runtara-workflows/src/workflow_features.rs
+++ b/crates/runtara-workflows/src/workflow_features.rs
@@ -29,6 +29,8 @@ pub struct ChildWorkflowReference {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum WorkflowFeature {
+    /// A Finish assigns persistent execution metadata.
+    RunLabel,
     /// A workflow step invokes an agent capability.
     AgentCall,
     /// A workflow step runs an AI-agent loop.
@@ -120,7 +122,8 @@ impl WorkflowFeatureSummary {
         self.features.iter().any(|feature| {
             matches!(
                 feature,
-                WorkflowFeature::AgentCall
+                WorkflowFeature::RunLabel
+                    | WorkflowFeature::AgentCall
                     | WorkflowFeature::AiAgent
                     | WorkflowFeature::ChildWorkflow
                     | WorkflowFeature::LogEvent
@@ -158,7 +161,8 @@ impl WorkflowFeatureSummary {
         self.features.iter().any(|feature| {
             matches!(
                 feature,
-                WorkflowFeature::AgentCall
+                WorkflowFeature::RunLabel
+                    | WorkflowFeature::AgentCall
                     | WorkflowFeature::AiAgent
                     | WorkflowFeature::ChildWorkflow
                     | WorkflowFeature::LogEvent
@@ -292,7 +296,11 @@ impl FeatureAnalyzer {
         }
 
         match step {
-            Step::Finish(_) => {}
+            Step::Finish(step) => {
+                if step.run_label.is_some() {
+                    self.summary.features.insert(WorkflowFeature::RunLabel);
+                }
+            }
             Step::Agent(step) => {
                 self.summary.features.insert(WorkflowFeature::AgentCall);
                 self.agent_ids.insert(canonicalize_agent_id(&step.agent_id));

--- a/crates/runtara-workflows/tests/direct_wasm_execute.rs
+++ b/crates/runtara-workflows/tests/direct_wasm_execute.rs
@@ -7394,6 +7394,7 @@ struct CheckpointingRuntimeHost {
     advance_clock_on_step_end: Mutex<Option<(String, u64)>>,
     checkpoints: Mutex<HashMap<String, Vec<u8>>>,
     completed: Mutex<Option<Vec<u8>>>,
+    run_label: Mutex<Option<String>>,
     sleeps: Mutex<Vec<String>>,
     /// Externally-delivered custom signals keyed by checkpoint (signal) id —
     /// the wake-scheduler-side signal store. `poll_custom_signal` reads it
@@ -7434,6 +7435,7 @@ impl CheckpointingRuntimeHost {
             advance_clock_on_step_end: Mutex::new(None),
             checkpoints: Mutex::new(HashMap::new()),
             completed: Mutex::new(None),
+            run_label: Mutex::new(None),
             sleeps: Mutex::new(Vec::new()),
             custom_signals: Mutex::new(HashMap::new()),
             clock_offset_ms: Mutex::new(0),
@@ -7515,6 +7517,11 @@ impl runtara_component_host::runtime_host::RuntimeHost for CheckpointingRuntimeH
     async fn complete(&self, output: Vec<u8>) -> Result<(), String> {
         *self.completed.lock().unwrap() = Some(output);
         Ok(())
+    }
+    async fn complete_with_label(&self, output: Vec<u8>, run_label: Vec<u8>) -> Result<(), String> {
+        *self.run_label.lock().unwrap() =
+            serde_json::from_slice(&run_label).map_err(|e| e.to_string())?;
+        self.complete(output).await
     }
     async fn fail(&self, error: Vec<u8>) -> Result<(), String> {
         *self.failed.lock().unwrap() = Some(error);

--- a/crates/runtara-workflows/tests/run_label.rs
+++ b/crates/runtara-workflows/tests/run_label.rs
@@ -1,0 +1,167 @@
+// Copyright (C) 2025 SyncMyOrders Sp. z o.o.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#![cfg(feature = "compiler")]
+
+use runtara_dsl::{ExecutionGraph, agent_meta::AgentCatalog};
+use runtara_workflow_stdlib::direct_json::DirectJsonManifest;
+use runtara_workflows::{
+    direct_wasm::build_direct_workflow_manifest, validation::validate_workflow,
+};
+use serde_json::{Value, json};
+
+fn graph(label: Value) -> ExecutionGraph {
+    serde_json::from_value(json!({
+        "entryPoint":"finish", "durable":false,
+        "steps":{"finish":{"id":"finish", "stepType":"Finish", "runLabel":label,
+            "inputMapping":{"result":{"valueType":"immediate", "value":42}}}}
+    }))
+    .unwrap()
+}
+
+#[test]
+fn run_label_mapping_is_separate_validated_and_optional() {
+    for (label, source, expected) in [
+        (
+            json!({"valueType":"immediate","value":" Order/12 [done] "}),
+            json!({}),
+            json!("Order/12 [done]"),
+        ),
+        (
+            json!({"valueType":"reference","value":"data.label"}),
+            json!({"data":{"label":"Job-1.2 (done)"}}),
+            json!("Job-1.2 (done)"),
+        ),
+        (
+            json!({"valueType":"template","value":"Order/{{ data.id }}"}),
+            json!({"data":{"id":123}}),
+            json!("Order/123"),
+        ),
+        (
+            json!({"valueType":"reference","value":"data.label"}),
+            json!({"data":{}}),
+            Value::Null,
+        ),
+        (
+            json!({"valueType":"immediate","value":""}),
+            json!({}),
+            Value::Null,
+        ),
+        (
+            json!({"valueType":"immediate","value":"x".repeat(251)}),
+            json!({}),
+            json!("x".repeat(250)),
+        ),
+        (
+            json!({"valueType":"reference","value":"data.label"}),
+            json!({"data":{"label":"x".repeat(500)}}),
+            json!("x".repeat(250)),
+        ),
+        (
+            json!({"valueType":"template","value":"{{"}),
+            json!({}),
+            Value::Null,
+        ),
+    ] {
+        let manifest = build_direct_workflow_manifest(&graph(label)).unwrap();
+        let runtime = DirectJsonManifest::parse(&manifest.to_canonical_json().unwrap()).unwrap();
+        let mapping = manifest
+            .graph
+            .mappings
+            .iter()
+            .find(|m| m.purpose == "finish.runLabel")
+            .unwrap();
+        let resolved = runtime
+            .apply_mapping(mapping.id, &serde_json::to_vec(&source).unwrap())
+            .unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&resolved).unwrap(),
+            expected
+        );
+        let outputs = manifest
+            .graph
+            .mappings
+            .iter()
+            .find(|m| m.purpose == "finish.inputMapping")
+            .unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&runtime.apply_mapping(outputs.id, b"{}").unwrap())
+                .unwrap(),
+            json!({"result":42})
+        );
+        assert!(manifest.feature_summary.needs_runtime(false));
+    }
+    let manifest = build_direct_workflow_manifest(&graph(
+        json!({"valueType":"reference","value":"data.label"}),
+    ))
+    .unwrap();
+    let runtime = DirectJsonManifest::parse(&manifest.to_canonical_json().unwrap()).unwrap();
+    let id = manifest
+        .graph
+        .mappings
+        .iter()
+        .find(|m| m.purpose == "finish.runLabel")
+        .unwrap()
+        .id;
+    for value in [
+        json!(123),
+        json!(true),
+        json!({}),
+        json!([]),
+        json!("bad_label"),
+        json!("   "),
+        json!("--- ./()[]"),
+        json!("\u{200b}"),
+    ] {
+        let output = runtime
+            .apply_mapping(
+                id,
+                &serde_json::to_vec(&json!({"data":{"label":value}})).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output).unwrap(),
+            Value::Null
+        );
+    }
+}
+
+#[test]
+fn run_label_static_validation_covers_value_scope_and_references() {
+    for value in [
+        json!(12),
+        json!("bad_label"),
+        json!("   "),
+        json!("--- ./()[]"),
+        json!("\u{200b}"),
+    ] {
+        let g = graph(json!({"valueType":"immediate","value":value}));
+        assert!(
+            validate_workflow(&g, &AgentCatalog::default())
+                .errors
+                .iter()
+                .any(|e| e.code() == "E131")
+        );
+        assert!(build_direct_workflow_manifest(&g).is_err());
+    }
+    let g = graph(json!({"valueType":"reference","value":"steps.missing.outputs.label"}));
+    assert!(
+        validate_workflow(&g, &AgentCatalog::default())
+            .errors
+            .iter()
+            .any(|e| e.code() == "E010")
+    );
+    let child = graph(json!({"valueType":"immediate","value":"child"}));
+    let g: ExecutionGraph = serde_json::from_value(json!({
+        "entryPoint":"loop", "steps":{
+            "loop":{"id":"loop","stepType":"While","condition":{"type":"operation","op":"EQ","arguments":[{"valueType":"immediate","value":true},{"valueType":"immediate","value":true}]},"config":{"maxIterations":1},"subgraph":child},
+            "finish":{"id":"finish","stepType":"Finish"}
+        },"executionPlan":[{"fromStep":"loop","toStep":"finish"}]
+    })).unwrap();
+    assert!(
+        validate_workflow(&g, &AgentCatalog::default())
+            .errors
+            .iter()
+            .any(|e| e.code() == "E131")
+    );
+    assert!(build_direct_workflow_manifest(&g).is_err());
+}

--- a/crates/runtara-workflows/tests/wasm_emitter_audit/execution.rs
+++ b/crates/runtara-workflows/tests/wasm_emitter_audit/execution.rs
@@ -108,6 +108,152 @@ fn run(id: &str, graph: Value) -> Value {
     ))
 }
 
+#[test]
+fn run_label_is_persisted_by_compiled_finish_without_changing_output() {
+    let mut graph = early_finish_graph(true, true);
+    graph["steps"]["early"]["runLabel"] =
+        json!({"valueType":"template","value":"Order/{{ 12 }} [done]"});
+    graph["steps"]["merge"]["runLabel"] = immediate(json!("unreached"));
+    let (_temp, artifact) = compile("run-label-branch", graph);
+    let host = Arc::new(CheckpointingRuntimeHost::new(b"{}"));
+    let output = completed(run_invoke_once(
+        &artifact.wasm_path,
+        host.clone(),
+        b"{}".to_vec(),
+    ));
+    assert_eq!(output, json!({"result":"early"}));
+    assert_eq!(
+        host.run_label.lock().unwrap().as_deref(),
+        Some("Order/12 [done]")
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(host.completed.lock().unwrap().as_ref().unwrap()).unwrap(),
+        output
+    );
+}
+
+#[test]
+fn run_label_invalid_dynamic_value_is_ignored_without_changing_output() {
+    for template in ["invalid_{{ 12 }}", "--- ./()[]", "   ", "\u{200b}"] {
+        let mut graph = early_finish_graph(true, true);
+        graph["steps"]["early"]["runLabel"] = json!({"valueType":"template","value":template});
+        let (_temp, artifact) = compile("run-label-invalid", graph);
+        let host = Arc::new(CheckpointingRuntimeHost::new(b"{}"));
+        assert_eq!(
+            completed(run_invoke_once(
+                &artifact.wasm_path,
+                host.clone(),
+                b"{}".to_vec()
+            )),
+            json!({"result":"early"})
+        );
+        assert_eq!(
+            serde_json::from_slice::<Value>(host.completed.lock().unwrap().as_ref().unwrap())
+                .unwrap(),
+            json!({"result":"early"})
+        );
+        assert!(host.run_label.lock().unwrap().is_none());
+        assert!(host.failed.lock().unwrap().is_none());
+    }
+}
+
+#[test]
+fn run_label_in_inline_child_does_not_rename_parent() {
+    let child: ExecutionGraph = serde_json::from_value(json!({"entryPoint":"finish","steps":{
+        "finish":{"id":"finish","stepType":"Finish","runLabel":immediate(json!("child")),"inputMapping":{"ok":immediate(json!(true))}}
+    }})).unwrap();
+    let root = json!({"entryPoint":"child","steps":{
+        "child":{"id":"child","stepType":"EmbedWorkflow","childWorkflowId":"child","childVersion":1},
+        "finish":finish("finish")
+    },"executionPlan":[{"fromStep":"child","toStep":"finish"}]});
+    let (_temp, artifact) = compile_with_children(
+        "run-label-parent",
+        root,
+        vec![ChildWorkflowInput {
+            step_id: "child".into(),
+            workflow_id: "child".into(),
+            version_requested: "1".into(),
+            version_resolved: 1,
+            execution_graph: child,
+        }],
+    );
+    let host = Arc::new(CheckpointingRuntimeHost::new(b"{}"));
+    assert_eq!(
+        completed(run_invoke_once(
+            &artifact.wasm_path,
+            host.clone(),
+            b"{}".to_vec()
+        )),
+        json!({"ok":true})
+    );
+    assert!(host.run_label.lock().unwrap().is_none());
+}
+
+#[test]
+fn run_label_resolves_after_resume_and_empty_or_null_remain_unlabelled() {
+    for (value, expected) in [
+        (json!(" Resumed/42 "), Some("Resumed/42".to_string())),
+        (json!("x".repeat(300)), Some("x".repeat(250))),
+        (json!("---"), None),
+        (json!(42), None),
+        (json!({"x":1}), None),
+        (json!("   "), None),
+        (json!(""), None),
+        (Value::Null, None),
+    ] {
+        let graph = json!({"entryPoint":"delay","inputSchema":{"label":{"type":"string","nullable":true}},"steps":{
+            "delay":{"id":"delay","stepType":"Delay","durationMs":immediate(json!(60_000))},
+            "finish":{"id":"finish","stepType":"Finish","runLabel":{"valueType":"reference","value":"data.label"},"inputMapping":{"ok":immediate(json!(true))}}
+        },"executionPlan":[{"fromStep":"delay","toStep":"finish"}]});
+        let (_temp, artifact) = compile("run-label-resume", graph);
+        let host = audit_deadline_host(1_000_000);
+        let input = serde_json::to_vec(&json!({"label":value})).unwrap();
+        assert_at(
+            run_invoke_once(&artifact.wasm_path, host.clone(), input.clone()),
+            1_060_000,
+        );
+        assert!(host.run_label.lock().unwrap().is_none());
+        assert!(host.completed.lock().unwrap().is_none());
+        *host.pinned_clock_ms.lock().unwrap() = Some(1_060_001);
+        assert_eq!(
+            completed(run_invoke_once(&artifact.wasm_path, host.clone(), input)),
+            json!({"ok":true})
+        );
+        assert_eq!(*host.run_label.lock().unwrap(), expected);
+    }
+}
+
+#[test]
+fn run_label_on_error_handler_finish_completes_the_execution() {
+    let mut graph = timeout_graph(60_000, false);
+    graph["executionPlan"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({"fromStep":"loop","toStep":"recovered","label":"onError"}));
+    graph["steps"]["recovered"] = finish("recovered");
+    graph["steps"]["recovered"]["runLabel"] = immediate(json!("Timeout (recovered)"));
+    let (_temp, artifact) = compile("run-label-recovery", graph);
+    let host = audit_deadline_host(1_000_000);
+    assert_at(
+        run_invoke_once(&artifact.wasm_path, host.clone(), b"{}".to_vec()),
+        1_001_000,
+    );
+    *host.pinned_clock_ms.lock().unwrap() = Some(1_001_000);
+    assert_eq!(
+        completed(run_invoke_once(
+            &artifact.wasm_path,
+            host.clone(),
+            b"{}".to_vec()
+        )),
+        json!({"ok":true})
+    );
+    assert_eq!(
+        host.run_label.lock().unwrap().as_deref(),
+        Some("Timeout (recovered)")
+    );
+    assert!(host.failed.lock().unwrap().is_none());
+}
+
 fn early_finish_graph(outer: bool, inner: bool) -> Value {
     json!({"entryPoint": "outer", "steps": {
         "outer": {"id": "outer", "stepType": "Conditional", "condition": condition(outer)},


### PR DESCRIPTION
## Description

Add optional `runLabel` metadata to top-level Finish steps so users can identify workflow executions by a meaningful label instead of the workflow name. Labels support literals, references, and templates, remain separate from workflow output, and do not need to be unique.

- Accept ASCII letters and digits, ordinary spaces, `.`, `-`, `/`, `(`, `)`, `[` and `]`, with at least one letter or digit. Trim surrounding spaces and truncate valid long labels to 250 characters; the retained label must still contain a letter or digit.
- Treat invalid dynamic results, non-string values, and label evaluation errors as no label. Finish still completes and preserves its output. Invalid literal labels receive authoring validation feedback.
- Persist labels atomically with guarded successful completion across WASM, SDK, HTTP, and storage boundaries. Preserve replay/cancellation behavior and prevent nested workflows from renaming their parent execution.
- Display labels as execution titles with workflow context beneath them, falling back to workflow names when labels are absent.
- Apply case-insensitive substring search and exact label filters on the server before counting and pagination, including duplicate labels and stable page ordering.
- Document label authoring, normalization, truncation, ignored invalid dynamic values, display fallback, and paginated filtering in MCP tool descriptions, authoring guidance, and generated Finish schemas.

## Related Issue

No linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's coding standards
- [x] Formatting and workspace-wide Clippy checks pass
- [x] I have added tests that prove the feature works
- [x] I have updated the documentation
- [ ] Full CI feature/build matrix verified (focused checks are listed below)

## Testing

Final behavior verified with:

- MCP unit tests: 114 passed. Regenerated the runtime API client and verified the generated Finish schema includes the documented label behavior.

- DSL normalization and workflow mapping tests, plus five compiled WASM execution tests covering ignored invalid labels, truncation, output preservation, and resumed Finish execution.
- Core and SDK unit suites: 68 and 74 tests passed.
- Full feature-gated PostgreSQL storage suite (80 tests) and environment suite (319 tests) against fresh isolated databases, including concurrent sleep claims and wake scheduling. The server HTTP completion test also passed.
- Focused frontend label tests, scoped ESLint, and production frontend build including the generated WASM validator.
- Server and workflow component builds; `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` passed in the commit hook.
- A real local server with isolated PostgreSQL and Valkey: all 31 executions completed, including three invalid dynamic labels ignored, one 310-character label stored as 250 characters, and 24 duplicate labels. Browser assertions verified search totals, first/last pages, exact filtering, and successful output. Captured 14 screenshots locally.

The complete CI feature/build matrix was not rerun locally after the final behavior adjustment.

## Additional Notes

Migration `025_instance_run_label.sql` adds the nullable label column, a storage constraint, and non-unique exact/substring search indexes using `pg_trgm`. Deploy with rebuilt workflow runtime/stdlib components for the new optional completion metadata interface. Existing workflows without a label keep their existing completion path.


