### PR TITLE
Give runtara-environment one rule for reading its settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,14 @@ api-tests/.venv/
 .data/
 **/.data/
 
+# The same directory under a suffix. An isolated second server needs its own
+# DATA_DIR to avoid colliding with the running one, and the recipe for that
+# names it after whatever is being tested (.data-e2e, .data-perf). Those hold
+# compiled workflow artifacts and a wasmtime cache — megabytes of build output
+# that a `git add -A` would otherwise sweep straight into a commit.
+.data-*/
+**/.data-*/
+
 # Generated changelog (created during CI builds)
 debian/changelog
 

--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -54,8 +54,8 @@ impl CleanupWorkerConfig {
     /// - `RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS`: seconds between scans (default: 3600)
     /// - `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS`: days before run dirs are removed (default: 3)
     ///
-    /// The two numbers follow [`positive`](crate::config::positive): zero and
-    /// below fall back to the default rather than being honoured.
+    /// The two numbers follow the crate's positive-only rule: zero and below
+    /// fall back to the default rather than being honoured.
     pub fn from_env() -> Self {
         Self::from_vars(&ProcessEnv)
     }

--- a/crates/runtara-environment/src/cleanup_worker.rs
+++ b/crates/runtara-environment/src/cleanup_worker.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::config::parse_enabled;
+use crate::config::{ProcessEnv, Vars, days, parse_enabled, positive};
 use chrono::{DateTime, Utc};
 use tokio::sync::Notify;
 use tracing::{debug, info, warn};
@@ -53,28 +53,24 @@ impl CleanupWorkerConfig {
     ///   by default; only an explicit opt-out turns it off.
     /// - `RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS`: seconds between scans (default: 3600)
     /// - `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS`: days before run dirs are removed (default: 3)
+    ///
+    /// The two numbers follow [`positive`](crate::config::positive): zero and
+    /// below fall back to the default rather than being honoured.
     pub fn from_env() -> Self {
-        let enabled = parse_enabled(
-            std::env::var("RUNTARA_RUN_DIR_CLEANUP_ENABLED")
-                .ok()
-                .as_deref(),
-        );
+        Self::from_vars(&ProcessEnv)
+    }
 
-        let poll_interval_secs = std::env::var("RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(3600);
-
-        let max_age_days = std::env::var("RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(3);
-
+    /// [`Self::from_env`] against a supplied set of values.
+    pub(crate) fn from_vars(vars: &dyn Vars) -> Self {
         Self {
-            enabled,
+            enabled: parse_enabled(vars.get("RUNTARA_RUN_DIR_CLEANUP_ENABLED").as_deref()),
             data_dir: PathBuf::from(".data"),
-            poll_interval: Duration::from_secs(poll_interval_secs),
-            max_age: Duration::from_secs(max_age_days * 24 * 3600),
+            poll_interval: Duration::from_secs(positive(
+                vars,
+                "RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS",
+                3600,
+            )),
+            max_age: days(positive(vars, "RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS", 3)),
         }
     }
 }

--- a/crates/runtara-environment/src/config.rs
+++ b/crates/runtara-environment/src/config.rs
@@ -1,6 +1,70 @@
 // Copyright (C) 2026 SyncMyOrders Sp. z o.o.
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//! Pure configuration parsing shared by environment and server callers.
+//! How this crate reads its settings, and the rules every reader follows.
+//!
+//! Two things live here. The parsers, so that a setting spelled the same way in
+//! two families of variable is read the same way in both — the crate used to
+//! have three `*_CLEANUP_POLL_INTERVAL_SECS` variables whose zero values meant
+//! three different things. And [`Vars`], the seam that lets a `from_env`
+//! constructor be tested against values a test supplies rather than against
+//! process-global state every other test in the binary shares.
+//!
+//! Nothing here reads the environment on its own; [`ProcessEnv`] is the only
+//! thing that does, and it is one line.
+
+use std::time::Duration;
+
+/// Where a configuration value comes from.
+///
+/// The point of the indirection is testing. `std::env::set_var` is process-wide
+/// and `unsafe` since the 2024 edition, so a test that sets a variable to check
+/// how a config parses it is racing every other test in the binary. Readers in
+/// this crate that used to be untestable for that reason grew a
+/// `*_from_raw` twin each, which worked but meant the tested function and the
+/// called one were never quite the same function. Taking the lookup as an
+/// argument tests the real one.
+pub(crate) trait Vars {
+    /// The value set for `key`, if any.
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+/// The real environment. The only thing in this crate that reads it.
+pub(crate) struct ProcessEnv;
+
+impl Vars for ProcessEnv {
+    fn get(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+/// A fixed set of values, so a test can say what the environment holds.
+#[cfg(test)]
+pub(crate) struct FixedVars(pub(crate) std::collections::HashMap<String, String>);
+
+#[cfg(test)]
+impl FixedVars {
+    /// Build from `(key, value)` pairs.
+    pub(crate) fn new<const N: usize>(pairs: [(&str, &str); N]) -> Self {
+        Self(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        )
+    }
+
+    /// An environment with nothing set in it.
+    pub(crate) fn empty() -> Self {
+        Self(std::collections::HashMap::new())
+    }
+}
+
+#[cfg(test)]
+impl Vars for FixedVars {
+    fn get(&self, key: &str) -> Option<String> {
+        self.0.get(key).cloned()
+    }
+}
 
 /// Parse an optional enabled value using the default-on policy.
 ///
@@ -14,6 +78,46 @@ pub fn parse_enabled(value: Option<&str>) -> bool {
             "false" | "0" | "no" | "off" | "disabled"
         )
     })
+}
+
+/// Parse a setting that has to be positive, falling back to `default` for
+/// anything absent, unparseable, or non-positive.
+///
+/// This is the crate's rule for every interval, batch size, age and concurrency
+/// it reads, because honouring a zero is worse than ignoring it. A zero poll
+/// interval spins a worker as fast as the database will answer. A zero batch
+/// size makes a sweep delete `LIMIT 0` rows forever, because the loop only
+/// stops when a pass comes back short of a full batch and `0 < 0` never does. A
+/// zero concurrency stops a scheduler doing any work at all, and a zero
+/// retention age deletes everything the first time it runs. Each of those
+/// hammers something or breaks shutdown, and none is a value an operator can
+/// usefully have meant.
+///
+/// A setting where zero *is* meaningful does not belong here — see
+/// `debug_event_max_age_from_raw`, where zero means "do not sweep" and says so.
+pub(crate) fn positive_or_default<T>(raw: Option<&str>, default: T) -> T
+where
+    T: std::str::FromStr + PartialOrd + Default + Copy,
+{
+    raw.and_then(|v| v.trim().parse::<T>().ok())
+        .filter(|parsed| *parsed > T::default())
+        .unwrap_or(default)
+}
+
+/// Read a positive setting straight from `vars`.
+///
+/// The [`positive_or_default`] rule, spelled once for the common case of "look
+/// this key up and apply it".
+pub(crate) fn positive<T>(vars: &dyn Vars, key: &str, default: T) -> T
+where
+    T: std::str::FromStr + PartialOrd + Default + Copy,
+{
+    positive_or_default(vars.get(key).as_deref(), default)
+}
+
+/// A whole number of days, as a [`Duration`].
+pub(crate) fn days(count: u64) -> Duration {
+    Duration::from_secs(count * 24 * 3600)
 }
 
 #[cfg(test)]
@@ -48,5 +152,102 @@ mod tests {
         ] {
             assert!(!parse_enabled(Some(value)), "{value:?}");
         }
+    }
+
+    #[test]
+    fn a_positive_setting_is_taken_and_anything_else_falls_back() {
+        assert_eq!(positive_or_default(Some("7"), 3u64), 7);
+        assert_eq!(positive_or_default(Some("  7  "), 3u64), 7, "values trim");
+
+        for value in ["0", "-1", "", "   ", "abc", "3.5", "0x10"] {
+            assert_eq!(
+                positive_or_default(Some(value), 3u64),
+                3,
+                "{value:?} must not be honoured"
+            );
+        }
+        assert_eq!(positive_or_default(None, 3u64), 3);
+    }
+
+    #[test]
+    fn positive_reads_through_the_var_source() {
+        let vars = FixedVars::new([("A", "9"), ("B", "0")]);
+        assert_eq!(positive(&vars, "A", 3u64), 9);
+        assert_eq!(positive(&vars, "B", 3u64), 3, "zero falls back");
+        assert_eq!(positive(&vars, "MISSING", 3u64), 3);
+    }
+
+    #[test]
+    fn days_are_whole_days() {
+        assert_eq!(days(0), Duration::ZERO);
+        assert_eq!(days(3), Duration::from_secs(259_200));
+    }
+
+    /// The three cleanup workers must read the same setting the same way.
+    ///
+    /// They did not. All three take a poll interval in seconds and a maximum
+    /// age in days under parallel names, but only the database worker ran them
+    /// through the positive-only rule; the image and run-directory workers took
+    /// whatever parsed. So `…_POLL_INTERVAL_SECS=0` fell back to the documented
+    /// default for one worker and spun the other two, and `…_MAX_AGE_DAYS=0`
+    /// was ignored by one and told the other two that everything on disk was
+    /// old enough to delete. Nothing announced the difference — each worker
+    /// simply started and reported the interval it had settled on.
+    #[test]
+    fn the_three_cleanup_workers_agree_on_a_zero() {
+        let run_dir = crate::cleanup_worker::CleanupWorkerConfig::from_vars(&FixedVars::new([
+            ("RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS", "0"),
+            ("RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS", "0"),
+        ]));
+        let image =
+            crate::image_cleanup_worker::ImageCleanupWorkerConfig::from_vars(&FixedVars::new([
+                ("RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS", "0"),
+                ("RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS", "0"),
+            ]));
+        let db = crate::db_cleanup_worker::DbCleanupWorkerConfig::from_vars(&FixedVars::new([
+            ("RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS", "0"),
+            ("RUNTARA_DB_CLEANUP_MAX_AGE_DAYS", "0"),
+        ]));
+
+        for (worker, interval, max_age) in [
+            ("run-dir", run_dir.poll_interval, run_dir.max_age),
+            ("image", image.poll_interval, image.max_age),
+            ("db", db.poll_interval, db.max_age),
+        ] {
+            assert!(
+                !interval.is_zero(),
+                "{worker} cleanup took a zero poll interval, which spins its loop"
+            );
+            assert!(
+                !max_age.is_zero(),
+                "{worker} cleanup took a zero retention age, which deletes everything"
+            );
+        }
+
+        // Each still keeps its own default rather than being flattened onto a
+        // shared one — the rule is shared, the numbers are not.
+        assert_eq!(run_dir.poll_interval, Duration::from_secs(3600));
+        assert_eq!(image.poll_interval, Duration::from_secs(6 * 3600));
+        assert_eq!(db.poll_interval, Duration::from_secs(3600));
+        for max_age in [run_dir.max_age, image.max_age, db.max_age] {
+            assert_eq!(max_age, days(3));
+        }
+    }
+
+    /// Defaults with nothing set, which is what most deployments run.
+    #[test]
+    fn an_empty_environment_gives_every_worker_its_documented_defaults() {
+        let run_dir = crate::cleanup_worker::CleanupWorkerConfig::from_vars(&FixedVars::empty());
+        let image =
+            crate::image_cleanup_worker::ImageCleanupWorkerConfig::from_vars(&FixedVars::empty());
+        let db = crate::db_cleanup_worker::DbCleanupWorkerConfig::from_vars(&FixedVars::empty());
+
+        assert!(run_dir.enabled && image.enabled && db.enabled);
+        assert_eq!(run_dir.poll_interval, Duration::from_secs(3600));
+        assert_eq!(image.poll_interval, Duration::from_secs(6 * 3600));
+        assert_eq!(image.batch_size, 50);
+        assert_eq!(db.poll_interval, Duration::from_secs(3600));
+        assert_eq!(db.batch_size, 100);
+        assert_eq!(db.debug_event_max_age, Some(Duration::from_secs(24 * 3600)));
     }
 }

--- a/crates/runtara-environment/src/config.rs
+++ b/crates/runtara-environment/src/config.rs
@@ -5,11 +5,11 @@
 //! Two things live here. The parsers, so that a setting spelled the same way in
 //! two families of variable is read the same way in both — the crate used to
 //! have three `*_CLEANUP_POLL_INTERVAL_SECS` variables whose zero values meant
-//! three different things. And [`Vars`], the seam that lets a `from_env`
+//! three different things. And `Vars`, the seam that lets a `from_env`
 //! constructor be tested against values a test supplies rather than against
 //! process-global state every other test in the binary shares.
 //!
-//! Nothing here reads the environment on its own; [`ProcessEnv`] is the only
+//! Nothing here reads the environment on its own; `ProcessEnv` is the only
 //! thing that does, and it is one line.
 
 use std::time::Duration;
@@ -188,11 +188,25 @@ mod tests {
     /// They did not. All three take a poll interval in seconds and a maximum
     /// age in days under parallel names, but only the database worker ran them
     /// through the positive-only rule; the image and run-directory workers took
-    /// whatever parsed. So `…_POLL_INTERVAL_SECS=0` fell back to the documented
-    /// default for one worker and spun the other two, and `…_MAX_AGE_DAYS=0`
-    /// was ignored by one and told the other two that everything on disk was
-    /// old enough to delete. Nothing announced the difference — each worker
-    /// simply started and reported the interval it had settled on.
+    /// whatever parsed.
+    ///
+    /// What that cost in a running system was the image worker:
+    /// `RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS=0` spun its loop and
+    /// `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS=0` told it every image on disk was
+    /// old enough to delete, while the identically-shaped `RUNTARA_DB_CLEANUP_*`
+    /// pair fell back to the documented defaults. Nothing announced the
+    /// difference — each worker simply started and reported the interval it had
+    /// settled on.
+    ///
+    /// The run-directory worker parses the same zero but never runs on it, and
+    /// that is worth knowing before reading too much into this test:
+    /// `EnvironmentRuntimeConfig::start` overwrites `poll_interval` and
+    /// `max_age` on the config `from_env` returned, with builder fields no
+    /// caller anywhere sets. So both `RUNTARA_RUN_DIR_CLEANUP_*` numbers are
+    /// inert in the assembled runtime — before this change and after it. Its
+    /// `enabled` flag is not overwritten and does still take effect. What this
+    /// test pins for that worker is `from_vars` itself, which is what a caller
+    /// constructing the config directly gets.
     #[test]
     fn the_three_cleanup_workers_agree_on_a_zero() {
         let run_dir = crate::cleanup_worker::CleanupWorkerConfig::from_vars(&FixedVars::new([

--- a/crates/runtara-environment/src/db_cleanup_worker.rs
+++ b/crates/runtara-environment/src/db_cleanup_worker.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::config::parse_enabled;
+use crate::config::{ProcessEnv, Vars, days, parse_enabled, positive};
 use chrono::Utc;
 use runtara_core::persistence::Persistence;
 use sqlx::PgPool;
@@ -76,60 +76,25 @@ impl DbCleanupWorkerConfig {
     ///   disables the sweep, leaving debug events to age out with their
     ///   instance as before.
     pub fn from_env() -> Self {
-        let enabled = parse_enabled(std::env::var("RUNTARA_DB_CLEANUP_ENABLED").ok().as_deref());
+        Self::from_vars(&ProcessEnv)
+    }
 
-        let poll_interval_secs = positive_or_default(
-            std::env::var("RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS")
-                .ok()
-                .as_deref(),
-            3600,
-        );
-
-        let max_age_days = positive_or_default(
-            std::env::var("RUNTARA_DB_CLEANUP_MAX_AGE_DAYS")
-                .ok()
-                .as_deref(),
-            3,
-        );
-
-        let batch_size = positive_or_default(
-            std::env::var("RUNTARA_DB_CLEANUP_BATCH_SIZE")
-                .ok()
-                .as_deref(),
-            100,
-        );
-
-        let debug_event_max_age = debug_event_max_age_from_raw(
-            std::env::var("RUNTARA_EVENT_DEBUG_RETENTION_HOURS")
-                .ok()
-                .as_deref(),
-        );
-
+    /// [`Self::from_env`] against a supplied set of values.
+    pub(crate) fn from_vars(vars: &dyn Vars) -> Self {
         Self {
-            enabled,
-            poll_interval: Duration::from_secs(poll_interval_secs),
-            max_age: Duration::from_secs(max_age_days * 24 * 3600),
-            batch_size,
-            debug_event_max_age,
+            enabled: parse_enabled(vars.get("RUNTARA_DB_CLEANUP_ENABLED").as_deref()),
+            poll_interval: Duration::from_secs(positive(
+                vars,
+                "RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS",
+                3600,
+            )),
+            max_age: days(positive(vars, "RUNTARA_DB_CLEANUP_MAX_AGE_DAYS", 3)),
+            batch_size: positive(vars, "RUNTARA_DB_CLEANUP_BATCH_SIZE", 100),
+            debug_event_max_age: debug_event_max_age_from_raw(
+                vars.get("RUNTARA_EVENT_DEBUG_RETENTION_HOURS").as_deref(),
+            ),
         }
     }
-}
-
-/// Parse a positive setting, falling back to `default` for anything that is
-/// absent, unparseable, or non-positive.
-///
-/// Zero is rejected rather than honoured: a zero batch size makes the sweep
-/// delete `LIMIT 0` rows forever, because the loop only stops when a pass comes
-/// back short of a full batch and `0 < 0` never does. A zero poll interval
-/// spins the same way. Both hammer Postgres and stop shutdown from joining the
-/// worker, so neither is a value anyone can usefully ask for.
-fn positive_or_default<T>(raw: Option<&str>, default: T) -> T
-where
-    T: std::str::FromStr + PartialOrd + Default + Copy,
-{
-    raw.and_then(|v| v.trim().parse::<T>().ok())
-        .filter(|parsed| *parsed > T::default())
-        .unwrap_or(default)
 }
 
 /// Step-debug retention window from `RUNTARA_EVENT_DEBUG_RETENTION_HOURS`.
@@ -403,27 +368,53 @@ mod tests {
 
 #[cfg(test)]
 mod setting_validation_tests {
-    use super::positive_or_default;
+    use super::*;
+    use crate::config::FixedVars;
 
     /// Zero is the dangerous value, not merely an odd one: it makes the debug
     /// sweep delete `LIMIT 0` rows in a loop that only exits on a short batch,
     /// which never happens because `0 < 0` is false. That spins on Postgres and
     /// stops shutdown from joining the worker.
+    ///
+    /// The rule itself is `crate::config::positive_or_default` and is tested
+    /// there; what this pins is that this worker's settings go through it.
     #[test]
     fn non_positive_settings_fall_back_to_the_default() {
-        assert_eq!(positive_or_default(Some("0"), 100i64), 100);
-        assert_eq!(positive_or_default(Some("-5"), 100i64), 100);
-        assert_eq!(positive_or_default(Some(""), 100i64), 100);
-        assert_eq!(positive_or_default(Some("not-a-number"), 100i64), 100);
-        assert_eq!(positive_or_default(None, 100i64), 100);
-        assert_eq!(positive_or_default(Some("0"), 3600u64), 3600);
+        let config = DbCleanupWorkerConfig::from_vars(&FixedVars::new([
+            ("RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS", "0"),
+            ("RUNTARA_DB_CLEANUP_MAX_AGE_DAYS", "0"),
+            ("RUNTARA_DB_CLEANUP_BATCH_SIZE", "-5"),
+        ]));
+
+        assert_eq!(config.poll_interval, Duration::from_secs(3600));
+        assert_eq!(config.max_age, Duration::from_secs(3 * 24 * 3600));
+        assert_eq!(config.batch_size, 100);
     }
 
     #[test]
     fn positive_settings_are_honoured() {
-        assert_eq!(positive_or_default(Some("50"), 100i64), 50);
-        assert_eq!(positive_or_default(Some("  7  "), 100i64), 7);
-        assert_eq!(positive_or_default(Some("1"), 3600u64), 1);
+        let config = DbCleanupWorkerConfig::from_vars(&FixedVars::new([
+            ("RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS", "60"),
+            ("RUNTARA_DB_CLEANUP_MAX_AGE_DAYS", "  7  "),
+            ("RUNTARA_DB_CLEANUP_BATCH_SIZE", "25"),
+        ]));
+
+        assert_eq!(config.poll_interval, Duration::from_secs(60));
+        assert_eq!(config.max_age, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(config.batch_size, 25);
+    }
+
+    /// The retention window is the one setting here where zero is a real
+    /// answer, and it must keep meaning "do not sweep" rather than being
+    /// swallowed by the positive-only rule the others follow.
+    #[test]
+    fn a_zero_retention_window_still_disables_the_sweep() {
+        let config = DbCleanupWorkerConfig::from_vars(&FixedVars::new([(
+            "RUNTARA_EVENT_DEBUG_RETENTION_HOURS",
+            "0",
+        )]));
+
+        assert!(config.debug_event_max_age.is_none());
     }
 }
 

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -71,8 +71,8 @@ impl ImageCleanupWorkerConfig {
     /// - `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS`: days before stale images are deleted (default: 3)
     /// - `RUNTARA_IMAGE_CLEANUP_BATCH_SIZE`: max images per cycle (default: 50)
     ///
-    /// The three numbers follow [`positive`](crate::config::positive): zero and
-    /// below fall back to the default rather than being honoured.
+    /// The three numbers follow the crate's positive-only rule: zero and below
+    /// fall back to the default rather than being honoured.
     pub fn from_env() -> Self {
         Self::from_vars(&ProcessEnv)
     }

--- a/crates/runtara-environment/src/image_cleanup_worker.rs
+++ b/crates/runtara-environment/src/image_cleanup_worker.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::config::parse_enabled;
+use crate::config::{ProcessEnv, Vars, days, parse_enabled, positive};
 use chrono::Utc;
 use sqlx::PgPool;
 use tokio::sync::Notify;
@@ -70,33 +70,24 @@ impl ImageCleanupWorkerConfig {
     /// - `RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS`: seconds between cleanup runs (default: 21600)
     /// - `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS`: days before stale images are deleted (default: 3)
     /// - `RUNTARA_IMAGE_CLEANUP_BATCH_SIZE`: max images per cycle (default: 50)
+    ///
+    /// The three numbers follow [`positive`](crate::config::positive): zero and
+    /// below fall back to the default rather than being honoured.
     pub fn from_env() -> Self {
-        let enabled = parse_enabled(
-            std::env::var("RUNTARA_IMAGE_CLEANUP_ENABLED")
-                .ok()
-                .as_deref(),
-        );
+        Self::from_vars(&ProcessEnv)
+    }
 
-        let poll_interval_secs = std::env::var("RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(6 * 3600);
-
-        let max_age_days = std::env::var("RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(3);
-
-        let batch_size = std::env::var("RUNTARA_IMAGE_CLEANUP_BATCH_SIZE")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(50);
-
+    /// [`Self::from_env`] against a supplied set of values.
+    pub(crate) fn from_vars(vars: &dyn Vars) -> Self {
         Self {
-            enabled,
-            poll_interval: Duration::from_secs(poll_interval_secs),
-            max_age: Duration::from_secs(max_age_days * 24 * 3600),
-            batch_size,
+            enabled: parse_enabled(vars.get("RUNTARA_IMAGE_CLEANUP_ENABLED").as_deref()),
+            poll_interval: Duration::from_secs(positive(
+                vars,
+                "RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS",
+                6 * 3600,
+            )),
+            max_age: days(positive(vars, "RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS", 3)),
+            batch_size: positive(vars, "RUNTARA_IMAGE_CLEANUP_BATCH_SIZE", 50),
             data_dir: PathBuf::new(), // Set by runtime
         }
     }

--- a/crates/runtara-environment/src/lib.rs
+++ b/crates/runtara-environment/src/lib.rs
@@ -143,6 +143,20 @@
 //! `RUNTARA_EVENT_DEBUG_RETENTION_HOURS` is the deliberate exception: zero
 //! means "do not sweep" there, and it says so.
 //!
+//! Three of the variables above are read and then have no effect, which is
+//! worth knowing before setting one and expecting something to change.
+//! `EXECUTION_TIMEOUT_SECS` lands in `WorkflowRunnerConfig::default_timeout`,
+//! which nothing reads — an execution is bounded by
+//! [`execution_timeout::ExecutionTimeoutPolicy`], built by the server from its
+//! own configuration. `RUNTARA_RUN_DIR_CLEANUP_POLL_INTERVAL_SECS` and
+//! `RUNTARA_RUN_DIR_CLEANUP_MAX_AGE_DAYS` are parsed and then overwritten:
+//! `runtime::EnvironmentRuntimeConfig::start` replaces both fields with builder
+//! values that no caller sets, so the run-directory worker always runs on the
+//! builder's hour and three days. That worker's `_ENABLED` flag is not
+//! overwritten and does take effect. All three are long-standing and none is
+//! settled here; each is a question about the contract it belongs to rather
+//! than about how settings are parsed.
+//!
 //! Nothing outside `config::ProcessEnv` reads the process environment. That is
 //! what lets a `from_env` constructor be tested against supplied values rather
 //! than against global state every other test in the binary shares.

--- a/crates/runtara-environment/src/lib.rs
+++ b/crates/runtara-environment/src/lib.rs
@@ -129,9 +129,23 @@
 //!
 //! Background workers: the `RUNTARA_{RUN_DIR,DB,IMAGE}_CLEANUP_*` families,
 //! `RUNTARA_EVENT_DEBUG_RETENTION_HOURS`, `RUNTARA_AUTO_RECOVER` and
-//! `RUNTARA_MAX_AUTO_RESTARTS`. Every `*_ENABLED` switch and
-//! `RUNTARA_AUTO_RECOVER` share `crate::config::parse_enabled`, so
-//! all of them answer to `false`/`0`/`no`/`off`/`disabled` and default to on.
+//! `RUNTARA_MAX_AUTO_RESTARTS`.
+//!
+//! Two rules cover all of the above, and both live in [`config`]. Every
+//! `*_ENABLED` switch and `RUNTARA_AUTO_RECOVER` go through
+//! [`config::parse_enabled`], so all of them answer to
+//! `false`/`0`/`no`/`off`/`disabled` and default to on. Every interval, batch
+//! size, age, timeout and concurrency goes through the positive-only rule, so a
+//! value that is zero, negative or unparseable leaves the documented default in
+//! place instead of being obeyed — see `config::positive_or_default` for why
+//! obeying a zero is the worse of the two.
+//!
+//! `RUNTARA_EVENT_DEBUG_RETENTION_HOURS` is the deliberate exception: zero
+//! means "do not sweep" there, and it says so.
+//!
+//! Nothing outside `config::ProcessEnv` reads the process environment. That is
+//! what lets a `from_env` constructor be tested against supplied values rather
+//! than against global state every other test in the binary shares.
 //!
 //! # Modules
 //!

--- a/crates/runtara-environment/src/recovery.rs
+++ b/crates/runtara-environment/src/recovery.rs
@@ -22,6 +22,7 @@
 //! advances between recoveries, so a genuinely long-running workflow survives
 //! any number of restarts.
 
+use crate::config::{ProcessEnv, Vars, parse_enabled, positive};
 use runtara_core::persistence::{CompleteInstanceParams, Persistence};
 use tracing::{error, info, warn};
 
@@ -32,11 +33,12 @@ pub const DEFAULT_MAX_AUTO_RESTARTS: i32 = 5;
 /// Read the configured crash-loop cap (`RUNTARA_MAX_AUTO_RESTARTS`, default
 /// [`DEFAULT_MAX_AUTO_RESTARTS`]). Values below 1 fall back to the default.
 pub fn max_auto_restarts() -> i32 {
-    std::env::var("RUNTARA_MAX_AUTO_RESTARTS")
-        .ok()
-        .and_then(|v| v.parse::<i32>().ok())
-        .filter(|n| *n >= 1)
-        .unwrap_or(DEFAULT_MAX_AUTO_RESTARTS)
+    max_auto_restarts_from(&ProcessEnv)
+}
+
+/// [`max_auto_restarts`] against a supplied set of values.
+fn max_auto_restarts_from(vars: &dyn Vars) -> i32 {
+    positive(vars, "RUNTARA_MAX_AUTO_RESTARTS", DEFAULT_MAX_AUTO_RESTARTS)
 }
 
 /// Operator-level kill switch for automatic restart recovery. Set
@@ -49,7 +51,12 @@ pub fn max_auto_restarts() -> i32 {
 /// the `*_CLEANUP_ENABLED` opt-outs so every switch in the crate answers to the
 /// same spellings; a hand-rolled parser here used to ignore `off`.
 pub fn auto_recover_enabled() -> bool {
-    crate::config::parse_enabled(std::env::var("RUNTARA_AUTO_RECOVER").ok().as_deref())
+    auto_recover_enabled_from(&ProcessEnv)
+}
+
+/// [`auto_recover_enabled`] against a supplied set of values.
+fn auto_recover_enabled_from(vars: &dyn Vars) -> bool {
+    parse_enabled(vars.get("RUNTARA_AUTO_RECOVER").as_deref())
 }
 
 /// Outcome of a recovery decision.
@@ -201,7 +208,8 @@ pub async fn recover_or_fail(
 
 #[cfg(test)]
 mod tests {
-    use super::{Decision, decide};
+    use super::{Decision, auto_recover_enabled_from, decide, max_auto_restarts_from};
+    use crate::config::FixedVars;
 
     #[test]
     fn first_recovery_starts_at_one() {
@@ -250,6 +258,43 @@ mod tests {
         match decide(0, None, 10, 5, false) {
             Decision::Fail { error } => assert!(error.contains("disabled")),
             other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    /// The cap rejects anything that would disable crash-loop protection or
+    /// make it nonsensical, rather than honouring it.
+    ///
+    /// A cap of zero fails every restarted instance on its first attempt, which
+    /// reads as "recovery is broken" rather than as a configured policy; the
+    /// switch for turning recovery off is RUNTARA_AUTO_RECOVER.
+    #[test]
+    fn the_restart_cap_falls_back_on_anything_non_positive() {
+        for value in ["0", "-1", "", "  ", "lots"] {
+            let vars = FixedVars::new([("RUNTARA_MAX_AUTO_RESTARTS", value)]);
+            assert_eq!(max_auto_restarts_from(&vars), 5, "{value:?}");
+        }
+
+        assert_eq!(max_auto_restarts_from(&FixedVars::empty()), 5);
+        assert_eq!(
+            max_auto_restarts_from(&FixedVars::new([("RUNTARA_MAX_AUTO_RESTARTS", "12")])),
+            12
+        );
+    }
+
+    /// The kill switch answers to the same spellings as every other switch in
+    /// the crate; a hand-rolled parser here used to ignore `off`.
+    #[test]
+    fn auto_recovery_is_on_unless_explicitly_disabled() {
+        assert!(auto_recover_enabled_from(&FixedVars::empty()));
+
+        for value in ["false", "0", "no", "off", "disabled", "Off", "  FALSE  "] {
+            let vars = FixedVars::new([("RUNTARA_AUTO_RECOVER", value)]);
+            assert!(!auto_recover_enabled_from(&vars), "{value:?}");
+        }
+
+        for value in ["true", "1", "yes", "on", "typo"] {
+            let vars = FixedVars::new([("RUNTARA_AUTO_RECOVER", value)]);
+            assert!(auto_recover_enabled_from(&vars), "{value:?}");
         }
     }
 }

--- a/crates/runtara-environment/src/runner/common.rs
+++ b/crates/runtara-environment/src/runner/common.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 
 use tokio::fs;
 
+use crate::config::{ProcessEnv, Vars, positive};
+
 /// How much of a stderr preview is kept for diagnostics.
 const STDERR_PREVIEW_CHARS: usize = 2000;
 
@@ -61,9 +63,22 @@ impl WorkflowRunnerConfig {
     /// - `EXECUTION_TIMEOUT_SECS`: default execution timeout in seconds (default: 300).
     /// - `RUNTARA_SKIP_CERT_VERIFICATION`: skip TLS cert verification (default: false).
     /// - `RUNTARA_CONNECTION_SERVICE_URL`: connection service URL (optional).
+    ///
+    /// The timeout follows the crate's positive-only rule: a value that is
+    /// zero, negative or unparseable leaves the default in place, because a zero
+    /// would time out every execution the moment it started.
     pub fn from_env() -> Self {
+        Self::from_vars(&ProcessEnv)
+    }
+
+    /// [`Self::from_env`] against a supplied set of values.
+    ///
+    /// The working directory is not one of them. A relative `DATA_DIR` is
+    /// resolved against the real process cwd here, because that is what the
+    /// guests this config launches will themselves see.
+    pub(crate) fn from_vars(vars: &dyn Vars) -> Self {
         let data_dir_raw =
-            PathBuf::from(std::env::var("DATA_DIR").unwrap_or_else(|_| ".data".to_string()));
+            PathBuf::from(vars.get("DATA_DIR").unwrap_or_else(|| ".data".to_string()));
         let data_dir = if data_dir_raw.is_absolute() {
             data_dir_raw
         } else {
@@ -74,23 +89,18 @@ impl WorkflowRunnerConfig {
 
         Self {
             data_dir,
-            default_timeout: Duration::from_secs(
-                std::env::var("EXECUTION_TIMEOUT_SECS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(300),
-            ),
-            skip_cert_verification: std::env::var("RUNTARA_SKIP_CERT_VERIFICATION")
-                .ok()
+            default_timeout: Duration::from_secs(positive(vars, "EXECUTION_TIMEOUT_SECS", 300)),
+            skip_cert_verification: vars
+                .get("RUNTARA_SKIP_CERT_VERIFICATION")
                 .map(|v| parse_bool_lenient(&v))
                 .unwrap_or(false),
             // `RUNTARA_CONNECTION_SERVICE_URL` is the runner's own setting and
             // wins; `CONNECTION_SERVICE_URL` is the general name the rest of the
             // stack uses, accepted as a fallback so a deployment that sets only
             // that one still points guests at the right host.
-            connection_service_url: std::env::var("RUNTARA_CONNECTION_SERVICE_URL")
-                .or_else(|_| std::env::var("CONNECTION_SERVICE_URL"))
-                .ok(),
+            connection_service_url: vars
+                .get("RUNTARA_CONNECTION_SERVICE_URL")
+                .or_else(|| vars.get("CONNECTION_SERVICE_URL")),
         }
     }
 }
@@ -131,7 +141,7 @@ pub(crate) fn build_env(
     }
 
     // Forward SDK backend selection if set in the host environment.
-    if let Ok(backend) = std::env::var("RUNTARA_SDK_BACKEND") {
+    if let Some(backend) = ProcessEnv.get("RUNTARA_SDK_BACKEND") {
         env.insert("RUNTARA_SDK_BACKEND".to_string(), backend);
     }
 
@@ -272,5 +282,71 @@ mod tests {
 
         let env_without_core = build_env(&config(), "instance-1", "tenant-1", None, None);
         assert!(!env_without_core.contains_key("RUNTARA_HTTP_URL"));
+    }
+
+    /// The runner-specific connection URL wins, and the general one is the
+    /// fallback — documented behaviour that nothing exercised.
+    #[test]
+    fn the_runner_specific_connection_url_wins() {
+        use crate::config::FixedVars;
+
+        let both = WorkflowRunnerConfig::from_vars(&FixedVars::new([
+            ("RUNTARA_CONNECTION_SERVICE_URL", "http://runner"),
+            ("CONNECTION_SERVICE_URL", "http://general"),
+        ]));
+        assert_eq!(
+            both.connection_service_url.as_deref(),
+            Some("http://runner")
+        );
+
+        let general = WorkflowRunnerConfig::from_vars(&FixedVars::new([(
+            "CONNECTION_SERVICE_URL",
+            "http://general",
+        )]));
+        assert_eq!(
+            general.connection_service_url.as_deref(),
+            Some("http://general")
+        );
+
+        let neither = WorkflowRunnerConfig::from_vars(&FixedVars::empty());
+        assert!(neither.connection_service_url.is_none());
+    }
+
+    /// A zero timeout would expire every execution at the instant it started,
+    /// which is indistinguishable from the runner being broken.
+    #[test]
+    fn the_execution_timeout_refuses_a_zero() {
+        use crate::config::FixedVars;
+
+        for value in ["0", "-1", "", "soon"] {
+            let config = WorkflowRunnerConfig::from_vars(&FixedVars::new([(
+                "EXECUTION_TIMEOUT_SECS",
+                value,
+            )]));
+            assert_eq!(
+                config.default_timeout,
+                Duration::from_secs(300),
+                "{value:?}"
+            );
+        }
+
+        let set =
+            WorkflowRunnerConfig::from_vars(&FixedVars::new([("EXECUTION_TIMEOUT_SECS", "45")]));
+        assert_eq!(set.default_timeout, Duration::from_secs(45));
+    }
+
+    /// An absolute DATA_DIR is taken as given; a relative one is resolved
+    /// against the process working directory the guests will also see.
+    #[test]
+    fn an_absolute_data_dir_is_left_alone() {
+        use crate::config::FixedVars;
+
+        let absolute =
+            WorkflowRunnerConfig::from_vars(&FixedVars::new([("DATA_DIR", "/srv/runtara-data")]));
+        assert_eq!(absolute.data_dir, PathBuf::from("/srv/runtara-data"));
+
+        let relative = WorkflowRunnerConfig::from_vars(&FixedVars::new([("DATA_DIR", "state")]));
+        assert!(relative.data_dir.is_absolute());
+        assert!(relative.data_dir.ends_with("state"));
     }
 }

--- a/crates/runtara-environment/src/runner/common.rs
+++ b/crates/runtara-environment/src/runner/common.rs
@@ -64,9 +64,15 @@ impl WorkflowRunnerConfig {
     /// - `RUNTARA_SKIP_CERT_VERIFICATION`: skip TLS cert verification (default: false).
     /// - `RUNTARA_CONNECTION_SERVICE_URL`: connection service URL (optional).
     ///
-    /// The timeout follows the crate's positive-only rule: a value that is
-    /// zero, negative or unparseable leaves the default in place, because a zero
-    /// would time out every execution the moment it started.
+    /// The timeout follows the crate's positive-only rule, like every other
+    /// interval in the crate — but be aware that it currently decides nothing.
+    /// `default_timeout` is written here and read nowhere: what actually bounds
+    /// an execution is [`crate::execution_timeout::ExecutionTimeoutPolicy`],
+    /// which the server builds from its own configuration. So
+    /// `EXECUTION_TIMEOUT_SECS` has no effect on a running system today. The
+    /// field is left in place rather than removed because deciding between
+    /// "wire it up" and "delete it and the variable" is a question about the
+    /// timeout contract, not about how settings are parsed.
     pub fn from_env() -> Self {
         Self::from_vars(&ProcessEnv)
     }
@@ -312,8 +318,9 @@ mod tests {
         assert!(neither.connection_service_url.is_none());
     }
 
-    /// A zero timeout would expire every execution at the instant it started,
-    /// which is indistinguishable from the runner being broken.
+    /// The timeout still refuses a zero, so that if the field is ever wired up
+    /// it starts from a sane value rather than from whatever was set while
+    /// nothing was reading it.
     #[test]
     fn the_execution_timeout_refuses_a_zero() {
         use crate::config::FixedVars;

--- a/crates/runtara-environment/src/runner/embedded.rs
+++ b/crates/runtara-environment/src/runner/embedded.rs
@@ -49,6 +49,8 @@ use runtara_core::instance_handlers::{
 };
 use runtara_core::persistence::Persistence;
 
+use crate::config::{ProcessEnv, Vars, positive};
+
 use super::common::{self, WorkflowRunnerConfig};
 use super::traits::{
     CancelToken, ContainerMetrics, LaunchOptions, PreparationOccupancy, PreparedLaunch, Result,
@@ -1032,16 +1034,15 @@ impl EmbeddedWasmRunner {
 /// more than this cannot raise throughput, because the surplus can only
 /// queue while holding an admission reservation.
 pub fn max_concurrent_runs() -> usize {
-    std::env::var("RUNTARA_MAX_CONCURRENT_RUNS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or_else(|| {
-            std::thread::available_parallelism()
-                .map(|n| n.get().saturating_mul(4))
-                .unwrap_or(4)
-        })
-        .clamp(1, 1024)
+    max_concurrent_runs_from(&ProcessEnv)
+}
+
+/// [`max_concurrent_runs`] against a supplied set of values.
+fn max_concurrent_runs_from(vars: &dyn Vars) -> usize {
+    let per_core = std::thread::available_parallelism()
+        .map(|n| n.get().saturating_mul(4))
+        .unwrap_or(4);
+    positive(vars, "RUNTARA_MAX_CONCURRENT_RUNS", per_core).clamp(1, 1024)
 }
 
 /// How many artifact preparations may execute concurrently in this process.
@@ -1052,16 +1053,15 @@ pub fn max_concurrent_runs() -> usize {
 /// available core is the conservative default; an explicit setting is capped
 /// to keep a typo from turning a preparation burst into a compiler stampede.
 fn max_concurrent_preparations() -> usize {
-    std::env::var("RUNTARA_PREPARATION_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|count| *count > 0)
-        .unwrap_or_else(|| {
-            std::thread::available_parallelism()
-                .map(|count| count.get())
-                .unwrap_or(1)
-        })
-        .clamp(1, 64)
+    max_concurrent_preparations_from(&ProcessEnv)
+}
+
+/// [`max_concurrent_preparations`] against a supplied set of values.
+fn max_concurrent_preparations_from(vars: &dyn Vars) -> usize {
+    let per_core = std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1);
+    positive(vars, "RUNTARA_PREPARATION_CONCURRENCY", per_core).clamp(1, 64)
 }
 
 /// Maximum live or still-reaping precompile children.
@@ -1086,11 +1086,11 @@ fn max_concurrent_precompile_children(preparation_limit: usize) -> usize {
                 .max(1)
         })
         .unwrap_or(1);
-    let requested = std::env::var("RUNTARA_PRECOMPILE_CHILD_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|count| *count > 0)
-        .unwrap_or_else(|| preparation_limit.saturating_add(1));
+    let requested = positive(
+        &ProcessEnv,
+        "RUNTARA_PRECOMPILE_CHILD_CONCURRENCY",
+        preparation_limit.saturating_add(1),
+    );
     requested.min(host_cap).clamp(1, 4)
 }
 
@@ -1194,13 +1194,21 @@ fn warn_if_run_bound_exceeds_memory(permits: usize) {
 }
 
 fn limits_from_env() -> WorkflowLimits {
+    limits_from(&ProcessEnv)
+}
+
+/// [`limits_from_env`] against a supplied set of values.
+///
+/// A zero or unparseable cap keeps the default rather than being honoured: a
+/// guest allowed zero linear memory cannot start at all, so the setting would
+/// read as "every workflow is broken" rather than as a configured limit.
+fn limits_from(vars: &dyn Vars) -> WorkflowLimits {
     let mut limits = WorkflowLimits::default();
-    if let Some(max) = std::env::var("RUNTARA_INSTANCE_MEMORY_MAX_BYTES")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-    {
-        limits.max_memory_bytes = max;
-    }
+    limits.max_memory_bytes = positive(
+        vars,
+        "RUNTARA_INSTANCE_MEMORY_MAX_BYTES",
+        limits.max_memory_bytes,
+    );
     limits
 }
 

--- a/crates/runtara-environment/src/runner/mod.rs
+++ b/crates/runtara-environment/src/runner/mod.rs
@@ -9,6 +9,8 @@ pub mod embedded;
 pub mod mock;
 mod traits;
 
+use crate::config::Vars;
+
 pub use common::WorkflowRunnerConfig;
 pub use embedded::EmbeddedWasmRunner;
 pub use mock::MockRunner;
@@ -41,7 +43,7 @@ pub fn build_runner_with_core_http_url(
     >,
     core_http_url: Option<String>,
 ) -> Result<std::sync::Arc<dyn Runner>> {
-    if let Ok(requested) = std::env::var("RUNTARA_RUNNER")
+    if let Some(requested) = crate::config::ProcessEnv.get("RUNTARA_RUNNER")
         && !requested.is_empty()
     {
         tracing::warn!(

--- a/crates/runtara-environment/src/runtime.rs
+++ b/crates/runtara-environment/src/runtime.rs
@@ -48,6 +48,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use crate::cleanup_worker::{CleanupWorker, CleanupWorkerConfig};
+use crate::config::{ProcessEnv, Vars, positive};
 use crate::container_registry::ContainerRegistry;
 use crate::db_cleanup_worker::{DbCleanupWorker, DbCleanupWorkerConfig};
 use crate::execution_timeout::ExecutionTimeoutPolicy;
@@ -58,68 +59,41 @@ use crate::launch_dispatcher::{LaunchDispatcher, LaunchLifecycleObservers};
 use crate::runner::Runner;
 use crate::wake_scheduler::{WakeScheduler, WakeSchedulerConfig, default_wake_concurrency};
 
+// Every setting here follows `crate::config::positive`, which rejects a
+// non-positive or unparseable value rather than honouring it: a zero interval
+// would busy-spin, and a zero batch or concurrency would stop the scheduler
+// entirely. Taking the lookup as an argument is what makes them testable — the
+// alternative is mutating process-global environment state shared by every test
+// in the binary, which is why each of these used to carry a `*_from_raw` twin
+// that was tested while the function actually called was not.
+
 /// Idle poll interval for the wake scheduler, from
 /// `RUNTARA_WAKE_POLL_INTERVAL_MS` (default 5000).
 ///
 /// This is only the wait after a poll that found nothing more to do — a poll
 /// that fills its batch is followed immediately by the next one — so it bounds
 /// wake *latency* for an idle system, not wake throughput.
-fn wake_poll_interval_from_env() -> Duration {
-    wake_poll_interval_from_raw(
-        std::env::var("RUNTARA_WAKE_POLL_INTERVAL_MS")
-            .ok()
-            .as_deref(),
-    )
+fn wake_poll_interval(vars: &dyn Vars) -> Duration {
+    Duration::from_millis(positive(vars, "RUNTARA_WAKE_POLL_INTERVAL_MS", 5_000))
 }
 
 /// Instances claimed per wake poll, from `RUNTARA_WAKE_BATCH_SIZE`
 /// (default 200).
-fn wake_batch_size_from_env() -> i64 {
-    wake_batch_size_from_raw(std::env::var("RUNTARA_WAKE_BATCH_SIZE").ok().as_deref())
+fn wake_batch_size(vars: &dyn Vars) -> i64 {
+    positive(vars, "RUNTARA_WAKE_BATCH_SIZE", 200)
+}
+
+/// How long a wake claim is leased for, from `RUNTARA_WAKE_CLAIM_LEASE_SECS`
+/// (default: 300s). A batch claimed by a process that then dies becomes due
+/// again after this long, which is the recovery path for an interrupted wake.
+fn wake_claim_lease(vars: &dyn Vars) -> Duration {
+    Duration::from_secs(positive(vars, "RUNTARA_WAKE_CLAIM_LEASE_SECS", 300))
 }
 
 /// Concurrent relaunches within a wake batch, from `RUNTARA_WAKE_CONCURRENCY`
 /// (default: eight per core, see [`default_wake_concurrency`]).
-/// How long a wake claim is leased for, from `RUNTARA_WAKE_CLAIM_LEASE_SECS`
-/// (default: 300s). A batch claimed by a process that then dies becomes due
-/// again after this long, which is the recovery path for an interrupted wake.
-fn wake_claim_lease_from_env() -> Duration {
-    std::env::var("RUNTARA_WAKE_CLAIM_LEASE_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|secs| *secs > 0)
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(300))
-}
-
-fn wake_concurrency_from_env() -> usize {
-    wake_concurrency_from_raw(std::env::var("RUNTARA_WAKE_CONCURRENCY").ok().as_deref())
-}
-
-// The parsing halves are split out so they can be tested without mutating
-// process-global environment state, which is shared by every test in the
-// binary. Each rejects a non-positive or unparseable value rather than
-// honouring it: a zero interval would busy-spin, and a zero batch or
-// concurrency would stop the scheduler entirely.
-
-fn wake_poll_interval_from_raw(raw: Option<&str>) -> Duration {
-    Duration::from_millis(
-        raw.and_then(|v| v.parse::<u64>().ok())
-            .filter(|ms| *ms > 0)
-            .unwrap_or(5_000),
-    )
-}
-
-fn wake_batch_size_from_raw(raw: Option<&str>) -> i64 {
-    raw.and_then(|v| v.parse::<i64>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(200)
-}
-
-fn wake_concurrency_from_raw(raw: Option<&str>) -> usize {
-    raw.and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or_else(default_wake_concurrency)
+fn wake_concurrency(vars: &dyn Vars) -> usize {
+    positive(vars, "RUNTARA_WAKE_CONCURRENCY", default_wake_concurrency())
 }
 
 /// Builder for creating an [`EnvironmentRuntime`].
@@ -149,10 +123,10 @@ impl Default for EnvironmentRuntimeBuilder {
             core_persistence: None,
             runner: None,
             data_dir: PathBuf::from(".data"),
-            wake_poll_interval: wake_poll_interval_from_env(),
-            wake_batch_size: wake_batch_size_from_env(),
-            wake_concurrency: wake_concurrency_from_env(),
-            wake_claim_lease: wake_claim_lease_from_env(),
+            wake_poll_interval: wake_poll_interval(&ProcessEnv),
+            wake_batch_size: wake_batch_size(&ProcessEnv),
+            wake_concurrency: wake_concurrency(&ProcessEnv),
+            wake_claim_lease: wake_claim_lease(&ProcessEnv),
             request_timeout: Duration::from_secs(30),
             execution_timeout_policy: ExecutionTimeoutPolicy::default(),
             cleanup_poll_interval: Duration::from_secs(3600), // 1 hour
@@ -1133,6 +1107,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::FixedVars;
 
     /// A worker its configuration disabled has finished on purpose.
     ///
@@ -1269,51 +1244,70 @@ mod tests {
         assert!(builder.wake_concurrency >= 1);
     }
 
+    /// A value set for one wake setting must not reach another.
+    ///
+    /// These four are read from four keys that differ by one word, through one
+    /// shared helper, so a copied line that left the wrong key behind would be
+    /// easy to write and silent to run: the setting an operator asked for would
+    /// simply not take effect, and the log line would report the default as
+    /// though it had been chosen.
     #[test]
-    fn wake_poll_interval_parsing() {
-        assert_eq!(
-            wake_poll_interval_from_raw(None),
-            Duration::from_secs(5),
-            "unset falls back to the documented default"
-        );
-        assert_eq!(
-            wake_poll_interval_from_raw(Some("250")),
-            Duration::from_millis(250)
-        );
-        // A zero or malformed interval would turn the loop into a busy wait.
-        assert_eq!(
-            wake_poll_interval_from_raw(Some("0")),
-            Duration::from_secs(5)
-        );
-        assert_eq!(
-            wake_poll_interval_from_raw(Some("not-a-number")),
-            Duration::from_secs(5)
-        );
+    fn each_wake_setting_reads_its_own_key() {
+        let vars = FixedVars::new([
+            ("RUNTARA_WAKE_POLL_INTERVAL_MS", "250"),
+            ("RUNTARA_WAKE_BATCH_SIZE", "50"),
+            ("RUNTARA_WAKE_CLAIM_LEASE_SECS", "60"),
+            ("RUNTARA_WAKE_CONCURRENCY", "7"),
+        ]);
+
+        assert_eq!(wake_poll_interval(&vars), Duration::from_millis(250));
+        assert_eq!(wake_batch_size(&vars), 50);
+        assert_eq!(wake_claim_lease(&vars), Duration::from_secs(60));
+        assert_eq!(wake_concurrency(&vars), 7);
+    }
+
+    /// Every wake setting rejects a value that would break the scheduler.
+    ///
+    /// A zero interval turns the poll into a busy wait, a zero batch claims
+    /// nothing, a zero lease makes every claim instantly expired, and a zero
+    /// concurrency deadlocks the semaphore.
+    #[test]
+    fn no_wake_setting_honours_a_broken_value() {
+        for value in ["0", "-5", "", "not-a-number"] {
+            let vars = FixedVars::new([
+                ("RUNTARA_WAKE_POLL_INTERVAL_MS", value),
+                ("RUNTARA_WAKE_BATCH_SIZE", value),
+                ("RUNTARA_WAKE_CLAIM_LEASE_SECS", value),
+                ("RUNTARA_WAKE_CONCURRENCY", value),
+            ]);
+
+            assert_eq!(
+                wake_poll_interval(&vars),
+                Duration::from_secs(5),
+                "{value:?}"
+            );
+            assert_eq!(wake_batch_size(&vars), 200, "{value:?}");
+            assert_eq!(
+                wake_claim_lease(&vars),
+                Duration::from_secs(300),
+                "{value:?}"
+            );
+            assert_eq!(
+                wake_concurrency(&vars),
+                default_wake_concurrency(),
+                "{value:?}"
+            );
+        }
     }
 
     #[test]
-    fn wake_batch_size_parsing() {
-        assert_eq!(wake_batch_size_from_raw(None), 200);
-        assert_eq!(wake_batch_size_from_raw(Some("50")), 50);
-        // Zero or negative would claim nothing, stalling the scheduler.
-        assert_eq!(wake_batch_size_from_raw(Some("0")), 200);
-        assert_eq!(wake_batch_size_from_raw(Some("-5")), 200);
-        assert_eq!(wake_batch_size_from_raw(Some("")), 200);
-    }
+    fn unset_wake_settings_give_the_documented_defaults() {
+        let vars = FixedVars::empty();
 
-    #[test]
-    fn wake_concurrency_parsing() {
-        assert_eq!(wake_concurrency_from_raw(Some("7")), 7);
-        // Zero would deadlock the semaphore; fall back to the cored default.
-        assert_eq!(
-            wake_concurrency_from_raw(Some("0")),
-            default_wake_concurrency()
-        );
-        assert_eq!(
-            wake_concurrency_from_raw(Some("nope")),
-            default_wake_concurrency()
-        );
-        assert_eq!(wake_concurrency_from_raw(None), default_wake_concurrency());
+        assert_eq!(wake_poll_interval(&vars), Duration::from_secs(5));
+        assert_eq!(wake_batch_size(&vars), 200);
+        assert_eq!(wake_claim_lease(&vars), Duration::from_secs(300));
+        assert_eq!(wake_concurrency(&vars), default_wake_concurrency());
     }
 
     #[test]


### PR DESCRIPTION
`runtara-environment` read its settings at 31 `std::env::var` sites, each with its own parsing. Centralising configuration is a preference on its own — but the sites had drifted apart, and the drift is a defect.

After this, three reads remain: `config::ProcessEnv` itself, and two test-only database URLs in `test_support.rs` that are not runtime settings.

## The defect

All three cleanup workers take a poll interval in seconds and a retention age in days under parallel names, but only the database worker put them through the positive-only rule. The image and run-directory workers took whatever parsed. The rule was already written down three times in the crate, including the sentence in `runtime.rs` that says a zero interval would busy-spin.

So on `main`:

- `RUNTARA_IMAGE_CLEANUP_POLL_INTERVAL_SECS=0` spins that worker's loop, while the identically-shaped `RUNTARA_DB_CLEANUP_POLL_INTERVAL_SECS=0` falls back to the documented hour
- `RUNTARA_IMAGE_CLEANUP_MAX_AGE_DAYS=0` tells that worker every image on disk is old enough to delete, while `RUNTARA_DB_CLEANUP_MAX_AGE_DAYS=0` falls back to the documented three days
- `RUNTARA_INSTANCE_MEMORY_MAX_BYTES=0` gives every guest zero linear memory, and the component host refuses any growth past it — so no guest can allocate

Nothing announces any of this. Each worker starts and logs the interval it settled on.

The run-directory worker parses the same zeroes and never runs on them, which is worth stating rather than quietly counting it as a third fix: `EnvironmentRuntimeConfig::start` overwrites `poll_interval` and `max_age` on the config `from_env` returned, with builder fields no caller anywhere sets. Both `RUNTARA_RUN_DIR_CLEANUP_*` numbers are therefore inert in the assembled runtime, before this branch and after it. Its `_ENABLED` flag is not overwritten and does work. The rule now applies to `CleanupWorkerConfig::from_env()` for callers that construct it directly; making it reach the runtime means reconsidering those builder overrides, which is a separate question.

The rule now lives in `config.rs` with the reasoning the database worker had already written down, and every interval, batch size, age, timeout and concurrency reads through it. Defaults stay per-worker: the rule is shared, the numbers are not.

## The `Vars` seam

`from_env` delegates to `from_vars(&dyn Vars)`, so a config can be built from values a test supplies. `std::env::set_var` is process-wide and `unsafe` since the 2024 edition, so a test that sets a variable races every other test in the binary. Readers that were untestable for that reason had each grown a `*_from_raw` twin — which meant the tested function was never the one production called. Those twins are gone.

That also bought tests for things documented but unexercised: that `RUNTARA_CONNECTION_SERVICE_URL` wins over `CONNECTION_SERVICE_URL`, that an absolute `DATA_DIR` is taken as given while a relative one is resolved, and that each of the four wake settings reads its own key.

## Three settings that are read and then ignored

Found while doing this, and worth a reviewer's attention. `WorkflowRunnerConfig::default_timeout` is assigned and never read; what bounds an execution is `ExecutionTimeoutPolicy`, which the server builds from its own configuration. A live server started with `EXECUTION_TIMEOUT_SECS=0` ran a workflow to completion.

The setting still goes through the positive-only rule so that wiring the field up later starts from a sane value, and the doc comment records the state of things. Deciding between wiring it up and deleting both the field and the variable is a question about the timeout contract, not about parsing, so it is deliberately not settled here.

The two `RUNTARA_RUN_DIR_CLEANUP_*` numbers above are the same situation, found the same way. The crate docs now name all three, so an operator reading the list of variables can see which are read and then ignored.

## `.gitignore`

`.data/` was ignored but `.data-e2e/` and friends were not, and the isolated-server recipe creates exactly those — a second server needs its own `DATA_DIR`. They hold compiled workflow artifacts and a wasmtime cache, so a `git add -A` taken while one exists sweeps megabytes of build output into a commit. `.data-*/` is now ignored.

## Live check

One server started with every cleanup interval and age, plus `RUNTARA_INSTANCE_MEMORY_MAX_BYTES`, set to `0` at once:

```
Cleanup worker started        poll_interval_secs=3600   max_age_hours=72
Image cleanup worker started  poll_interval_secs=21600  max_age_days=3  batch_size=50
```

The image line is the one that demonstrates the change — on `main` that worker logs `poll_interval_secs=0` and spins. The run-directory line would print identically on `main`, for the builder-override reason above; it is shown for completeness, not as evidence.

What the run does establish: the image worker holds its documented interval, age and batch size; no spin (zero cleanup cycles in 30 s); and a workflow compiled and ran to completion under a zero memory limit, which is the `RUNTARA_INSTANCE_MEMORY_MAX_BYTES` fix end to end.

## Verification

- `cargo fmt --all -- --check`, `clippy --workspace --all-targets --features "$GATE_FEATURES" -- -D warnings` — clean
- `cargo test --workspace --lib` — 3791 passed
- `runtara-environment --features db-integration-tests -- --test-threads=1` — 328 passed
- `runtara-server --features db-integration-tests,valkey-integration-tests -- --test-threads=1` — 1294 passed, 7 ignored
- `e2e/test_durable_delay_parks_and_wakes.sh` — passed; it exercises the wake settings this converts
