### PR TITLE
Repair the three red e2e scripts, and the stale-artifact bug behind one of them

### DIFF
--- a/crates/runtara-environment/src/image_registry.rs
+++ b/crates/runtara-environment/src/image_registry.rs
@@ -295,6 +295,27 @@ impl ImageRegistry {
         Ok(image)
     }
 
+    /// Whether an image's registered artifact is still on disk.
+    ///
+    /// The row and the file can disagree. The row is immutable once written;
+    /// the file can go missing — a wiped data dir, a half-restored backup, an
+    /// operator clearing space. A caller about to reuse an artifact on the
+    /// strength of its row is exactly the caller that needs to know which it
+    /// has, because reusing a row whose file is gone produces an image that
+    /// registers fine and refuses to start.
+    ///
+    /// `false` for an image that does not exist at all: a caller asking whether
+    /// it can reuse this artifact gets the same answer either way.
+    pub async fn artifact_present(&self, image_id: &str) -> Result<bool> {
+        let Some(image) = self.get(image_id).await? else {
+            return Ok(false);
+        };
+        let path = std::path::PathBuf::from(&image.binary_path);
+        Ok(tokio::task::spawn_blocking(move || path.is_file())
+            .await
+            .unwrap_or(false))
+    }
+
     /// Get an image by ID, refusing one that belongs to another tenant.
     ///
     /// A hit owned by a different tenant reads as `None`, not as a rejection:

