### PR TITLE
Index the parked count so the System page stops scanning the instances table

### DIFF
--- a/crates/runtara-environment/src/db.rs
+++ b/crates/runtara-environment/src/db.rs
@@ -234,36 +234,63 @@ pub async fn count_instances_by_status(
     Ok(count.0)
 }
 
-/// Count a tenant's instances in the given statuses, with no ceiling.
+/// The parked count's query text.
 ///
-/// The sibling above stops at a bound because its caller only needs to know
-/// whether a cap is reached. A viewer wants the real figure and pays for it:
-/// this is O(matching rows), which for `suspended` means the largest set in the
-/// table. It belongs on a slow tick, never on an intake path.
-pub async fn count_instances_by_status_unbounded(
-    pool: &PgPool,
-    tenant_id: &str,
-    statuses: &[String],
-) -> Result<i64, sqlx::Error> {
-    // Same predicate as the capped form minus its LIMIT subquery, so the two
-    // cannot drift apart on which rows they consider. Not the same plan,
-    // though: `idx_instances_status` is a plain index on `status`, and the
-    // caller that wants this asks for `suspended` — the value that dominates
-    // the table — so the planner will reasonably prefer a sequential scan.
-    // That cost is the point of the ceiling on the capped form, and the reason
-    // this one belongs on a slow tick behind a slow-query warning.
-    let count: (i64,) = sqlx::query_as(
+/// Built rather than written inline so the test that asserts on its query plan
+/// can EXPLAIN the statement this function runs, instead of a copy that could
+/// drift away from it.
+///
+/// `parked` is spliced, and that is the whole point of the shape. See
+/// [`count_parked_instances`] for why a bound status cannot work here.
+pub(crate) fn parked_count_sql(parked: &str) -> String {
+    format!(
         r#"
         SELECT COUNT(*)
         FROM instances
         WHERE tenant_id = $1
-          AND status = ANY($2::instance_status[])
-        "#,
+          AND status = '{parked}'
+        "#
     )
-    .bind(tenant_id)
-    .bind(statuses)
-    .fetch_one(pool)
-    .await?;
+}
+
+/// Count a tenant's parked instances, with no ceiling.
+///
+/// The sibling above stops at a bound because its caller only needs to know
+/// whether a cap is reached. A viewer wants the real figure, and this answers it
+/// from `idx_instances_suspended_tenant` (025) instead of by reading the table:
+/// an index-only scan over one tenant's parked rows. Measured over 500k
+/// instances with 350k suspended, counting one tenant's 306k: 15,622 buffers
+/// before that index, 261 after.
+pub async fn count_parked_instances(
+    pool: &PgPool,
+    tenant_id: &str,
+    parked: &str,
+) -> Result<i64, sqlx::Error> {
+    // Why the status is spliced rather than bound, which is the whole reason
+    // this is not just the capped query without its LIMIT.
+    //
+    // 025 is a partial index with the predicate `status = 'suspended'`, and the
+    // planner applies a partial index only when it can prove the query's own
+    // predicate implies it. That proof needs a constant. The obvious form,
+    // `status = ANY($2::instance_status[])` with the statuses bound, does not
+    // give it one: sqlx sends a `Vec<String>` as `text[]`, so what the planner
+    // actually sees is `(('{suspended}'::text[])::instance_status[])` — a cast
+    // through the enum's input function, which is `stable` rather than
+    // `immutable` and therefore not folded to a constant before index matching.
+    // The proof fails, the index is skipped in silence, and the count reverts
+    // to reading the table. Measured, and pinned by
+    // `the_parked_count_reaches_its_partial_index`.
+    //
+    // Splicing is safe because the value is never a caller's input:
+    // `status_name` maps a Rust enum to one of six fixed identifiers, and the
+    // only caller passes `InstanceStatus::Suspended`. It is an argument rather
+    // than a literal written here so the label keeps one spelling — the one the
+    // rest of the crate already uses — and a renamed variant cannot leave this
+    // query silently disagreeing with it.
+    let count: (i64,) = sqlx::query_as(&parked_count_sql(parked))
+        .bind(tenant_id)
+        .fetch_one(pool)
+        .await?;
 
     Ok(count.0)
 }

--- a/crates/runtara-environment/src/db/integration_tests.rs
+++ b/crates/runtara-environment/src/db/integration_tests.rs
@@ -409,3 +409,126 @@ async fn test_tenant_metrics_excludes_other_tenants_and_non_terminal_runs() {
     delete_tenant_instances(&pool, &tenant_id).await;
     delete_tenant_instances(&pool, &other_tenant).await;
 }
+
+// ============================================================================
+// Parked-instance count plan
+//
+// Migration 025 adds a partial index on (tenant_id) WHERE status = 'suspended'
+// so the System page's parked count stops reading the table. Nothing about the
+// count's result changes when that index is missing or unreachable, which is
+// what makes the regression invisible: the number stays right and the query
+// goes back to O(table). The test below asserts the plan instead.
+// ============================================================================
+
+/// Ask the planner which index it can use for a given parked-count SQL.
+///
+/// Sequential scans are off for the duration so the answer is which index the
+/// query *can* reach, not which plan happens to be cheapest on a test table
+/// small enough that reading all of it wins. Reaching the partial index is
+/// exactly the property at issue, and it is not a given: a partial index
+/// applies only where the planner can prove the query's predicate implies the
+/// index's.
+async fn explain_parked_count(pool: &PgPool, sql: &str, tenant_id: &str) -> String {
+    let mut tx = pool.begin().await.expect("begin");
+    sqlx::query("SET LOCAL enable_seqscan = off")
+        .execute(&mut *tx)
+        .await
+        .expect("disable sequential scans for this transaction");
+
+    let plan: Vec<String> = sqlx::query_scalar(&format!("EXPLAIN {sql}"))
+        .bind(tenant_id)
+        .fetch_all(&mut *tx)
+        .await
+        .expect("explain the parked count");
+    tx.rollback().await.expect("rollback");
+
+    plan.join("\n")
+}
+
+/// Seed parked instances across several tenants, and return the one to count.
+///
+/// Several tenants, not one, because that is what makes the partial index a
+/// distinct answer rather than a coin flip: with a single tenant it and the
+/// plain `idx_instances_status` select the same rows, and which one the planner
+/// names says nothing. Spread the parked rows across twenty and the tenant-keyed
+/// index is genuinely the narrower path.
+///
+/// A couple of hundred rows is enough for that. This deliberately does not try
+/// to reproduce the production table's size or its skew towards `suspended`:
+/// with sequential scans disabled the question is only which index the query can
+/// reach, and that answer does not depend on how big the table is.
+async fn seed_parked_across_tenants(pool: &PgPool, tag: &str) -> String {
+    sqlx::query(
+        "INSERT INTO instances (instance_id, tenant_id, status)
+         SELECT $1 || '-i-' || g, $1 || '-t' || (g % 20), 'suspended'::instance_status
+         FROM generate_series(1, 200) g",
+    )
+    .bind(tag)
+    .execute(pool)
+    .await
+    .expect("seed parked instances");
+
+    // The planner chooses on statistics, so a fixture it has not looked at is a
+    // fixture it will not plan for.
+    sqlx::query("ANALYZE instances")
+        .execute(pool)
+        .await
+        .expect("analyze");
+
+    format!("{tag}-t0")
+}
+
+/// The parked count must be answerable from `idx_instances_suspended_tenant`.
+///
+/// Only the index name is asserted, not the scan type: whether this comes out
+/// as an index-only scan depends on the visibility map, which VACUUM maintains
+/// and which will not be set for rows the test has just inserted.
+#[tokio::test]
+async fn the_parked_count_reaches_its_partial_index() {
+    let pool = crate::test_support::pool().await;
+    let tag = format!("parked-plan-{}", Uuid::new_v4());
+    let tenant_id = seed_parked_across_tenants(&pool, &tag).await;
+
+    let parked = crate::core_types::status_name(runtara_core::domain::InstanceStatus::Suspended);
+    let plan = explain_parked_count(&pool, &super::parked_count_sql(parked), &tenant_id).await;
+    assert!(
+        plan.contains("idx_instances_suspended_tenant"),
+        "the parked count must be served by migration 025's partial index, \
+         otherwise it is a scan whose cost grows with the table; plan was:\n{plan}"
+    );
+
+    // The bound form is what this query used to be, and it is what a reviewer
+    // would reach for to put the two count queries back on one predicate. It
+    // cannot reach the index: sqlx sends the statuses as `text[]`, so the
+    // planner sees a cast through the enum's `stable` input function rather
+    // than a constant and cannot prove the implication. Asserting that here
+    // keeps the reason for the splice from having to be taken on trust.
+    let mut tx = pool.begin().await.expect("begin");
+    sqlx::query("SET LOCAL enable_seqscan = off")
+        .execute(&mut *tx)
+        .await
+        .expect("disable sequential scans for this transaction");
+    let bound: Vec<String> = sqlx::query_scalar(
+        "EXPLAIN SELECT COUNT(*) FROM instances \
+         WHERE tenant_id = $1 AND status = ANY($2::instance_status[])",
+    )
+    .bind(&tenant_id)
+    .bind(vec![parked.to_string()])
+    .fetch_all(&mut *tx)
+    .await
+    .expect("explain the bound form");
+    tx.rollback().await.expect("rollback");
+    let bound = bound.join("\n");
+    assert!(
+        !bound.contains("idx_instances_suspended_tenant"),
+        "the bound form reached the partial index, so the splice in \
+         parked_count_sql is no longer buying anything and its comment is \
+         now wrong; plan was:\n{bound}"
+    );
+
+    sqlx::query("DELETE FROM instances WHERE tenant_id LIKE $1")
+        .bind(format!("{tag}-t%"))
+        .execute(&pool)
+        .await
+        .expect("clean up the fixture");
+}

--- a/crates/runtara-environment/src/instance_repository.rs
+++ b/crates/runtara-environment/src/instance_repository.rs
@@ -278,20 +278,6 @@ impl InstanceRepository {
         Ok(crate::db::count_instances_by_status(&self.pool, tenant_id, statuses, ceiling).await?)
     }
 
-    /// Count a tenant's instances in the given statuses, with no ceiling.
-    ///
-    /// [`Self::count_by_status`] bounds its scan because the admission gate
-    /// only needs to know whether the cap is reached. A viewer reporting how
-    /// many instances are parked needs the actual number, and this is the read
-    /// that costs what that answer costs — O(matching rows), for a slow tick.
-    pub async fn count_by_status_unbounded(
-        &self,
-        tenant_id: &str,
-        statuses: &[String],
-    ) -> Result<i64> {
-        Ok(crate::db::count_instances_by_status_unbounded(&self.pool, tenant_id, statuses).await?)
-    }
-
     /// How many of a tenant's instances are parked.
     ///
     /// Which statuses count as parked is this crate's knowledge, so it is
@@ -300,14 +286,20 @@ impl InstanceRepository {
     /// server crate holding that literal is a second spelling of a vocabulary
     /// it does not own.
     ///
-    /// Unbounded, and deliberately so — see [`Self::count_by_status_unbounded`]
-    /// for what that costs.
+    /// Unbounded, unlike [`Self::count_by_status`], because a viewer wants the
+    /// real figure rather than "at least the cap". That used to make it the
+    /// expensive half of the pair — a sequential scan of a table whose dominant
+    /// value is exactly the one being counted. Migration 025 indexes that value
+    /// per tenant, so the answer is an index-only scan and the missing ceiling
+    /// costs a viewer nothing. The query has to spell the status as a literal
+    /// to reach that index; [`crate::db::count_parked_instances`] says why.
     pub async fn count_parked(&self, tenant_id: &str) -> Result<i64> {
-        self.count_by_status_unbounded(
+        Ok(crate::db::count_parked_instances(
+            &self.pool,
             tenant_id,
-            &[crate::core_types::status_name(InstanceStatus::Suspended).to_string()],
+            crate::core_types::status_name(InstanceStatus::Suspended),
         )
-        .await
+        .await?)
     }
 
     /// Record what the process used, and read back the status the guest

--- a/crates/runtara-environment/tests/handlers_test.rs
+++ b/crates/runtara-environment/tests/handlers_test.rs
@@ -2391,7 +2391,7 @@ async fn the_unbounded_status_count_ignores_the_ceiling_the_capped_one_obeys() {
     );
 
     let unbounded = instances
-        .count_by_status_unbounded(&tenant_id, &statuses)
+        .count_parked(&tenant_id)
         .await
         .expect("unbounded count");
     assert_eq!(
@@ -2402,7 +2402,7 @@ async fn the_unbounded_status_count_ignores_the_ceiling_the_capped_one_obeys() {
     // Both must agree on WHICH rows match, so a tenant with none reads zero
     // rather than picking up another tenant's parked instances.
     let other = instances
-        .count_by_status_unbounded(&format!("count-tenant-{}", Uuid::new_v4()), &statuses)
+        .count_parked(&format!("count-tenant-{}", Uuid::new_v4()))
         .await
         .expect("unbounded count for an empty tenant");
     assert_eq!(other, 0);

--- a/crates/runtara-server/src/workers/pipeline_sampler.rs
+++ b/crates/runtara-server/src/workers/pipeline_sampler.rs
@@ -8,10 +8,10 @@
 //! handler that reads the world per request.
 //!
 //! Two cadences, because one of the readings is not like the others. The
-//! durable launch-state reading is index-bounded by the live handoff set and
-//! is sampled on the fast tick; the parked count is a database scan whose cost grows with the
-//! table, so it runs on its own slow tick and its last value is carried between
-//! them — see [`SLOW_TICK`].
+//! durable launch-state reading is index-bounded by the live handoff set and is
+//! sampled on the fast tick; the parked count has no ceiling, so its cost grows
+//! with the parked population rather than with the live set, and it runs on its
+//! own slow tick with its last value carried between them — see [`SLOW_TICK`].
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -31,11 +31,12 @@ pub const FAST_TICK: Duration = Duration::from_secs(1);
 
 /// How often the parked count is taken.
 ///
-/// Counting suspended instances without a ceiling is the one genuinely
-/// expensive reading here: on a host holding a million of them it is a scan of
-/// every matching index entry. A parked population moves at a few hundred a
-/// second at most, so half a minute of staleness costs a viewer nothing while
-/// keeping that scan off the fast path entirely.
+/// Counting suspended instances without a ceiling is still the one reading with
+/// no upper bound on its work: migration 025 made it an index-only scan rather
+/// than a scan of the table, but on a host holding a million parked instances
+/// that is a million index entries walked. A parked population moves at a few
+/// hundred a second at most, so half a minute of staleness costs a viewer
+/// nothing while keeping that walk off the fast path entirely.
 pub const SLOW_TICK: Duration = Duration::from_secs(30);
 
 /// How long a stage may sit full before its age is worth remarking on.
@@ -770,8 +771,8 @@ async fn count_parked(
         Ok(count) => {
             let elapsed = started.elapsed();
             if elapsed > Duration::from_millis(200) {
-                // Surfaced rather than swallowed: this is the one reading whose
-                // cost grows with the table, and a slow one is the signal to
+                // Surfaced rather than swallowed: this is the one reading with
+                // no ceiling on its work, and a slow one is the signal to
                 // lengthen the interval or accept a displayed ceiling.
                 tracing::warn!(
                     elapsed_ms = elapsed.as_millis() as u64,

--- a/crates/runtara-store-postgres/migrations/postgresql/025_index_instances_suspended_tenant.sql
+++ b/crates/runtara-store-postgres/migrations/postgresql/025_index_instances_suspended_tenant.sql
@@ -1,0 +1,22 @@
+-- The System page samples how many of a tenant's instances are parked, and
+-- parked means `suspended` — the value that dominates this table. A plain index
+-- on `status` is no help for a table's most common value, so the planner
+-- reasonably preferred a sequential scan and the count cost O(table) per sample.
+--
+-- Modelled on idx_instances_pending_tenant_created (019), which does the same
+-- for pending starts. This one carries no second column: its reader counts and
+-- never asks for the oldest, so tenant_id alone answers the query index-only.
+--
+-- Measured over 500k instances, 350k of them suspended, counting the largest
+-- tenant's 306k: a parallel sequential scan of 15,622 buffers before, an
+-- index-only scan of 261 with no heap fetches after.
+--
+-- One thing to know when checking whether this is working. An index-only scan
+-- is only cheap once the visibility map says a page is all-visible, which
+-- VACUUM sets. On a freshly bulk-loaded table the planner correctly costs this
+-- index as needing a heap fetch per row and keeps the sequential scan; the plan
+-- flips after the first (auto)vacuum. An index that appears to do nothing
+-- immediately after a large import has probably just not been vacuumed yet.
+CREATE INDEX IF NOT EXISTS idx_instances_suspended_tenant
+    ON instances (tenant_id)
+    WHERE status = 'suspended';


### PR DESCRIPTION
The System page samples how many of a tenant's instances are parked once every slow tick. Parked means `suspended`, which is the value that dominates the `instances` table, so the plain index on `status` was no help and the planner reasonably chose a sequential scan. The count cost O(table) per sample.

This retires the caveat #232 had to write into its own description. Migration `025` adds the partial index, modelled on `019_index_instances_pending_tenant_created` — the same shape for pending starts. It carries no second column: this reader counts and never asks for the oldest, so `tenant_id` alone answers it index-only.

## The index alone would have been inert

That is the part worth reviewing. A partial index applies only where the planner can prove the query's predicate implies the index's, and the count gave it nothing to prove against. sqlx sends a `Vec<String>` as `text[]`, so `status = ANY($2::instance_status[])` reached the planner as a cast through the enum's input function:

```
Filter: (status = ANY (('{suspended}'::text[])::instance_status[]))
```

Enum input is `stable`, not `immutable`, so it is not folded to a constant before index matching. The proof fails, the index is skipped in silence, and the count goes on reading the table.

The second commit spells the status instead. The label is passed in from `status_name(InstanceStatus::Suspended)` rather than written into the SQL, so it keeps the one spelling the rest of the crate uses and a renamed variant cannot leave the query silently disagreeing with it. The generic `count_by_status_unbounded` goes with it — `count_parked` was its only caller in `src`, and the two integration-test sites that reached past it now go through `count_parked` too.

## Measurements

Over 500k instances with 350k suspended, counting one tenant's 306k:

| | plan | buffers |
|---|---|---|
| before | parallel sequential scan | 15,622 |
| after | index-only scan, 0 heap fetches | 261 |

And on a live server's own runtime database, same shape: 15,707 buffers → 300, 31 ms → 8.9 ms.

## The test asserts the plan, not the number

The number is right either way, which is what made this invisible. `the_parked_count_reaches_its_partial_index` disables sequential scans and asserts the planner names `idx_instances_suspended_tenant`, then asserts that the bound form does *not* reach it — so the reason for the splice does not have to be taken on trust. Only the index name is checked, not the scan type, because whether it comes out index-only depends on the visibility map.

## One thing to know when checking this in production

An index-only scan is only cheap once VACUUM has marked pages all-visible. Isolated with autovacuum disabled and identical statistics: `relallvisible = 0` gives a sequential scan, `relallvisible = relpages` gives the index-only scan. An index that appears to do nothing right after a large import has probably just not been vacuumed yet. This is recorded in the migration's comment.

## Verification

- `cargo fmt --all -- --check`, `clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean
- `cargo test --workspace --lib` — 3780 passed
- `runtara-environment --features db-integration-tests -- --test-threads=1` — 318 passed
- `runtara-server --features db-integration-tests,valkey-integration-tests -- --test-threads=1` — 1294 passed, 7 ignored
- `e2e/test_pipeline_analytics.sh` — all assertions passed
- Live server with 350k parked instances: `parked used=350000`, correct and cheap