--- a/crates/runtara-server/src/api/services/compilation.rs
+++ b/crates/runtara-server/src/api/services/compilation.rs
@@ -434,6 +434,25 @@ pub struct CompilationService {
 }
 
 impl CompilationService {
+    /// Whether an image's artifact is on disk, for the reuse decision.
+    ///
+    /// A lookup failure answers `false`: the cost of re-registering an artifact
+    /// that was actually present is one wasted write, and the cost of reusing
+    /// one that was not is a workflow that never starts.
+    async fn artifact_present_for_reuse(&self, client: &RuntimeClient, image_id: &str) -> bool {
+        match client.image_artifact_present(image_id).await {
+            Ok(present) => present,
+            Err(error) => {
+                warn!(
+                    image_id = %image_id,
+                    error = %error,
+                    "Could not confirm the registered artifact is on disk; re-registering"
+                );
+                false
+            }
+        }
+    }
+
     pub fn new(
         repository: Arc<WorkflowRepository>,
         connection_service_url: Option<String>,
@@ -896,6 +915,29 @@ impl CompilationService {
             .find_image_by_name_summary(tenant_id, &image_name)
             .await
         {
+            // Reuse needs the row AND the file. The row is immutable and the
+            // checksums prove provenance, but a matching row whose artifact has
+            // gone from disk is precisely what a forced recompile is here to
+            // repair — and reusing it re-registers nothing, so the file stays
+            // missing and the caller retries into the same failure until its
+            // budget runs out.
+            Ok(Some(existing_image))
+                if image_matches_compiled_artifact(
+                    &existing_image,
+                    &source_checksum,
+                    result.compiler_mode,
+                    track_events,
+                    &result.binary_checksum,
+                ) && self
+                    .artifact_present_for_reuse(client, &existing_image.image_id)
+                    .await =>
+            {
+                info!(
+                    image_id = %existing_image.image_id,
+                    "Reusing already registered immutable workflow artifact"
+                );
+                existing_image.image_id
+            }
             Ok(Some(existing_image))
                 if image_matches_compiled_artifact(
                     &existing_image,
@@ -905,11 +947,13 @@ impl CompilationService {
                     &result.binary_checksum,
                 ) =>
             {
-                info!(
+                warn!(
                     image_id = %existing_image.image_id,
-                    "Reusing already registered immutable workflow artifact"
+                    image_name = %image_name,
+                    "Registered artifact is missing from disk; re-registering the compiled binary"
                 );
-                existing_image.image_id
+                self.register_image(client, &result, registration, &image_name)
+                    .await?
             }
             Ok(Some(existing_image)) => {
                 warn!(

--- a/crates/runtara-server/src/environment_client.rs
+++ b/crates/runtara-server/src/environment_client.rs
@@ -385,6 +385,15 @@ impl EnvironmentClient {
             .map(image_summary))
     }
 
+    /// Whether an image's registered artifact is still on disk.
+    ///
+    /// The compile path reuses an immutable artifact on the strength of its
+    /// row; this is how it checks the file is actually there before doing so.
+    #[instrument(skip(self), fields(image_id = %image_id), level = "debug")]
+    pub async fn image_artifact_present(&self, image_id: &str) -> Result<bool> {
+        Ok(self.image_registry().artifact_present(image_id).await?)
+    }
+
     /// Get one image, scoped to a tenant.
     #[instrument(skip(self), fields(image_id = %image_id, tenant_id = %tenant_id), level = "debug")]
     pub async fn get_image(&self, image_id: &str, tenant_id: &str) -> Result<Option<ImageSummary>> {

--- a/crates/runtara-server/src/runtime_client.rs
+++ b/crates/runtara-server/src/runtime_client.rs
@@ -724,6 +724,14 @@ impl RuntimeClient {
             .map(|image| image.image_id))
     }
 
+    /// Whether an image's registered artifact is still on disk.
+    pub async fn image_artifact_present(&self, image_id: &str) -> Result<bool, RuntimeError> {
+        self.client
+            .image_artifact_present(image_id)
+            .await
+            .map_err(|e| RuntimeError::SdkError(e.to_string()))
+    }
+
     /// Find an image by name for a tenant and return the full summary.
     pub async fn find_image_by_name_summary(
         &self,

--- a/e2e/test_negative_duration_on_resume.sh
+++ b/e2e/test_negative_duration_on_resume.sh
@@ -221,10 +221,27 @@ DRAIN_STATUS=$(db_field status "${INSTANCE_ID}")
 DRAIN_FINISHED=$(db_field finished_at "${INSTANCE_ID}")
 DRAIN_REASON=$(db_field termination_reason "${INSTANCE_ID}")
 echo "  post-drain: status=${DRAIN_STATUS} finished_at=${DRAIN_FINISHED} reason=${DRAIN_REASON}"
-# Precondition: the drain must have created the poison source (finished_at set).
-if [ "${DRAIN_STATUS}" != "suspended" ] || [ "${DRAIN_FINISHED}" = "NULL" ]; then
-    print_error "Precondition not met: expected suspended with finished_at stamped (got status=${DRAIN_STATUS}, finished_at=${DRAIN_FINISHED}). Adjust DELAY_MS/GRACE_MS so the guest is force-stopped mid-run."
+# Precondition: a parked instance to resume. The status is the part that
+# matters; `finished_at` is reported rather than required.
+#
+# This used to demand `finished_at` be stamped, on the reasoning that the drain
+# creates the poison this test then proves is rendered safely. That is no longer
+# how a park ends. `LaunchRepository::mark_suspended` now runs
+# `UPDATE instances SET status='suspended', finished_at = NULL` when it
+# reconciles the launch — a few hundred milliseconds after the drain stamps it —
+# so the poison is cleared at the write layer, which is a stronger guarantee
+# than rendering it safely. Requiring it turned that fix into a test failure.
+#
+# Both outcomes still exercise what this test is for: the instance resumes, and
+# no reader may ever see a negative duration.
+if [ "${DRAIN_STATUS}" != "suspended" ]; then
+    print_error "Precondition not met: expected a suspended instance to resume (got status=${DRAIN_STATUS}). Adjust DELAY_MS/GRACE_MS so the guest is force-stopped mid-run."
     exit 1
+fi
+if [ "${DRAIN_FINISHED}" = "NULL" ]; then
+    echo "  drain left finished_at cleared — the launch reconciliation beat the read (expected)"
+else
+    echo "  drain left finished_at stamped — resume must clear it before running"
 fi
 
 print_step "Restarting runtara-server (boot 2)..."

--- a/e2e/test_negative_duration_on_resume.sh
+++ b/e2e/test_negative_duration_on_resume.sh
@@ -87,6 +87,19 @@ api_duration() { curl -sS "${API}/workflows/instances/$1" | jq -r '.data.executi
 # runtime DB row fields
 db_field() { psql_quiet -d "${TEST_DB_RUNTIME}" -c "SELECT COALESCE($1::text,'NULL') FROM instances WHERE instance_id='$2'" | tr -d '[:space:]'; }
 db_duration_ms() { psql_quiet -d "${TEST_DB_RUNTIME}" -c "SELECT COALESCE((EXTRACT(EPOCH FROM (finished_at - started_at))*1000)::text,'NULL') FROM instances WHERE instance_id='$1'" | tr -d '[:space:]'; }
+# status, finished_at and duration from ONE row read.
+#
+# The poll below used to call db_field twice and db_duration_ms a third time,
+# which is three separate connections against a row that is being rewritten. It
+# could pair a status read from before a transition with a finished_at from
+# after it, and report a running row carrying a finished_at that never existed
+# at any instant — the exact thing the loop is watching for. Read the row once.
+db_row() {
+    psql_quiet -d "${TEST_DB_RUNTIME}" -c \
+        "SELECT status::text || '|' || COALESCE(finished_at::text,'NULL') || '|' \
+                || COALESCE((EXTRACT(EPOCH FROM (finished_at - started_at))*1000)::text,'NULL') \
+           FROM instances WHERE instance_id='$1'" | tr -d '[:space:]'
+}
 
 cleanup() {
     if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
@@ -254,9 +267,11 @@ STALE_FINISHED_WHILE_RUNNING=0
 SAW_RUNNING_AFTER_RELAUNCH=0
 FINAL=""
 for i in {1..60}; do
-    S=$(db_field status "${INSTANCE_ID}")
-    FIN=$(db_field finished_at "${INSTANCE_ID}")
-    DUR=$(db_duration_ms "${INSTANCE_ID}")
+    ROW=$(db_row "${INSTANCE_ID}")
+    S="${ROW%%|*}"
+    REST="${ROW#*|}"
+    FIN="${REST%%|*}"
+    DUR="${REST#*|}"
     ADUR=$(api_duration "${INSTANCE_ID}")
     printf "  t=%02d status=%-9s finished_at=%s db_dur_ms=%s api_dur=%s\n" "$i" "${S}" "${FIN}" "${DUR}" "${ADUR}"
 

--- a/e2e/test_recovery_environment_restart.sh
+++ b/e2e/test_recovery_environment_restart.sh
@@ -97,6 +97,13 @@ trap cleanup EXIT
 start_server() {
     # Start (or restart) runtara-server with identical env so the wake scheduler
     # and orphan recovery see the same DBs / data dir / Valkey across restarts.
+    #
+    # The two connection URLs are pinned rather than left to be derived from
+    # INTERNAL_PORT. `runtara-server` calls `dotenvy::dotenv()` at startup, which
+    # fills any variable this script does not set — so a developer `.env` that
+    # names CONNECTION_SERVICE_URL silently wins over the derivation, and the
+    # guest resolves credentials against whatever server that points at. Every
+    # other port here is pinned for the same reason; these two were the gap.
     RUNTARA_SERVER_DATABASE_URL="${SERVER_DB_URL}" \
     OBJECT_MODEL_DATABASE_URL="${SERVER_DB_URL}" \
     RUNTARA_DATABASE_URL="${RUNTIME_DB_URL}" \
@@ -104,6 +111,8 @@ start_server() {
     SERVER_HOST=127.0.0.1 \
     SERVER_PORT="${TEST_PORT_PUBLIC}" \
     INTERNAL_PORT="${TEST_PORT_INTERNAL}" \
+    CONNECTION_SERVICE_URL="http://127.0.0.1:${TEST_PORT_INTERNAL}/api/connections" \
+    RUNTARA_CONNECTION_SERVICE_URL="http://127.0.0.1:${TEST_PORT_INTERNAL}/api/connections" \
     RUNTARA_CORE_PORT="${TEST_CORE_PORT}" \
     RUNTARA_ENVIRONMENT_PORT="${TEST_ENV_PORT}" \
     RUNTARA_CORE_HTTP_PORT="${TEST_CORE_HTTP_PORT}" \

--- a/e2e/test_trigger_replay_idempotency.sh
+++ b/e2e/test_trigger_replay_idempotency.sh
@@ -12,20 +12,13 @@
 # a forced recompilation restores the artifact. Replaying the same event must be
 # deduplicated and ACKed without a second instance row.
 #
-# KNOWN FAILING, and the failure looks real rather than stale. The repair fires
-# — "Image or image artifact missing in Environment; forcing recompilation" —
-# and the compile reports success in ~0.1s, but the artifact is never written
-# back, so the next retry hits the same "registered artifact is missing from
-# disk" and the event burns its retry budget. One observed run: 13 repair
-# attempts, 14 compiles reported successful, and exactly ONE
-# `register_image_stream` call. The early "already registered, skipping
-# compilation" check at compilation.rs:662 does honour force_recompile, so the
-# skipping happens further in — a compilation cache keyed on source, most
-# likely, which a forced rebuild after artifact loss should miss.
-#
-# Raising TRIGGER_MAX_RETRIES does not help: the loop never converges. Do not
-# weaken this test to make it pass — it is detecting that artifact loss is
-# currently unrecoverable by recompilation.
+# This test earned its keep: it caught artifact loss being unrecoverable by
+# recompilation. The repair fired and the compile reported success, but the
+# post-compile reuse branch matched the existing image row on checksums and
+# skipped registration, so the deleted file was never rewritten and the event
+# retried into the same failure until its budget ran out (13 repair attempts,
+# 14 compiles reported successful, one register_image_stream call). Reuse now
+# requires the artifact to be on disk as well as the row to match.
 
 set -euo pipefail
 

--- a/e2e/test_trigger_replay_idempotency.sh
+++ b/e2e/test_trigger_replay_idempotency.sh
@@ -170,24 +170,43 @@ ARTIFACT_BACKUP=$(mktemp -t runtara-trigger-replay-artifact.XXXXXX)
 cp "${ARTIFACT}" "${ARTIFACT_BACKUP}"
 rm "${ARTIFACT}"
 
-echo "3. Publishing one event against the stale image and waiting for forced repair"
-INSTANCE_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-REQUESTED_AT="$(date +%s)000"
-EVENT=$(jq -nc \
-    --arg instance_id "${INSTANCE_ID}" \
-    --arg tenant_id "${TENANT_ID}" \
-    --arg workflow_id "${WORKFLOW_ID}" \
-    --argjson version "${VERSION}" \
-    --argjson requested_at "${REQUESTED_AT}" \
-    '{instance_id:$instance_id,tenant_id:$tenant_id,workflow_id:$workflow_id,version:$version,
-      inputs:{data:{input:{e2e:true}},variables:{}},
-      trigger:{type:"http_api",correlation_id:null},requested_at:$requested_at,
-      track_events:false,debug:false}')
-
+echo "3. Executing against the stale image and waiting for forced repair"
+# The first delivery is produced by the server, not hand-crafted here.
+#
+# This used to XADD a synthetic event built from scratch. The trigger worker now
+# refuses any event without a durable source request id — `missing_durable_request_id`,
+# a permanent failure — because admission is durable and a producer that bypasses
+# it can double-launch. A shell script cannot mint that id without duplicating
+# the outbox's invariants, and it should not: driving the real endpoint gets a
+# real request row, and the event the worker sees is the one production writes.
+#
+# The replay in step 4 then re-publishes THAT event verbatim, which is a truer
+# test of idempotency than replaying something only this script knows how to build.
 READS_BEFORE=$(group_entries_read)
-FIRST_ENTRY_ID=$(redis XADD "${STREAM}" '*' \
-    event_type trigger trigger_type http_api instance_id "${INSTANCE_ID}" \
-    workflow_id "${WORKFLOW_ID}" data "${EVENT}")
+EXECUTE_RESPONSE=$(curl -fsS --max-time 120 -X POST \
+    "${API}/workflows/${WORKFLOW_ID}/execute" \
+    -H 'Content-Type: application/json' \
+    -d '{"inputs":{"data":{"input":{"e2e":true}},"variables":{}}}')
+INSTANCE_ID=$(jq -r '.data.instanceId // .data.instance_id // empty' <<<"${EXECUTE_RESPONSE}")
+[ -n "${INSTANCE_ID}" ] || { echo "execute did not return an instance id: ${EXECUTE_RESPONSE}"; exit 1; }
+
+# Find the entry the server just published for this instance, and keep its
+# payload so the replay can repeat it exactly.
+FIRST_ENTRY_ID=""
+EVENT=""
+for _ in {1..30}; do
+    ENTRY=$(redis XREVRANGE "${STREAM}" + - COUNT 50 2>/dev/null || true)
+    FIRST_ENTRY_ID=$(awk -v id="${INSTANCE_ID}" '
+        /^[0-9]+-[0-9]+$/ { entry = $0 }
+        $0 == id { print entry; exit }
+    ' <<<"${ENTRY}")
+    [ -n "${FIRST_ENTRY_ID}" ] && break
+    sleep 1
+done
+[ -n "${FIRST_ENTRY_ID}" ] || { echo "server published no trigger entry for ${INSTANCE_ID}"; exit 1; }
+EVENT=$(redis XRANGE "${STREAM}" "${FIRST_ENTRY_ID}" "${FIRST_ENTRY_ID}" COUNT 1 \
+    | awk 'prev == "data" { print; exit } { prev = $0 }')
+[ -n "${EVENT}" ] || { echo "could not read the published event payload"; exit 1; }
 
 for _ in {1..120}; do
     INSTANCE_COUNT=$(db_scalar "${RUNTARA_DATABASE_URL}" \

--- a/e2e/test_trigger_replay_idempotency.sh
+++ b/e2e/test_trigger_replay_idempotency.sh
@@ -90,6 +90,24 @@ wait_for_group_read() {
     return 1
 }
 
+# Delivery and acknowledgement are two separate Valkey calls, so an entry is
+# briefly pending between the read that increments `entries-read` and the XACK
+# that clears it. Asserting on a single XPENDING right after the read is a race
+# the assertion loses whenever it samples inside that window: the worker
+# acknowledged a deduplicated replay six milliseconds after delivery and the
+# check ran two milliseconds in. Poll instead — the assertion is still "this
+# entry gets acknowledged", it just no longer requires that to be instantaneous.
+wait_for_ack() {
+    local entry_id="$1"
+    for _ in {1..30}; do
+        if [ -z "$(redis XPENDING "${STREAM}" "${GROUP}" "${entry_id}" "${entry_id}" 1)" ]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
 cleanup() {
     set +e
 
@@ -227,7 +245,7 @@ done
 [ "${INSTANCE_COUNT:-0}" = "1" ] || { echo "repaired execution never registered"; exit 1; }
 [ -f "${ARTIFACT}" ] || { echo "forced recompilation did not restore ${ARTIFACT}"; exit 1; }
 wait_for_group_read "${READS_BEFORE}" || { echo "trigger group did not consume first event"; exit 1; }
-[ -z "$(redis XPENDING "${STREAM}" "${GROUP}" "${FIRST_ENTRY_ID}" "${FIRST_ENTRY_ID}" 1)" ] || {
+wait_for_ack "${FIRST_ENTRY_ID}" || {
     echo "first event was not acknowledged after repair"
     exit 1
 }
@@ -249,7 +267,7 @@ REPLAY_ENTRY_ID=$(redis XADD "${STREAM}" '*' \
     event_type trigger trigger_type http_api instance_id "${INSTANCE_ID}" \
     workflow_id "${WORKFLOW_ID}" data "${EVENT}")
 wait_for_group_read "${READS_BEFORE}" || { echo "trigger group did not consume replay"; exit 1; }
-[ -z "$(redis XPENDING "${STREAM}" "${GROUP}" "${REPLAY_ENTRY_ID}" "${REPLAY_ENTRY_ID}" 1)" ] || {
+wait_for_ack "${REPLAY_ENTRY_ID}" || {
     echo "deduplicated replay was not acknowledged"
     exit 1
 }

--- a/e2e/test_trigger_replay_idempotency.sh
+++ b/e2e/test_trigger_replay_idempotency.sh
@@ -8,9 +8,24 @@
 #     environment or the repository .env file.
 #
 # The test creates an isolated workflow/image, backs up and removes that image's
-# binary, then publishes a trigger event directly. The first delivery must stay
-# pending while a forced recompilation restores the artifact. Replaying the same
-# instance id must be deduplicated and ACKed without a second instance row.
+# binary, then executes the workflow. The first delivery must stay pending while
+# a forced recompilation restores the artifact. Replaying the same event must be
+# deduplicated and ACKed without a second instance row.
+#
+# KNOWN FAILING, and the failure looks real rather than stale. The repair fires
+# — "Image or image artifact missing in Environment; forcing recompilation" —
+# and the compile reports success in ~0.1s, but the artifact is never written
+# back, so the next retry hits the same "registered artifact is missing from
+# disk" and the event burns its retry budget. One observed run: 13 repair
+# attempts, 14 compiles reported successful, and exactly ONE
+# `register_image_stream` call. The early "already registered, skipping
+# compilation" check at compilation.rs:662 does honour force_recompile, so the
+# skipping happens further in — a compilation cache keyed on source, most
+# likely, which a forced rebuild after artifact loss should miss.
+#
+# Raising TRIGGER_MAX_RETRIES does not help: the loop never converges. Do not
+# weaken this test to make it pass — it is detecting that artifact loss is
+# currently unrecoverable by recompilation.
 
 set -euo pipefail
 


### PR DESCRIPTION
Three top-level e2e scripts were failing on `main`. Two failed purely for the tests' own reasons. The third needed a test-side fix as well — it hand-built a stream event the trigger worker now permanently rejects — and only once that was cleared did it reach the real product bug it exists to catch. Weakening the test to make it green would have hidden that bug.

## The three scripts

**`test_recovery_environment_restart.sh`** — failed on `main` because the guest resolved connection metadata against `:7002`. The script sets neither `CONNECTION_SERVICE_URL` nor `RUNTARA_CONNECTION_SERVICE_URL`, and `dotenvy` fills anything unset from the repo `.env`, which pins both to a developer's running server. The isolated stack then asked the wrong tenant for its connections. Both names are now pinned to the test's own internal port.

What that cost in coverage, stated carefully: `test_obm_sql_workflow.sh` Leg 4 already covers the basic drain → restart → resume path with an exactly-once assertion, and pins its own connection URLs, so it was unaffected and the path was not dark. What was red is the only script checking the drain's *quality* — that a graceful stop pauses at a checkpoint rather than force-stopping, over twenty iterations with no duplicated work — plus the abrupt SIGKILL mode, which has no other coverage at all.

**`test_negative_duration_on_resume.sh`** — required a precondition that no longer exists. It waited for a suspended instance that still carried a stale `finished_at`, which is exactly the poison a previous fix removed: `LaunchRepository::mark_suspended` now clears the column. The precondition is now just `suspended`, and the assertions still cover what the test is for — that a resumed run never reports a negative duration.

**`test_trigger_replay_idempotency.sh`** — see below.

## The product bug

The trigger test drove a workflow whose registered image had lost its file on disk. The repair loop fired, recompilation reported success, and the event retried into the same failure until its budget ran out — 13 repair attempts, 14 compiles all reported successful, one `register_image_stream` call.

The post-compile reuse branch in `compilation.rs` matched the existing image row on checksums and skipped registration, so the deleted file was never rewritten. It trusted the row and never asked about the file. Reuse now additionally requires the artifact to be present:

```rust
Ok(Some(existing_image)) if image_matches_compiled_artifact(...) && self
    .artifact_present_for_reuse(client, &existing_image.image_id).await => { /* reuse */ }
Ok(Some(existing_image)) if image_matches_compiled_artifact(...) => {
    warn!(... "Registered artifact is missing from disk; re-registering the compiled binary");
    self.register_image(client, &result, registration, &image_name).await?
}
```

`ImageRegistry::artifact_present` does the `is_file` check on a blocking pool and answers `false` for a row that is gone, propagating a genuine lookup error. `CompilationService::artifact_present_for_reuse` is what turns that error into `false`, so a registry hiccup degrades to re-registering rather than to trusting a row it could not read.

## Two test-side fixes worth calling out

The trigger script used to hand-craft its first stream event. The trigger worker now refuses any event without a durable source request id (`missing_durable_request_id`, a permanent failure), and a shell script cannot mint one without duplicating the outbox's invariants. Step 3 drives `POST /workflows/{id}/execute` and step 4 replays the event the server actually published — a truer idempotency test than replaying something only the script knows how to build.

The last commit fixes a race in the same script. It asserted on a single `XPENDING` taken the moment `entries-read` incremented, but delivery and acknowledgement are two separate Valkey calls. The worker acknowledged a deduplicated replay six milliseconds after delivery and the check landed two milliseconds in, failing a run whose server log recorded the ACK. The assertion still requires the entry to be acknowledged; it no longer requires that to be instantaneous.

## Verification

- `cargo fmt --all -- --check`, `clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean
- `cargo test --workspace --lib` — 3780 passed
- `runtara-environment --features db-integration-tests -- --test-threads=1` — 317 passed
- `runtara-server --features db-integration-tests,valkey-integration-tests -- --test-threads=1` — 1294 passed, 7 ignored
- All three scripts against a server rebuilt at the final commit: recovery graceful and abrupt (20/20 rows, no duplicates), negative-duration, and trigger replay (`stale artifact repaired, replay ACKed, instance rows=1`). The trigger script was run three times before the ACK fix was committed and once after the rebuild.

## Note

`test_recovery_environment_restart.sh` and several sibling scripts carry a real Postgres password as a shell default (`POSTGRES_PASSWORD:-…`), introduced around `20eaeb5f` and copied since. Out of scope here and left untouched, but it should be dealt with separately.
